### PR TITLE
fix: update sync-openapi.yml to use new spec repo and gh api download

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           PR_COUNT=$(gh pr list --search "in:title \"${{ env.PR_TITLE }}\"" --state open --json number --jq length)
           if [ "$PR_COUNT" -gt "0" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Found existing open PR - skipping"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine spec source and version

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -42,7 +42,7 @@ env:
   SPEC_DIR: docs/specifications/api
   PR_TITLE: "feat: update F5 Distributed Cloud OpenAPI specifications"
   # V2 spec source configuration
-  ENRICHED_REPO: robinmordasiewicz/f5xc-api-enriched
+  ENRICHED_REPO: f5xc-salesdemos/api-specs-enriched
   # Default to v2 specs unless overridden
   SPEC_SOURCE: ${{ inputs.spec_source || 'v2' }}
   SPEC_VERSION: ${{ inputs.spec_version || 'latest' }}
@@ -85,24 +85,21 @@ jobs:
           if [ "$SPEC_SOURCE" = "v2" ]; then
             # Determine v2 version
             if [ "$SPEC_VERSION" = "latest" ] || [ -z "$SPEC_VERSION" ]; then
-              # Get latest release from enriched repo
-              LATEST=$(gh release list --repo "${{ env.ENRICHED_REPO }}" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+              # Get latest release from enriched repo via gh api (works for private repos)
+              LATEST=$(gh api repos/${{ env.ENRICHED_REPO }}/releases --jq '.[0].tag_name' 2>/dev/null || echo "")
               if [ -z "$LATEST" ]; then
                 echo "::warning::Could not determine latest v2 release, falling back to v1"
                 SPEC_SOURCE="v1"
-                echo "spec_source=v1" >> $GITHUB_OUTPUT
+                echo "spec_source=v1" >> "$GITHUB_OUTPUT"
               else
                 SPEC_VERSION="$LATEST"
                 echo "Using latest v2 release: $SPEC_VERSION"
               fi
             fi
-            echo "spec_version=$SPEC_VERSION" >> $GITHUB_OUTPUT
+            echo "spec_version=$SPEC_VERSION" >> "$GITHUB_OUTPUT"
 
-            # Build v2 download URL
             if [ "$SPEC_SOURCE" = "v2" ]; then
-              DOWNLOAD_URL="https://github.com/${{ env.ENRICHED_REPO }}/releases/download/${SPEC_VERSION}/f5xc-api-specs-${SPEC_VERSION}.zip"
-              echo "V2 download URL: $DOWNLOAD_URL"
-              echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
+              echo "download_method=gh_api" >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -110,41 +107,64 @@ jobs:
             # V1 legacy URL
             DOWNLOAD_URL="https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
             echo "V1 download URL: $DOWNLOAD_URL"
-            echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
-            echo "spec_version=v1" >> $GITHUB_OUTPUT
+            echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
+            echo "download_method=curl" >> "$GITHUB_OUTPUT"
+            echo "spec_version=v1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download OpenAPI specs
         if: steps.existing_pr.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p ${{ env.SPEC_DIR }}
 
-          DOWNLOAD_URL="${{ steps.spec_config.outputs.download_url }}"
+          DOWNLOAD_METHOD="${{ steps.spec_config.outputs.download_method }}"
           SPEC_SOURCE="${{ steps.spec_config.outputs.spec_source }}"
 
-          echo "Downloading specs from: $DOWNLOAD_URL"
+          if [ "$DOWNLOAD_METHOD" = "gh_api" ]; then
+            # V2: Download via gh api (supports private repos)
+            echo "Downloading v2 specs via gh api..."
+            ASSET_ID=$(gh api repos/${{ env.ENRICHED_REPO }}/releases --jq \
+              '[.[0].assets[] | select(.name | startswith("f5xc-api-specs"))] | .[0].id')
+            gh api repos/${{ env.ENRICHED_REPO }}/releases/assets/"$ASSET_ID" \
+              -H "Accept: application/octet-stream" > openapi.zip
+            echo "Download successful"
 
-          # Retry logic with exponential backoff
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "::group::Download attempt $attempt of $max_attempts"
-            if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip "$DOWNLOAD_URL"; then
-              echo "Download successful"
+            # Also download api-catalog.json standalone asset
+            CATALOG_ID=$(gh api repos/${{ env.ENRICHED_REPO }}/releases --jq \
+              '[.[0].assets[] | select(.name=="api-catalog.json")] | .[0].id')
+            if [ -n "$CATALOG_ID" ] && [ "$CATALOG_ID" != "null" ]; then
+              gh api repos/${{ env.ENRICHED_REPO }}/releases/assets/"$CATALOG_ID" \
+                -H "Accept: application/octet-stream" > "${{ env.SPEC_DIR }}/api-catalog.json"
+              echo "Downloaded api-catalog.json"
+            fi
+          else
+            # V1: Download via curl
+            DOWNLOAD_URL="${{ steps.spec_config.outputs.download_url }}"
+            echo "Downloading specs from: $DOWNLOAD_URL"
+
+            max_attempts=3
+            attempt=1
+            while [ "$attempt" -le "$max_attempts" ]; do
+              echo "::group::Download attempt $attempt of $max_attempts"
+              if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip "$DOWNLOAD_URL"; then
+                echo "Download successful"
+                echo "::endgroup::"
+                break
+              fi
               echo "::endgroup::"
-              break
-            fi
-            echo "::endgroup::"
-            attempt=$((attempt + 1))
-            if [ $attempt -le $max_attempts ]; then
-              sleep_time=$((2 ** attempt * 5))
-              echo "::warning::Download failed, retrying in ${sleep_time}s..."
-              sleep $sleep_time
-            else
-              echo "::error::All $max_attempts download attempts failed"
-              exit 1
-            fi
-          done
+              attempt=$((attempt + 1))
+              if [ "$attempt" -le "$max_attempts" ]; then
+                sleep_time=$((2 ** attempt * 5))
+                echo "::warning::Download failed, retrying in ${sleep_time}s..."
+                sleep "$sleep_time"
+              else
+                echo "::error::All $max_attempts download attempts failed"
+                exit 1
+              fi
+            done
+          fi
 
           # Clear existing specs before extracting
           rm -rf ${{ env.SPEC_DIR }}/*

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -80,7 +80,7 @@ jobs:
           SPEC_VERSION="${{ env.SPEC_VERSION }}"
 
           echo "Spec source: $SPEC_SOURCE"
-          echo "spec_source=$SPEC_SOURCE" >> $GITHUB_OUTPUT
+          echo "spec_source=$SPEC_SOURCE" >> "$GITHUB_OUTPUT"
 
           if [ "$SPEC_SOURCE" = "v2" ]; then
             # Determine v2 version


### PR DESCRIPTION
## Summary

- Update `ENRICHED_REPO` from decommissioned `robinmordasiewicz/f5xc-api-enriched` to `f5xc-salesdemos/api-specs-enriched`
- Replace `curl` download with `gh api` asset download for private repo compatibility
- Also download `api-catalog.json` standalone asset during sync
- Fix SC2086 quoting in the v1 fallback retry loop

This fixes the twice-daily spec sync workflow so the provider always builds against the latest API specs.

## Test plan

- [x] Verify workflow YAML is valid
- [ ] CI passes
- [ ] Manual workflow_dispatch test after merge

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)