### PR TITLE
feat: add MCP data artifact to releases and dispatch to terraform-provider-mcp

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -158,3 +158,52 @@ jobs:
       gpg-private-key-passphrase: ${{ secrets.gpg-passphrase }}
     with:
       setup-go-version-file: 'go.mod'
+
+  upload-mcp-data:
+    name: Upload MCP Data Artifact
+    needs: [tag, release]
+    if: needs.tag.outputs.created == 'true' && inputs.create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.tag.outputs.new_tag }}
+
+      - name: Create MCP data tarball
+        run: |
+          VERSION="${{ needs.tag.outputs.new_tag }}"
+          VERSION="${VERSION#v}"
+
+          echo "Creating MCP data tarball for v${VERSION}..."
+
+          # Create tarball with documentation, OpenAPI specs, and metadata
+          tar czf "mcp-data-${VERSION}.tar.gz" \
+            --transform 's,^,mcp-data/,' \
+            docs/resources/ \
+            docs/data-sources/ \
+            docs/functions/ \
+            docs/guides/ \
+            docs/index.md \
+            docs/specifications/api/ \
+            tools/metadata/ \
+            tools/subscription-tiers.json
+
+          echo "Tarball contents:"
+          tar tzf "mcp-data-${VERSION}.tar.gz" | head -20
+          echo "..."
+          echo "Total files: $(tar tzf "mcp-data-${VERSION}.tar.gz" | wc -l)"
+          echo "Size: $(ls -lh "mcp-data-${VERSION}.tar.gz" | awk '{print $5}')"
+
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.tag.outputs.new_tag }}"
+          VERSION="${VERSION#v}"
+
+          gh release upload "${{ needs.tag.outputs.new_tag }}" \
+            "mcp-data-${VERSION}.tar.gz" \
+            --clobber
+
+          echo "Uploaded mcp-data-${VERSION}.tar.gz to release ${{ needs.tag.outputs.new_tag }}"

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -809,6 +809,34 @@ jobs:
           echo "=============================================="
 
   # ===========================================================================
+  # STEP 5b: Notify terraform-provider-mcp of new release
+  # ===========================================================================
+  notify-mcp-repo:
+    name: Notify MCP Repo
+    needs: [tag-release]
+    if: |
+      always() &&
+      needs.tag-release.result == 'success' &&
+      needs.tag-release.outputs.tag-created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to terraform-provider-mcp
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+        run: |
+          VERSION="${{ needs.tag-release.outputs.new-tag }}"
+          echo "Dispatching provider-release event to terraform-provider-mcp..."
+          echo "Version: $VERSION"
+
+          gh api repos/f5xc-salesdemos/terraform-provider-mcp/dispatches \
+            --method POST \
+            -f event_type=provider-release \
+            -f "client_payload[version]=$VERSION" \
+            -f "client_payload[repository]=${{ github.repository }}"
+
+          echo "Dispatched provider-release event to terraform-provider-mcp"
+
+  # ===========================================================================
   # STEP 6: Create PR for regenerated content (human commits only)
   # ===========================================================================
   # NOTE: We create a PR instead of pushing directly to respect branch protection.
@@ -1078,7 +1106,7 @@ jobs:
   # ===========================================================================
   summary:
     name: Workflow Summary
-    needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, mcp-unified, create-regeneration-pr, tag-release]
+    needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, mcp-unified, create-regeneration-pr, tag-release, notify-mcp-repo]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1104,6 +1132,7 @@ jobs:
           echo "| Regeneration PR Created | ${{ needs.create-regeneration-pr.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Tagged/Released | ${{ needs.tag-release.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| MCP Unified Build/Publish | ${{ needs.mcp-unified.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Notify MCP Repo | ${{ needs.notify-mcp-repo.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Delayed Tagging Logic" >> $GITHUB_STEP_SUMMARY
           echo "- Bot commits -> Tag immediately (regeneration complete)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Add `upload-mcp-data` job to `_tag-release.yml` that creates a tarball (`mcp-data-{version}.tar.gz`) containing documentation, OpenAPI specs, and metadata, then uploads it to the GitHub Release
- Add `notify-mcp-repo` job to `on-merge.yml` that dispatches a `provider-release` event to `f5xc-salesdemos/terraform-provider-mcp` when a new tag is created

## Test plan
- [ ] Verify `_tag-release.yml` YAML is valid
- [ ] Verify `on-merge.yml` YAML is valid
- [ ] After merge, confirm MCP data tarball appears on the next GitHub Release
- [ ] Confirm repository dispatch fires to terraform-provider-mcp

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)