### PR TITLE
fix(docs): rename page_title to title for Starlight docsSchema

### DIFF
--- a/docs/data-sources/address_allocator.md
+++ b/docs/data-sources/address_allocator.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_address_allocator Data Source - terraform-provider-f5xc"
+title: "f5xc_address_allocator Data Source - terraform-provider-f5xc"
 subcategory: "Cloud Resources"
 description: |-
   Manages Address Allocator will create an address allocator object in 'system' namespace of the user. in F5 Distributed Cloud.

--- a/docs/data-sources/advertise_policy.md
+++ b/docs/data-sources/advertise_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_advertise_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_advertise_policy Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a Advertise Policy resource in F5 Distributed Cloud for advertise_policy object controls how and where a service represented by a given virtual_host object is advertised to consumers. configuration.

--- a/docs/data-sources/alert_policy.md
+++ b/docs/data-sources/alert_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_alert_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_alert_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new Alert Policy Object. in F5 Distributed Cloud.

--- a/docs/data-sources/alert_receiver.md
+++ b/docs/data-sources/alert_receiver.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_alert_receiver Data Source - terraform-provider-f5xc"
+title: "f5xc_alert_receiver Data Source - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new Alert Receiver object. in F5 Distributed Cloud.

--- a/docs/data-sources/api_crawler.md
+++ b/docs/data-sources/api_crawler.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_crawler Data Source - terraform-provider-f5xc"
+title: "f5xc_api_crawler Data Source - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages a API Crawler resource in F5 Distributed Cloud.

--- a/docs/data-sources/api_definition.md
+++ b/docs/data-sources/api_definition.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_definition Data Source - terraform-provider-f5xc"
+title: "f5xc_api_definition Data Source - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages API Definition. in F5 Distributed Cloud.

--- a/docs/data-sources/api_discovery.md
+++ b/docs/data-sources/api_discovery.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_discovery Data Source - terraform-provider-f5xc"
+title: "f5xc_api_discovery Data Source - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/api_testing.md
+++ b/docs/data-sources/api_testing.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_testing Data Source - terraform-provider-f5xc"
+title: "f5xc_api_testing Data Source - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages a API Testing resource in F5 Distributed Cloud.

--- a/docs/data-sources/apm.md
+++ b/docs/data-sources/apm.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_apm Data Source - terraform-provider-f5xc"
+title: "f5xc_apm Data Source - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new APM as a service with configured parameters. in F5 Distributed Cloud.

--- a/docs/data-sources/app_api_group.md
+++ b/docs/data-sources/app_api_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_api_group Data Source - terraform-provider-f5xc"
+title: "f5xc_app_api_group Data Source - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages app_api_group creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/app_firewall.md
+++ b/docs/data-sources/app_firewall.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_firewall Data Source - terraform-provider-f5xc"
+title: "f5xc_app_firewall Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages Application Firewall. in F5 Distributed Cloud.

--- a/docs/data-sources/app_setting.md
+++ b/docs/data-sources/app_setting.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_setting Data Source - terraform-provider-f5xc"
+title: "f5xc_app_setting Data Source - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages App setting configuration in namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/app_type.md
+++ b/docs/data-sources/app_type.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_type Data Source - terraform-provider-f5xc"
+title: "f5xc_app_type Data Source - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/authentication.md
+++ b/docs/data-sources/authentication.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_authentication Data Source - terraform-provider-f5xc"
+title: "f5xc_authentication Data Source - terraform-provider-f5xc"
 subcategory: "Authentication"
 description: |-
   Manages a Authentication resource in F5 Distributed Cloud.

--- a/docs/data-sources/aws_tgw_site.md
+++ b/docs/data-sources/aws_tgw_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_aws_tgw_site Data Source - terraform-provider-f5xc"
+title: "f5xc_aws_tgw_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a AWS TGW Site resource in F5 Distributed Cloud for deploying F5 sites connected via AWS Transit Gateway.

--- a/docs/data-sources/aws_vpc_site.md
+++ b/docs/data-sources/aws_vpc_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_aws_vpc_site Data Source - terraform-provider-f5xc"
+title: "f5xc_aws_vpc_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a AWS VPC Site resource in F5 Distributed Cloud for deploying F5 sites within AWS VPC environments.

--- a/docs/data-sources/azure_vnet_site.md
+++ b/docs/data-sources/azure_vnet_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_azure_vnet_site Data Source - terraform-provider-f5xc"
+title: "f5xc_azure_vnet_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a Azure VNET Site resource in F5 Distributed Cloud for deploying F5 sites within Azure Virtual Network environments.

--- a/docs/data-sources/bgp.md
+++ b/docs/data-sources/bgp.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bgp Data Source - terraform-provider-f5xc"
+title: "f5xc_bgp Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a BGP resource in F5 Distributed Cloud for bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration.

--- a/docs/data-sources/bgp_asn_set.md
+++ b/docs/data-sources/bgp_asn_set.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bgp_asn_set Data Source - terraform-provider-f5xc"
+title: "f5xc_bgp_asn_set Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages bgp_asn_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/bgp_routing_policy.md
+++ b/docs/data-sources/bgp_routing_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bgp_routing_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_bgp_routing_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a BGP Routing Policy resource in F5 Distributed Cloud for bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration.

--- a/docs/data-sources/bot_defense_app_infrastructure.md
+++ b/docs/data-sources/bot_defense_app_infrastructure.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bot_defense_app_infrastructure Data Source - terraform-provider-f5xc"
+title: "f5xc_bot_defense_app_infrastructure Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages Bot Defense App Infrastructure in a given namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/cdn_cache_rule.md
+++ b/docs/data-sources/cdn_cache_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cdn_cache_rule Data Source - terraform-provider-f5xc"
+title: "f5xc_cdn_cache_rule Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a CDN Cache Rule resource in F5 Distributed Cloud for cdn loadbalancer specification. configuration.

--- a/docs/data-sources/cdn_loadbalancer.md
+++ b/docs/data-sources/cdn_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cdn_loadbalancer Data Source - terraform-provider-f5xc"
+title: "f5xc_cdn_loadbalancer Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a CDN Load Balancer resource in F5 Distributed Cloud for content delivery and edge caching with load balancing.

--- a/docs/data-sources/certificate.md
+++ b/docs/data-sources/certificate.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_certificate Data Source - terraform-provider-f5xc"
+title: "f5xc_certificate Data Source - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a Certificate resource in F5 Distributed Cloud for TLS/SSL certificate management.

--- a/docs/data-sources/certificate_chain.md
+++ b/docs/data-sources/certificate_chain.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_certificate_chain Data Source - terraform-provider-f5xc"
+title: "f5xc_certificate_chain Data Source - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a Certificate Chain resource in F5 Distributed Cloud for certificate chain configuration for TLS.

--- a/docs/data-sources/cloud_connect.md
+++ b/docs/data-sources/cloud_connect.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_connect Data Source - terraform-provider-f5xc"
+title: "f5xc_cloud_connect Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Cloud Connect resource in F5 Distributed Cloud for establishing connectivity to cloud provider networks.

--- a/docs/data-sources/cloud_credentials.md
+++ b/docs/data-sources/cloud_credentials.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_credentials Data Source - terraform-provider-f5xc"
+title: "f5xc_cloud_credentials Data Source - terraform-provider-f5xc"
 subcategory: "Authentication"
 description: |-
   Manages a Cloud Credentials resource in F5 Distributed Cloud for api to create cloud_credentials object. configuration.

--- a/docs/data-sources/cloud_elastic_ip.md
+++ b/docs/data-sources/cloud_elastic_ip.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_elastic_ip Data Source - terraform-provider-f5xc"
+title: "f5xc_cloud_elastic_ip Data Source - terraform-provider-f5xc"
 subcategory: "Cloud Resources"
 description: |-
   Manages Cloud Elastic IP creates Cloud Elastic IP object Object is attached to a site. in F5 Distributed Cloud.

--- a/docs/data-sources/cloud_link.md
+++ b/docs/data-sources/cloud_link.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_link Data Source - terraform-provider-f5xc"
+title: "f5xc_cloud_link Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages new CloudLink with configured parameters. in F5 Distributed Cloud.

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cluster Data Source - terraform-provider-f5xc"
+title: "f5xc_cluster Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages cluster will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/cminstance.md
+++ b/docs/data-sources/cminstance.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cminstance Data Source - terraform-provider-f5xc"
+title: "f5xc_cminstance Data Source - terraform-provider-f5xc"
 subcategory: "Subscriptions"
 description: |-
   Manages App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/code_base_integration.md
+++ b/docs/data-sources/code_base_integration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_code_base_integration Data Source - terraform-provider-f5xc"
+title: "f5xc_code_base_integration Data Source - terraform-provider-f5xc"
 subcategory: "Integrations"
 description: |-
   Manages integration details. in F5 Distributed Cloud.

--- a/docs/data-sources/container_registry.md
+++ b/docs/data-sources/container_registry.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_container_registry Data Source - terraform-provider-f5xc"
+title: "f5xc_container_registry Data Source - terraform-provider-f5xc"
 subcategory: "Kubernetes"
 description: |-
   Manages a Container Registry resource in F5 Distributed Cloud for container image registry configuration.

--- a/docs/data-sources/crl.md
+++ b/docs/data-sources/crl.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_crl Data Source - terraform-provider-f5xc"
+title: "f5xc_crl Data Source - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a CRL resource in F5 Distributed Cloud for api to create crl object. configuration.

--- a/docs/data-sources/data_group.md
+++ b/docs/data-sources/data_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_data_group Data Source - terraform-provider-f5xc"
+title: "f5xc_data_group Data Source - terraform-provider-f5xc"
 subcategory: "BIG-IP Integration"
 description: |-
   Manages data group in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/data-sources/data_type.md
+++ b/docs/data-sources/data_type.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_data_type Data Source - terraform-provider-f5xc"
+title: "f5xc_data_type Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages data_type creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/dc_cluster_group.md
+++ b/docs/data-sources/dc_cluster_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_dc_cluster_group Data Source - terraform-provider-f5xc"
+title: "f5xc_dc_cluster_group Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages DC Cluster group in given namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/discovery.md
+++ b/docs/data-sources/discovery.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_discovery Data Source - terraform-provider-f5xc"
+title: "f5xc_discovery Data Source - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/dns_compliance_checks.md
+++ b/docs/data-sources/dns_compliance_checks.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_dns_compliance_checks Data Source - terraform-provider-f5xc"
+title: "f5xc_dns_compliance_checks Data Source - terraform-provider-f5xc"
 subcategory: "DNS"
 description: |-
   Manages DNS Compliance Checks Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/data-sources/dns_domain.md
+++ b/docs/data-sources/dns_domain.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_dns_domain Data Source - terraform-provider-f5xc"
+title: "f5xc_dns_domain Data Source - terraform-provider-f5xc"
 subcategory: "DNS"
 description: |-
   Manages DNS Domain in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.

--- a/docs/data-sources/endpoint.md
+++ b/docs/data-sources/endpoint.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_endpoint Data Source - terraform-provider-f5xc"
+title: "f5xc_endpoint Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages endpoint will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/enhanced_firewall_policy.md
+++ b/docs/data-sources/enhanced_firewall_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_enhanced_firewall_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_enhanced_firewall_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Enhanced Firewall Policy resource in F5 Distributed Cloud for enhanced firewall policy specification. configuration.

--- a/docs/data-sources/external_connector.md
+++ b/docs/data-sources/external_connector.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_external_connector Data Source - terraform-provider-f5xc"
+title: "f5xc_external_connector Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a External Connector resource in F5 Distributed Cloud for external_connector configuration specification. configuration.

--- a/docs/data-sources/fast_acl.md
+++ b/docs/data-sources/fast_acl.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_fast_acl Data Source - terraform-provider-f5xc"
+title: "f5xc_fast_acl Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud.

--- a/docs/data-sources/fast_acl_rule.md
+++ b/docs/data-sources/fast_acl_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_fast_acl_rule Data Source - terraform-provider-f5xc"
+title: "f5xc_fast_acl_rule Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud.

--- a/docs/data-sources/filter_set.md
+++ b/docs/data-sources/filter_set.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_filter_set Data Source - terraform-provider-f5xc"
+title: "f5xc_filter_set Data Source - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages specification. in F5 Distributed Cloud.

--- a/docs/data-sources/fleet.md
+++ b/docs/data-sources/fleet.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_fleet Data Source - terraform-provider-f5xc"
+title: "f5xc_fleet Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages fleet will create a fleet object in 'system' namespace of the user. in F5 Distributed Cloud.

--- a/docs/data-sources/forward_proxy_policy.md
+++ b/docs/data-sources/forward_proxy_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_forward_proxy_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_forward_proxy_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Forward Proxy Policy resource in F5 Distributed Cloud for forward proxy policy specification. configuration.

--- a/docs/data-sources/forwarding_class.md
+++ b/docs/data-sources/forwarding_class.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_forwarding_class Data Source - terraform-provider-f5xc"
+title: "f5xc_forwarding_class Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Forwarding Class resource in F5 Distributed Cloud for forwarding class is created by users in system namespace. configuration.

--- a/docs/data-sources/gcp_vpc_site.md
+++ b/docs/data-sources/gcp_vpc_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_gcp_vpc_site Data Source - terraform-provider-f5xc"
+title: "f5xc_gcp_vpc_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a GCP VPC Site resource in F5 Distributed Cloud for deploying F5 sites within Google Cloud VPC environments.

--- a/docs/data-sources/global_log_receiver.md
+++ b/docs/data-sources/global_log_receiver.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_global_log_receiver Data Source - terraform-provider-f5xc"
+title: "f5xc_global_log_receiver Data Source - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new Global Log Receiver object. in F5 Distributed Cloud.

--- a/docs/data-sources/healthcheck.md
+++ b/docs/data-sources/healthcheck.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_healthcheck Data Source - terraform-provider-f5xc"
+title: "f5xc_healthcheck Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a Healthcheck resource in F5 Distributed Cloud for healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration.

--- a/docs/data-sources/http_loadbalancer.md
+++ b/docs/data-sources/http_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_http_loadbalancer Data Source - terraform-provider-f5xc"
+title: "f5xc_http_loadbalancer Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a HTTP Load Balancer resource in F5 Distributed Cloud for load balancing HTTP/HTTPS traffic with advanced routing and security.

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -1,3 +1,6 @@
+---
+title: "Data Sources"
+---
 # Data Sources
 
 Terraform data sources for querying existing F5 Distributed Cloud infrastructure.

--- a/docs/data-sources/ip_prefix_set.md
+++ b/docs/data-sources/ip_prefix_set.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_ip_prefix_set Data Source - terraform-provider-f5xc"
+title: "f5xc_ip_prefix_set Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages ip_prefix_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/irule.md
+++ b/docs/data-sources/irule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_irule Data Source - terraform-provider-f5xc"
+title: "f5xc_irule Data Source - terraform-provider-f5xc"
 subcategory: "BIG-IP Integration"
 description: |-
   Manages iRule in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/data-sources/log_receiver.md
+++ b/docs/data-sources/log_receiver.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_log_receiver Data Source - terraform-provider-f5xc"
+title: "f5xc_log_receiver Data Source - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new Log Receiver object. in F5 Distributed Cloud.

--- a/docs/data-sources/malicious_user_mitigation.md
+++ b/docs/data-sources/malicious_user_mitigation.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_malicious_user_mitigation Data Source - terraform-provider-f5xc"
+title: "f5xc_malicious_user_mitigation Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages malicious_user_mitigation creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_namespace Data Source - terraform-provider-f5xc"
+title: "f5xc_namespace Data Source - terraform-provider-f5xc"
 subcategory: "Organization"
 description: |-
   Manages new namespace. Name of the object is name of the name space. in F5 Distributed Cloud.

--- a/docs/data-sources/nat_policy.md
+++ b/docs/data-sources/nat_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_nat_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_nat_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a NAT Policy resource in F5 Distributed Cloud for nat policy create specification configures nat policy with multiple rules,. configuration.

--- a/docs/data-sources/network_connector.md
+++ b/docs/data-sources/network_connector.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_connector Data Source - terraform-provider-f5xc"
+title: "f5xc_network_connector Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Network Connector resource in F5 Distributed Cloud for network connector is created by users in system namespace. configuration.

--- a/docs/data-sources/network_firewall.md
+++ b/docs/data-sources/network_firewall.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_firewall Data Source - terraform-provider-f5xc"
+title: "f5xc_network_firewall Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Network Firewall resource in F5 Distributed Cloud for network firewall is created by users in system namespace. configuration.

--- a/docs/data-sources/network_interface.md
+++ b/docs/data-sources/network_interface.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_interface Data Source - terraform-provider-f5xc"
+title: "f5xc_network_interface Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Network Interface resource in F5 Distributed Cloud for network interface represents configuration of a network device. it is created by users in system namespace. configuration.

--- a/docs/data-sources/network_policy.md
+++ b/docs/data-sources/network_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_network_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new network policy with configured parameters in specified namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/network_policy_rule.md
+++ b/docs/data-sources/network_policy_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_policy_rule Data Source - terraform-provider-f5xc"
+title: "f5xc_network_policy_rule Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages network policy rule with configured parameters in specified namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/network_policy_view.md
+++ b/docs/data-sources/network_policy_view.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_policy_view Data Source - terraform-provider-f5xc"
+title: "f5xc_network_policy_view Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Network Policy View resource in F5 Distributed Cloud for network policy view specification. configuration.

--- a/docs/data-sources/nfv_service.md
+++ b/docs/data-sources/nfv_service.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_nfv_service Data Source - terraform-provider-f5xc"
+title: "f5xc_nfv_service Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages new NFV service with configured parameters. in F5 Distributed Cloud.

--- a/docs/data-sources/nginx_service_discovery.md
+++ b/docs/data-sources/nginx_service_discovery.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_nginx_service_discovery Data Source - terraform-provider-f5xc"
+title: "f5xc_nginx_service_discovery Data Source - terraform-provider-f5xc"
 subcategory: "Uncategorized"
 description: |-
   Manages a Nginx Service Discovery resource in F5 Distributed Cloud for api to create nginx service discovery object for a site or virtual site in system namespace. configuration.

--- a/docs/data-sources/origin_pool.md
+++ b/docs/data-sources/origin_pool.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_origin_pool Data Source - terraform-provider-f5xc"
+title: "f5xc_origin_pool Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a Origin Pool resource in F5 Distributed Cloud for defining backend server pools for load balancer targets.

--- a/docs/data-sources/policer.md
+++ b/docs/data-sources/policer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_policer Data Source - terraform-provider-f5xc"
+title: "f5xc_policer Data Source - terraform-provider-f5xc"
 subcategory: "Service Mesh"
 description: |-
   Manages new policer with traffic rate limits. in F5 Distributed Cloud.

--- a/docs/data-sources/policy_based_routing.md
+++ b/docs/data-sources/policy_based_routing.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_policy_based_routing Data Source - terraform-provider-f5xc"
+title: "f5xc_policy_based_routing Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Policy Based Routing resource in F5 Distributed Cloud for network policy based routing create specification. configuration.

--- a/docs/data-sources/protocol_inspection.md
+++ b/docs/data-sources/protocol_inspection.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_protocol_inspection Data Source - terraform-provider-f5xc"
+title: "f5xc_protocol_inspection Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages Protocol Inspection Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/data-sources/protocol_policer.md
+++ b/docs/data-sources/protocol_policer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_protocol_policer Data Source - terraform-provider-f5xc"
+title: "f5xc_protocol_policer Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages protocol_policer object, protocol_policer object contains list of L4 protocol match condition and corresponding traffic rate limits. in F5 Distributed Cloud.

--- a/docs/data-sources/proxy.md
+++ b/docs/data-sources/proxy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_proxy Data Source - terraform-provider-f5xc"
+title: "f5xc_proxy Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Proxy resource in F5 Distributed Cloud for tcp loadbalancer create specification. configuration.

--- a/docs/data-sources/rate_limiter.md
+++ b/docs/data-sources/rate_limiter.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_rate_limiter Data Source - terraform-provider-f5xc"
+title: "f5xc_rate_limiter Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages rate_limiter creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/rate_limiter_policy.md
+++ b/docs/data-sources/rate_limiter_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_rate_limiter_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_rate_limiter_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Rate Limiter Policy resource in F5 Distributed Cloud for rate limiter policy create specification. configuration.

--- a/docs/data-sources/route.md
+++ b/docs/data-sources/route.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_route Data Source - terraform-provider-f5xc"
+title: "f5xc_route Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages route object in a given namespace. Route object is list of route rules. Each rule has match condition to match incoming requests and actions to take on matching requests. in F5 Distributed Cloud.

--- a/docs/data-sources/secret_management_access.md
+++ b/docs/data-sources/secret_management_access.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_secret_management_access Data Source - terraform-provider-f5xc"
+title: "f5xc_secret_management_access Data Source - terraform-provider-f5xc"
 subcategory: "Authentication"
 description: |-
   Manages secret_management_access creates a new object in storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/securemesh_site.md
+++ b/docs/data-sources/securemesh_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_securemesh_site Data Source - terraform-provider-f5xc"
+title: "f5xc_securemesh_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a Securemesh Site resource in F5 Distributed Cloud for deploying secure mesh edge sites with distributed security capabilities.

--- a/docs/data-sources/segment.md
+++ b/docs/data-sources/segment.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_segment Data Source - terraform-provider-f5xc"
+title: "f5xc_segment Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Segment resource in F5 Distributed Cloud for segment. configuration.

--- a/docs/data-sources/sensitive_data_policy.md
+++ b/docs/data-sources/sensitive_data_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_sensitive_data_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_sensitive_data_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages sensitive_data_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/service_policy.md
+++ b/docs/data-sources/service_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_service_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_service_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages service_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/service_policy_rule.md
+++ b/docs/data-sources/service_policy_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_service_policy_rule Data Source - terraform-provider-f5xc"
+title: "f5xc_service_policy_rule Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages service_policy_rule creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/site.md
+++ b/docs/data-sources/site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_site Data Source - terraform-provider-f5xc"
+title: "f5xc_site Data Source - terraform-provider-f5xc"
 subcategory: "Uncategorized"
 description: |-
   Manages a Site resource in F5 Distributed Cloud for app stack site specification. configuration.

--- a/docs/data-sources/site_mesh_group.md
+++ b/docs/data-sources/site_mesh_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_site_mesh_group Data Source - terraform-provider-f5xc"
+title: "f5xc_site_mesh_group Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages Site Mesh Group in system namespace of user. in F5 Distributed Cloud.

--- a/docs/data-sources/subnet.md
+++ b/docs/data-sources/subnet.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_subnet Data Source - terraform-provider-f5xc"
+title: "f5xc_subnet Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Subnet resource in F5 Distributed Cloud for subnet object contains configuration for an interface of a vm/pod. it is created in user or shared namespace. configuration.

--- a/docs/data-sources/tcp_loadbalancer.md
+++ b/docs/data-sources/tcp_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_tcp_loadbalancer Data Source - terraform-provider-f5xc"
+title: "f5xc_tcp_loadbalancer Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a TCP Load Balancer resource in F5 Distributed Cloud for load balancing TCP traffic across origin pools.

--- a/docs/data-sources/tenant_configuration.md
+++ b/docs/data-sources/tenant_configuration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_tenant_configuration Data Source - terraform-provider-f5xc"
+title: "f5xc_tenant_configuration Data Source - terraform-provider-f5xc"
 subcategory: "Organization"
 description: |-
   Manages a Tenant Configuration resource in F5 Distributed Cloud for tenant configuration specification. configuration.

--- a/docs/data-sources/trusted_ca_list.md
+++ b/docs/data-sources/trusted_ca_list.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_trusted_ca_list Data Source - terraform-provider-f5xc"
+title: "f5xc_trusted_ca_list Data Source - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a Trusted CA List resource in F5 Distributed Cloud for trusted certificate authority list management.

--- a/docs/data-sources/tunnel.md
+++ b/docs/data-sources/tunnel.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_tunnel Data Source - terraform-provider-f5xc"
+title: "f5xc_tunnel Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages tunnel in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.

--- a/docs/data-sources/udp_loadbalancer.md
+++ b/docs/data-sources/udp_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_udp_loadbalancer Data Source - terraform-provider-f5xc"
+title: "f5xc_udp_loadbalancer Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a UDP Load Balancer resource in F5 Distributed Cloud for load balancing UDP traffic across origin pools.

--- a/docs/data-sources/usb_policy.md
+++ b/docs/data-sources/usb_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_usb_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_usb_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new USB policy object. in F5 Distributed Cloud.

--- a/docs/data-sources/user_identification.md
+++ b/docs/data-sources/user_identification.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_user_identification Data Source - terraform-provider-f5xc"
+title: "f5xc_user_identification Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages user_identification creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/virtual_host.md
+++ b/docs/data-sources/virtual_host.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_virtual_host Data Source - terraform-provider-f5xc"
+title: "f5xc_virtual_host Data Source - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages virtual host in a given namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/virtual_network.md
+++ b/docs/data-sources/virtual_network.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_virtual_network Data Source - terraform-provider-f5xc"
+title: "f5xc_virtual_network Data Source - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages virtual network in given namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/virtual_site.md
+++ b/docs/data-sources/virtual_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_virtual_site Data Source - terraform-provider-f5xc"
+title: "f5xc_virtual_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages virtual site object in given namespace. in F5 Distributed Cloud.

--- a/docs/data-sources/voltstack_site.md
+++ b/docs/data-sources/voltstack_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_voltstack_site Data Source - terraform-provider-f5xc"
+title: "f5xc_voltstack_site Data Source - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a Voltstack Site resource in F5 Distributed Cloud for deploying Volterra stack sites for edge computing.

--- a/docs/data-sources/waf_exclusion_policy.md
+++ b/docs/data-sources/waf_exclusion_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_waf_exclusion_policy Data Source - terraform-provider-f5xc"
+title: "f5xc_waf_exclusion_policy Data Source - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages WAF exclusion policy. in F5 Distributed Cloud.

--- a/docs/data-sources/workload.md
+++ b/docs/data-sources/workload.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_workload Data Source - terraform-provider-f5xc"
+title: "f5xc_workload Data Source - terraform-provider-f5xc"
 subcategory: "Kubernetes"
 description: |-
   Manages workload_flavor. in F5 Distributed Cloud.

--- a/docs/data-sources/workload_flavor.md
+++ b/docs/data-sources/workload_flavor.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_workload_flavor Data Source - terraform-provider-f5xc"
+title: "f5xc_workload_flavor Data Source - terraform-provider-f5xc"
 subcategory: "Kubernetes"
 description: |-
   Manages workload_flavor. in F5 Distributed Cloud.

--- a/docs/functions/blindfold.md
+++ b/docs/functions/blindfold.md
@@ -1,5 +1,5 @@
 ---
-page_title: "blindfold function - terraform-provider-f5xc"
+title: "blindfold function - terraform-provider-f5xc"
 description: |-
   Encrypts base64-encoded plaintext using F5 Distributed Cloud Secret Management (blindfold).
   Returns a sealed secret string suitable for use in blindfold_secret_info.location fields.

--- a/docs/functions/blindfold_file.md
+++ b/docs/functions/blindfold_file.md
@@ -1,5 +1,5 @@
 ---
-page_title: "blindfold_file function - terraform-provider-f5xc"
+title: "blindfold_file function - terraform-provider-f5xc"
 description: |-
   Reads a file and encrypts its contents using F5 Distributed Cloud Secret Management (blindfold).
   Returns a sealed secret string suitable for use in blindfold_secret_info.location fields.

--- a/docs/functions/index.md
+++ b/docs/functions/index.md
@@ -1,3 +1,6 @@
+---
+title: "Functions"
+---
 # Functions
 
 Provider-defined functions for F5 Distributed Cloud operations.

--- a/docs/guides/addon-activation.md
+++ b/docs/guides/addon-activation.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Guide: Addon Service Activation"
+title: "Guide: Addon Service Activation"
 subcategory: "Guides"
 description: |-
   Learn how to activate F5XC addon services using Terraform.

--- a/docs/guides/advanced-http-loadbalancer.md
+++ b/docs/guides/advanced-http-loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Guide: Advanced HTTP Load Balancer Security"
+title: "Guide: Advanced HTTP Load Balancer Security"
 subcategory: "Guides"
 description: |-
   Advanced guide to deploying a fully-secured HTTP Load Balancer with all security

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Guide: Authentication Methods"
+title: "Guide: Authentication Methods"
 subcategory: "Guides"
 description: |-
   Comprehensive guide to authenticating the F5 Distributed Cloud Terraform

--- a/docs/guides/blindfold.md
+++ b/docs/guides/blindfold.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Guide: Blindfold Secret Management Functions"
+title: "Guide: Blindfold Secret Management Functions"
 subcategory: "Guides"
 description: |-
   Learn how to securely encrypt secrets using F5XC Blindfold functions.

--- a/docs/guides/http-loadbalancer.md
+++ b/docs/guides/http-loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Guide: HTTP Load Balancer with Security Features"
+title: "Guide: HTTP Load Balancer with Security Features"
 subcategory: "Guides"
 description: |-
   Step-by-step guide to deploy a production-ready HTTP Load Balancer with WAF,

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,3 +1,6 @@
+---
+title: "Guides"
+---
 # Guides
 
 Step-by-step tutorials for common F5 Distributed Cloud scenarios.

--- a/docs/guides/v3-migration.md
+++ b/docs/guides/v3-migration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Guide: Migrating to Provider v3.0.0"
+title: "Guide: Migrating to Provider v3.0.0"
 subcategory: "Guides"
 description: |-
   Migration guide for upgrading from F5XC Terraform provider v2.x to v3.0.0,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-page_title: "F5XC Provider"
+title: "F5XC Provider"
 description: |-
   Terraform provider for F5 Distributed Cloud (F5XC) enabling infrastructure as code for load balancers, security policies, sites, and networking. Community-maintained provider built from public F5 API documentation.
 ---

--- a/docs/resources/address_allocator.md
+++ b/docs/resources/address_allocator.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_address_allocator Resource - terraform-provider-f5xc"
+title: "f5xc_address_allocator Resource - terraform-provider-f5xc"
 subcategory: "Cloud Resources"
 description: |-
   Manages Address Allocator will create an address allocator object in 'system' namespace of the user. in F5 Distributed Cloud.

--- a/docs/resources/advertise_policy.md
+++ b/docs/resources/advertise_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_advertise_policy Resource - terraform-provider-f5xc"
+title: "f5xc_advertise_policy Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a Advertise Policy resource in F5 Distributed Cloud for advertise_policy object controls how and where a service represented by a given virtual_host object is advertised to consumers. configuration.

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_alert_policy Resource - terraform-provider-f5xc"
+title: "f5xc_alert_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new Alert Policy Object. in F5 Distributed Cloud.

--- a/docs/resources/alert_receiver.md
+++ b/docs/resources/alert_receiver.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_alert_receiver Resource - terraform-provider-f5xc"
+title: "f5xc_alert_receiver Resource - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new Alert Receiver object. in F5 Distributed Cloud.

--- a/docs/resources/api_crawler.md
+++ b/docs/resources/api_crawler.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_crawler Resource - terraform-provider-f5xc"
+title: "f5xc_api_crawler Resource - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages a API Crawler resource in F5 Distributed Cloud.

--- a/docs/resources/api_definition.md
+++ b/docs/resources/api_definition.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_definition Resource - terraform-provider-f5xc"
+title: "f5xc_api_definition Resource - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages API Definition. in F5 Distributed Cloud.

--- a/docs/resources/api_discovery.md
+++ b/docs/resources/api_discovery.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_discovery Resource - terraform-provider-f5xc"
+title: "f5xc_api_discovery Resource - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/api_testing.md
+++ b/docs/resources/api_testing.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_api_testing Resource - terraform-provider-f5xc"
+title: "f5xc_api_testing Resource - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages a API Testing resource in F5 Distributed Cloud.

--- a/docs/resources/apm.md
+++ b/docs/resources/apm.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_apm Resource - terraform-provider-f5xc"
+title: "f5xc_apm Resource - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new APM as a service with configured parameters. in F5 Distributed Cloud.

--- a/docs/resources/app_api_group.md
+++ b/docs/resources/app_api_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_api_group Resource - terraform-provider-f5xc"
+title: "f5xc_app_api_group Resource - terraform-provider-f5xc"
 subcategory: "API Security"
 description: |-
   Manages app_api_group creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/app_firewall.md
+++ b/docs/resources/app_firewall.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_firewall Resource - terraform-provider-f5xc"
+title: "f5xc_app_firewall Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages Application Firewall. in F5 Distributed Cloud.

--- a/docs/resources/app_setting.md
+++ b/docs/resources/app_setting.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_setting Resource - terraform-provider-f5xc"
+title: "f5xc_app_setting Resource - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages App setting configuration in namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/app_type.md
+++ b/docs/resources/app_type.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_app_type Resource - terraform-provider-f5xc"
+title: "f5xc_app_type Resource - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/authentication.md
+++ b/docs/resources/authentication.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_authentication Resource - terraform-provider-f5xc"
+title: "f5xc_authentication Resource - terraform-provider-f5xc"
 subcategory: "Authentication"
 description: |-
   Manages a Authentication resource in F5 Distributed Cloud.

--- a/docs/resources/aws_tgw_site.md
+++ b/docs/resources/aws_tgw_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_aws_tgw_site Resource - terraform-provider-f5xc"
+title: "f5xc_aws_tgw_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a AWS TGW Site resource in F5 Distributed Cloud for deploying F5 sites connected via AWS Transit Gateway.

--- a/docs/resources/aws_vpc_site.md
+++ b/docs/resources/aws_vpc_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_aws_vpc_site Resource - terraform-provider-f5xc"
+title: "f5xc_aws_vpc_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a AWS VPC Site resource in F5 Distributed Cloud for deploying F5 sites within AWS VPC environments.

--- a/docs/resources/azure_vnet_site.md
+++ b/docs/resources/azure_vnet_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_azure_vnet_site Resource - terraform-provider-f5xc"
+title: "f5xc_azure_vnet_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a Azure VNET Site resource in F5 Distributed Cloud for deploying F5 sites within Azure Virtual Network environments.

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bgp Resource - terraform-provider-f5xc"
+title: "f5xc_bgp Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a BGP resource in F5 Distributed Cloud for bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration.

--- a/docs/resources/bgp_asn_set.md
+++ b/docs/resources/bgp_asn_set.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bgp_asn_set Resource - terraform-provider-f5xc"
+title: "f5xc_bgp_asn_set Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages bgp_asn_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/bgp_routing_policy.md
+++ b/docs/resources/bgp_routing_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bgp_routing_policy Resource - terraform-provider-f5xc"
+title: "f5xc_bgp_routing_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a BGP Routing Policy resource in F5 Distributed Cloud for bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration.

--- a/docs/resources/bot_defense_app_infrastructure.md
+++ b/docs/resources/bot_defense_app_infrastructure.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_bot_defense_app_infrastructure Resource - terraform-provider-f5xc"
+title: "f5xc_bot_defense_app_infrastructure Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages Bot Defense App Infrastructure in a given namespace. in F5 Distributed Cloud.

--- a/docs/resources/cdn_cache_rule.md
+++ b/docs/resources/cdn_cache_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cdn_cache_rule Resource - terraform-provider-f5xc"
+title: "f5xc_cdn_cache_rule Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a CDN Cache Rule resource in F5 Distributed Cloud for cdn loadbalancer specification. configuration.

--- a/docs/resources/cdn_loadbalancer.md
+++ b/docs/resources/cdn_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cdn_loadbalancer Resource - terraform-provider-f5xc"
+title: "f5xc_cdn_loadbalancer Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a CDN Load Balancer resource in F5 Distributed Cloud for content delivery and edge caching with load balancing.

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_certificate Resource - terraform-provider-f5xc"
+title: "f5xc_certificate Resource - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a Certificate resource in F5 Distributed Cloud for TLS/SSL certificate management.

--- a/docs/resources/certificate_chain.md
+++ b/docs/resources/certificate_chain.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_certificate_chain Resource - terraform-provider-f5xc"
+title: "f5xc_certificate_chain Resource - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a Certificate Chain resource in F5 Distributed Cloud for certificate chain configuration for TLS.

--- a/docs/resources/cloud_connect.md
+++ b/docs/resources/cloud_connect.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_connect Resource - terraform-provider-f5xc"
+title: "f5xc_cloud_connect Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Cloud Connect resource in F5 Distributed Cloud for establishing connectivity to cloud provider networks.

--- a/docs/resources/cloud_credentials.md
+++ b/docs/resources/cloud_credentials.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_credentials Resource - terraform-provider-f5xc"
+title: "f5xc_cloud_credentials Resource - terraform-provider-f5xc"
 subcategory: "Authentication"
 description: |-
   Manages a Cloud Credentials resource in F5 Distributed Cloud for api to create cloud_credentials object. configuration.

--- a/docs/resources/cloud_elastic_ip.md
+++ b/docs/resources/cloud_elastic_ip.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_elastic_ip Resource - terraform-provider-f5xc"
+title: "f5xc_cloud_elastic_ip Resource - terraform-provider-f5xc"
 subcategory: "Cloud Resources"
 description: |-
   Manages Cloud Elastic IP creates Cloud Elastic IP object Object is attached to a site. in F5 Distributed Cloud.

--- a/docs/resources/cloud_link.md
+++ b/docs/resources/cloud_link.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cloud_link Resource - terraform-provider-f5xc"
+title: "f5xc_cloud_link Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages new CloudLink with configured parameters. in F5 Distributed Cloud.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cluster Resource - terraform-provider-f5xc"
+title: "f5xc_cluster Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages cluster will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/cminstance.md
+++ b/docs/resources/cminstance.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_cminstance Resource - terraform-provider-f5xc"
+title: "f5xc_cminstance Resource - terraform-provider-f5xc"
 subcategory: "Subscriptions"
 description: |-
   Manages App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/code_base_integration.md
+++ b/docs/resources/code_base_integration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_code_base_integration Resource - terraform-provider-f5xc"
+title: "f5xc_code_base_integration Resource - terraform-provider-f5xc"
 subcategory: "Integrations"
 description: |-
   Manages integration details. in F5 Distributed Cloud.

--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_container_registry Resource - terraform-provider-f5xc"
+title: "f5xc_container_registry Resource - terraform-provider-f5xc"
 subcategory: "Kubernetes"
 description: |-
   Manages a Container Registry resource in F5 Distributed Cloud for container image registry configuration.

--- a/docs/resources/crl.md
+++ b/docs/resources/crl.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_crl Resource - terraform-provider-f5xc"
+title: "f5xc_crl Resource - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a CRL resource in F5 Distributed Cloud for api to create crl object. configuration.

--- a/docs/resources/data_group.md
+++ b/docs/resources/data_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_data_group Resource - terraform-provider-f5xc"
+title: "f5xc_data_group Resource - terraform-provider-f5xc"
 subcategory: "BIG-IP Integration"
 description: |-
   Manages data group in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/resources/data_type.md
+++ b/docs/resources/data_type.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_data_type Resource - terraform-provider-f5xc"
+title: "f5xc_data_type Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages data_type creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/dc_cluster_group.md
+++ b/docs/resources/dc_cluster_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_dc_cluster_group Resource - terraform-provider-f5xc"
+title: "f5xc_dc_cluster_group Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages DC Cluster group in given namespace. in F5 Distributed Cloud.

--- a/docs/resources/discovery.md
+++ b/docs/resources/discovery.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_discovery Resource - terraform-provider-f5xc"
+title: "f5xc_discovery Resource - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/dns_compliance_checks.md
+++ b/docs/resources/dns_compliance_checks.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_dns_compliance_checks Resource - terraform-provider-f5xc"
+title: "f5xc_dns_compliance_checks Resource - terraform-provider-f5xc"
 subcategory: "DNS"
 description: |-
   Manages DNS Compliance Checks Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/resources/dns_domain.md
+++ b/docs/resources/dns_domain.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_dns_domain Resource - terraform-provider-f5xc"
+title: "f5xc_dns_domain Resource - terraform-provider-f5xc"
 subcategory: "DNS"
 description: |-
   Manages DNS Domain in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_endpoint Resource - terraform-provider-f5xc"
+title: "f5xc_endpoint Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages endpoint will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/enhanced_firewall_policy.md
+++ b/docs/resources/enhanced_firewall_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_enhanced_firewall_policy Resource - terraform-provider-f5xc"
+title: "f5xc_enhanced_firewall_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Enhanced Firewall Policy resource in F5 Distributed Cloud for enhanced firewall policy specification. configuration.

--- a/docs/resources/external_connector.md
+++ b/docs/resources/external_connector.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_external_connector Resource - terraform-provider-f5xc"
+title: "f5xc_external_connector Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a External Connector resource in F5 Distributed Cloud for external_connector configuration specification. configuration.

--- a/docs/resources/fast_acl.md
+++ b/docs/resources/fast_acl.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_fast_acl Resource - terraform-provider-f5xc"
+title: "f5xc_fast_acl Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud.

--- a/docs/resources/fast_acl_rule.md
+++ b/docs/resources/fast_acl_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_fast_acl_rule Resource - terraform-provider-f5xc"
+title: "f5xc_fast_acl_rule Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud.

--- a/docs/resources/filter_set.md
+++ b/docs/resources/filter_set.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_filter_set Resource - terraform-provider-f5xc"
+title: "f5xc_filter_set Resource - terraform-provider-f5xc"
 subcategory: "Applications"
 description: |-
   Manages specification. in F5 Distributed Cloud.

--- a/docs/resources/fleet.md
+++ b/docs/resources/fleet.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_fleet Resource - terraform-provider-f5xc"
+title: "f5xc_fleet Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages fleet will create a fleet object in 'system' namespace of the user. in F5 Distributed Cloud.

--- a/docs/resources/forward_proxy_policy.md
+++ b/docs/resources/forward_proxy_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_forward_proxy_policy Resource - terraform-provider-f5xc"
+title: "f5xc_forward_proxy_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Forward Proxy Policy resource in F5 Distributed Cloud for forward proxy policy specification. configuration.

--- a/docs/resources/forwarding_class.md
+++ b/docs/resources/forwarding_class.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_forwarding_class Resource - terraform-provider-f5xc"
+title: "f5xc_forwarding_class Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Forwarding Class resource in F5 Distributed Cloud for forwarding class is created by users in system namespace. configuration.

--- a/docs/resources/gcp_vpc_site.md
+++ b/docs/resources/gcp_vpc_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_gcp_vpc_site Resource - terraform-provider-f5xc"
+title: "f5xc_gcp_vpc_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a GCP VPC Site resource in F5 Distributed Cloud for deploying F5 sites within Google Cloud VPC environments.

--- a/docs/resources/global_log_receiver.md
+++ b/docs/resources/global_log_receiver.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_global_log_receiver Resource - terraform-provider-f5xc"
+title: "f5xc_global_log_receiver Resource - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new Global Log Receiver object. in F5 Distributed Cloud.

--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_healthcheck Resource - terraform-provider-f5xc"
+title: "f5xc_healthcheck Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a Healthcheck resource in F5 Distributed Cloud for healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration.

--- a/docs/resources/http_loadbalancer.md
+++ b/docs/resources/http_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_http_loadbalancer Resource - terraform-provider-f5xc"
+title: "f5xc_http_loadbalancer Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a HTTP Load Balancer resource in F5 Distributed Cloud for load balancing HTTP/HTTPS traffic with advanced routing and security.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,3 +1,6 @@
+---
+title: "Resources"
+---
 # Resources
 
 Terraform resources for managing F5 Distributed Cloud infrastructure.

--- a/docs/resources/ip_prefix_set.md
+++ b/docs/resources/ip_prefix_set.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_ip_prefix_set Resource - terraform-provider-f5xc"
+title: "f5xc_ip_prefix_set Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages ip_prefix_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/irule.md
+++ b/docs/resources/irule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_irule Resource - terraform-provider-f5xc"
+title: "f5xc_irule Resource - terraform-provider-f5xc"
 subcategory: "BIG-IP Integration"
 description: |-
   Manages iRule in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/resources/log_receiver.md
+++ b/docs/resources/log_receiver.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_log_receiver Resource - terraform-provider-f5xc"
+title: "f5xc_log_receiver Resource - terraform-provider-f5xc"
 subcategory: "Monitoring"
 description: |-
   Manages new Log Receiver object. in F5 Distributed Cloud.

--- a/docs/resources/malicious_user_mitigation.md
+++ b/docs/resources/malicious_user_mitigation.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_malicious_user_mitigation Resource - terraform-provider-f5xc"
+title: "f5xc_malicious_user_mitigation Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages malicious_user_mitigation creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_namespace Resource - terraform-provider-f5xc"
+title: "f5xc_namespace Resource - terraform-provider-f5xc"
 subcategory: "Organization"
 description: |-
   Manages new namespace. Name of the object is name of the name space. in F5 Distributed Cloud.

--- a/docs/resources/nat_policy.md
+++ b/docs/resources/nat_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_nat_policy Resource - terraform-provider-f5xc"
+title: "f5xc_nat_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a NAT Policy resource in F5 Distributed Cloud for nat policy create specification configures nat policy with multiple rules,. configuration.

--- a/docs/resources/network_connector.md
+++ b/docs/resources/network_connector.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_connector Resource - terraform-provider-f5xc"
+title: "f5xc_network_connector Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Network Connector resource in F5 Distributed Cloud for network connector is created by users in system namespace. configuration.

--- a/docs/resources/network_firewall.md
+++ b/docs/resources/network_firewall.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_firewall Resource - terraform-provider-f5xc"
+title: "f5xc_network_firewall Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Network Firewall resource in F5 Distributed Cloud for network firewall is created by users in system namespace. configuration.

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_interface Resource - terraform-provider-f5xc"
+title: "f5xc_network_interface Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Network Interface resource in F5 Distributed Cloud for network interface represents configuration of a network device. it is created by users in system namespace. configuration.

--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_policy Resource - terraform-provider-f5xc"
+title: "f5xc_network_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new network policy with configured parameters in specified namespace. in F5 Distributed Cloud.

--- a/docs/resources/network_policy_rule.md
+++ b/docs/resources/network_policy_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_policy_rule Resource - terraform-provider-f5xc"
+title: "f5xc_network_policy_rule Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages network policy rule with configured parameters in specified namespace. in F5 Distributed Cloud.

--- a/docs/resources/network_policy_view.md
+++ b/docs/resources/network_policy_view.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_network_policy_view Resource - terraform-provider-f5xc"
+title: "f5xc_network_policy_view Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Network Policy View resource in F5 Distributed Cloud for network policy view specification. configuration.

--- a/docs/resources/nfv_service.md
+++ b/docs/resources/nfv_service.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_nfv_service Resource - terraform-provider-f5xc"
+title: "f5xc_nfv_service Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages new NFV service with configured parameters. in F5 Distributed Cloud.

--- a/docs/resources/nginx_service_discovery.md
+++ b/docs/resources/nginx_service_discovery.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_nginx_service_discovery Resource - terraform-provider-f5xc"
+title: "f5xc_nginx_service_discovery Resource - terraform-provider-f5xc"
 subcategory: "Uncategorized"
 description: |-
   Manages a Nginx Service Discovery resource in F5 Distributed Cloud for api to create nginx service discovery object for a site or virtual site in system namespace. configuration.

--- a/docs/resources/origin_pool.md
+++ b/docs/resources/origin_pool.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_origin_pool Resource - terraform-provider-f5xc"
+title: "f5xc_origin_pool Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a Origin Pool resource in F5 Distributed Cloud for defining backend server pools for load balancer targets.

--- a/docs/resources/policer.md
+++ b/docs/resources/policer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_policer Resource - terraform-provider-f5xc"
+title: "f5xc_policer Resource - terraform-provider-f5xc"
 subcategory: "Service Mesh"
 description: |-
   Manages new policer with traffic rate limits. in F5 Distributed Cloud.

--- a/docs/resources/policy_based_routing.md
+++ b/docs/resources/policy_based_routing.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_policy_based_routing Resource - terraform-provider-f5xc"
+title: "f5xc_policy_based_routing Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Policy Based Routing resource in F5 Distributed Cloud for network policy based routing create specification. configuration.

--- a/docs/resources/protocol_inspection.md
+++ b/docs/resources/protocol_inspection.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_protocol_inspection Resource - terraform-provider-f5xc"
+title: "f5xc_protocol_inspection Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages Protocol Inspection Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.

--- a/docs/resources/protocol_policer.md
+++ b/docs/resources/protocol_policer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_protocol_policer Resource - terraform-provider-f5xc"
+title: "f5xc_protocol_policer Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages protocol_policer object, protocol_policer object contains list of L4 protocol match condition and corresponding traffic rate limits. in F5 Distributed Cloud.

--- a/docs/resources/proxy.md
+++ b/docs/resources/proxy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_proxy Resource - terraform-provider-f5xc"
+title: "f5xc_proxy Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Proxy resource in F5 Distributed Cloud for tcp loadbalancer create specification. configuration.

--- a/docs/resources/rate_limiter.md
+++ b/docs/resources/rate_limiter.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_rate_limiter Resource - terraform-provider-f5xc"
+title: "f5xc_rate_limiter Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages rate_limiter creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/rate_limiter_policy.md
+++ b/docs/resources/rate_limiter_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_rate_limiter_policy Resource - terraform-provider-f5xc"
+title: "f5xc_rate_limiter_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages a Rate Limiter Policy resource in F5 Distributed Cloud for rate limiter policy create specification. configuration.

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_route Resource - terraform-provider-f5xc"
+title: "f5xc_route Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages route object in a given namespace. Route object is list of route rules. Each rule has match condition to match incoming requests and actions to take on matching requests. in F5 Distributed Cloud.

--- a/docs/resources/secret_management_access.md
+++ b/docs/resources/secret_management_access.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_secret_management_access Resource - terraform-provider-f5xc"
+title: "f5xc_secret_management_access Resource - terraform-provider-f5xc"
 subcategory: "Authentication"
 description: |-
   Manages secret_management_access creates a new object in storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/securemesh_site.md
+++ b/docs/resources/securemesh_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_securemesh_site Resource - terraform-provider-f5xc"
+title: "f5xc_securemesh_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a Securemesh Site resource in F5 Distributed Cloud for deploying secure mesh edge sites with distributed security capabilities.

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_segment Resource - terraform-provider-f5xc"
+title: "f5xc_segment Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Segment resource in F5 Distributed Cloud for segment. configuration.

--- a/docs/resources/sensitive_data_policy.md
+++ b/docs/resources/sensitive_data_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_sensitive_data_policy Resource - terraform-provider-f5xc"
+title: "f5xc_sensitive_data_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages sensitive_data_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/service_policy.md
+++ b/docs/resources/service_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_service_policy Resource - terraform-provider-f5xc"
+title: "f5xc_service_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages service_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/service_policy_rule.md
+++ b/docs/resources/service_policy_rule.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_service_policy_rule Resource - terraform-provider-f5xc"
+title: "f5xc_service_policy_rule Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages service_policy_rule creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_site Resource - terraform-provider-f5xc"
+title: "f5xc_site Resource - terraform-provider-f5xc"
 subcategory: "Uncategorized"
 description: |-
   Manages a Site resource in F5 Distributed Cloud for app stack site specification. configuration.

--- a/docs/resources/site_mesh_group.md
+++ b/docs/resources/site_mesh_group.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_site_mesh_group Resource - terraform-provider-f5xc"
+title: "f5xc_site_mesh_group Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages Site Mesh Group in system namespace of user. in F5 Distributed Cloud.

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_subnet Resource - terraform-provider-f5xc"
+title: "f5xc_subnet Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages a Subnet resource in F5 Distributed Cloud for subnet object contains configuration for an interface of a vm/pod. it is created in user or shared namespace. configuration.

--- a/docs/resources/tcp_loadbalancer.md
+++ b/docs/resources/tcp_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_tcp_loadbalancer Resource - terraform-provider-f5xc"
+title: "f5xc_tcp_loadbalancer Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a TCP Load Balancer resource in F5 Distributed Cloud for load balancing TCP traffic across origin pools.

--- a/docs/resources/tenant_configuration.md
+++ b/docs/resources/tenant_configuration.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_tenant_configuration Resource - terraform-provider-f5xc"
+title: "f5xc_tenant_configuration Resource - terraform-provider-f5xc"
 subcategory: "Organization"
 description: |-
   Manages a Tenant Configuration resource in F5 Distributed Cloud for tenant configuration specification. configuration.

--- a/docs/resources/trusted_ca_list.md
+++ b/docs/resources/trusted_ca_list.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_trusted_ca_list Resource - terraform-provider-f5xc"
+title: "f5xc_trusted_ca_list Resource - terraform-provider-f5xc"
 subcategory: "Certificates"
 description: |-
   Manages a Trusted CA List resource in F5 Distributed Cloud for trusted certificate authority list management.

--- a/docs/resources/tunnel.md
+++ b/docs/resources/tunnel.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_tunnel Resource - terraform-provider-f5xc"
+title: "f5xc_tunnel Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages tunnel in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.

--- a/docs/resources/udp_loadbalancer.md
+++ b/docs/resources/udp_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_udp_loadbalancer Resource - terraform-provider-f5xc"
+title: "f5xc_udp_loadbalancer Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages a UDP Load Balancer resource in F5 Distributed Cloud for load balancing UDP traffic across origin pools.

--- a/docs/resources/usb_policy.md
+++ b/docs/resources/usb_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_usb_policy Resource - terraform-provider-f5xc"
+title: "f5xc_usb_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages new USB policy object. in F5 Distributed Cloud.

--- a/docs/resources/user_identification.md
+++ b/docs/resources/user_identification.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_user_identification Resource - terraform-provider-f5xc"
+title: "f5xc_user_identification Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages user_identification creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.

--- a/docs/resources/virtual_host.md
+++ b/docs/resources/virtual_host.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_virtual_host Resource - terraform-provider-f5xc"
+title: "f5xc_virtual_host Resource - terraform-provider-f5xc"
 subcategory: "Load Balancing"
 description: |-
   Manages virtual host in a given namespace. in F5 Distributed Cloud.

--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_virtual_network Resource - terraform-provider-f5xc"
+title: "f5xc_virtual_network Resource - terraform-provider-f5xc"
 subcategory: "Networking"
 description: |-
   Manages virtual network in given namespace. in F5 Distributed Cloud.

--- a/docs/resources/virtual_site.md
+++ b/docs/resources/virtual_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_virtual_site Resource - terraform-provider-f5xc"
+title: "f5xc_virtual_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages virtual site object in given namespace. in F5 Distributed Cloud.

--- a/docs/resources/voltstack_site.md
+++ b/docs/resources/voltstack_site.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_voltstack_site Resource - terraform-provider-f5xc"
+title: "f5xc_voltstack_site Resource - terraform-provider-f5xc"
 subcategory: "Sites"
 description: |-
   Manages a Voltstack Site resource in F5 Distributed Cloud for deploying Volterra stack sites for edge computing.

--- a/docs/resources/waf_exclusion_policy.md
+++ b/docs/resources/waf_exclusion_policy.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_waf_exclusion_policy Resource - terraform-provider-f5xc"
+title: "f5xc_waf_exclusion_policy Resource - terraform-provider-f5xc"
 subcategory: "Security"
 description: |-
   Manages WAF exclusion policy. in F5 Distributed Cloud.

--- a/docs/resources/workload.md
+++ b/docs/resources/workload.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_workload Resource - terraform-provider-f5xc"
+title: "f5xc_workload Resource - terraform-provider-f5xc"
 subcategory: "Kubernetes"
 description: |-
   Manages workload_flavor. in F5 Distributed Cloud.

--- a/docs/resources/workload_flavor.md
+++ b/docs/resources/workload_flavor.md
@@ -1,5 +1,5 @@
 ---
-page_title: "f5xc_workload_flavor Resource - terraform-provider-f5xc"
+title: "f5xc_workload_flavor Resource - terraform-provider-f5xc"
 subcategory: "Kubernetes"
 description: |-
   Manages workload_flavor. in F5 Distributed Cloud.


### PR DESCRIPTION
## Summary

Rename `page_title` → `title` in all 207 docs .md frontmatter blocks to satisfy Starlight's `docsSchema()` which requires `title` (string). Added missing frontmatter to 4 index files (`docs/guides/index.md`, `docs/resources/index.md`, `docs/data-sources/index.md`, `docs/functions/index.md`).

Refs f5xc-salesdemos/xcsh#223