### PR TITLE
feat: SP-4 constraints pipeline — fix 3 bugs unlocking validators for 58 resources

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,atmost,atleast

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -36,6 +36,9 @@ import (
 {{- if .HasListSizeValidators}}
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 {{- end}}
+{{- if .HasInt64RangeValidators}}
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+{{- end}}
 {{- if .HasPatternValidators}}
 	"regexp"
 {{- end}}
@@ -149,6 +152,16 @@ func (r *{{.TitleCase}}Resource) Schema(ctx context.Context, req resource.Schema
 					listvalidator.SizeAtMost({{.MaxItems}}),
 {{- else}}
 					listvalidator.SizeAtLeast({{.MinItems}}),
+{{- end}}
+				},
+{{- else if and (eq .Type "int64") (or (gt .Minimum 0) (gt .Maximum 0))}}
+				Validators: []validator.Int64{
+{{- if and (gt .Minimum 0) (gt .Maximum 0)}}
+					int64validator.Between({{.Minimum}}, {{.Maximum}}),
+{{- else if gt .Maximum 0}}
+					int64validator.AtMost({{.Maximum}}),
+{{- else}}
+					int64validator.AtLeast({{.Minimum}}),
 {{- end}}
 				},
 {{- end}}

--- a/tools/pkg/constraints/constraints.go
+++ b/tools/pkg/constraints/constraints.go
@@ -9,29 +9,44 @@ type Parsed struct {
 	Pattern   string
 	MinItems  int
 	MaxItems  int
+	Minimum   int
+	Maximum   int
 }
 
 // Parse extracts constraint data from x-f5xc-constraints map.
 // Returns nil for nil input, low-confidence, or non-deterministic constraints.
-// Only uses constraints where metadata.deterministic==true OR metadata.confidence >= 0.9.
+// Accepts deterministic at top level (actual spec format) or in metadata (legacy).
+// Only uses constraints where deterministic==true OR metadata.confidence >= 0.9.
 func Parse(raw map[string]interface{}) *Parsed {
 	if raw == nil {
 		return nil
 	}
+
 	deterministic := false
 	confidence := 0.0
+
+	// Check top-level deterministic (actual spec format since v2.1.80+)
+	if d, ok := raw["deterministic"].(bool); ok {
+		deterministic = d
+	}
+
+	// Also check metadata for confidence and legacy deterministic
 	if meta, ok := raw["metadata"].(map[string]interface{}); ok {
-		if d, ok := meta["deterministic"].(bool); ok {
-			deterministic = d
+		if d, ok := meta["deterministic"].(bool); ok && d {
+			deterministic = true
 		}
 		if c, ok := meta["confidence"].(float64); ok {
 			confidence = c
 		}
 	}
+
 	if !deterministic && confidence < 0.9 {
 		return nil
 	}
+
 	p := &Parsed{}
+
+	// String constraints
 	if v, ok := raw["minLength"].(float64); ok {
 		p.MinLength = int(v)
 	}
@@ -41,11 +56,22 @@ func Parse(raw map[string]interface{}) *Parsed {
 	if v, ok := raw["pattern"].(string); ok {
 		p.Pattern = v
 	}
+
+	// List/array constraints
 	if v, ok := raw["minItems"].(float64); ok {
 		p.MinItems = int(v)
 	}
 	if v, ok := raw["maxItems"].(float64); ok {
 		p.MaxItems = int(v)
 	}
+
+	// Numeric constraints
+	if v, ok := raw["minimum"].(float64); ok {
+		p.Minimum = int(v)
+	}
+	if v, ok := raw["maximum"].(float64); ok {
+		p.Maximum = int(v)
+	}
+
 	return p
 }

--- a/tools/pkg/constraints/constraints_test.go
+++ b/tools/pkg/constraints/constraints_test.go
@@ -151,3 +151,73 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestParse_TopLevelDeterministic(t *testing.T) {
+	input := map[string]interface{}{
+		"constraintType": "string",
+		"category":       "naming",
+		"maxLength":      float64(1024),
+		"minLength":      float64(1),
+		"pattern":        "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+		"deterministic":  true,
+		"metadata": map[string]interface{}{
+			"source":     "api-probed",
+			"confidence": 0.99,
+		},
+	}
+	result := Parse(input)
+	if result == nil {
+		t.Fatal("Parse() returned nil for top-level deterministic=true constraint")
+	}
+	if result.MinLength != 1 {
+		t.Errorf("MinLength = %d, want 1", result.MinLength)
+	}
+	if result.MaxLength != 1024 {
+		t.Errorf("MaxLength = %d, want 1024", result.MaxLength)
+	}
+	if result.Pattern != "^[a-z]([-a-z0-9]*[a-z0-9])?$" {
+		t.Errorf("Pattern = %q, want naming pattern", result.Pattern)
+	}
+}
+
+func TestParse_NumericConstraints(t *testing.T) {
+	input := map[string]interface{}{
+		"constraintType": "number",
+		"category":       "threshold",
+		"minimum":        float64(1),
+		"maximum":        float64(16),
+		"deterministic":  true,
+		"metadata": map[string]interface{}{
+			"source":     "api-probed",
+			"confidence": 0.99,
+		},
+	}
+	result := Parse(input)
+	if result == nil {
+		t.Fatal("Parse() returned nil for numeric constraint")
+	}
+	if result.Minimum != 1 {
+		t.Errorf("Minimum = %d, want 1", result.Minimum)
+	}
+	if result.Maximum != 16 {
+		t.Errorf("Maximum = %d, want 16", result.Maximum)
+	}
+}
+
+func TestParse_ConfidenceInMetadata_NoDeterministic(t *testing.T) {
+	input := map[string]interface{}{
+		"constraintType": "string",
+		"maxLength":      float64(1200),
+		"metadata": map[string]interface{}{
+			"source":     "inferred",
+			"confidence": float64(0.9),
+		},
+	}
+	result := Parse(input)
+	if result == nil {
+		t.Fatal("Parse() returned nil for confidence=0.9 constraint")
+	}
+	if result.MaxLength != 1200 {
+		t.Errorf("MaxLength = %d, want 1200", result.MaxLength)
+	}
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -146,6 +146,8 @@ type TerraformAttribute struct {
 	Pattern              string            // From validation rules
 	MinItems             int               // From x-f5xc-constraints.min_items
 	MaxItems             int               // From x-f5xc-constraints.max_items
+	Minimum  int
+	Maximum  int
 }
 
 // ResourceTemplate contains data for generating a Terraform resource.
@@ -175,6 +177,7 @@ type ResourceTemplate struct {
 	HasEnumValidators      bool   // True if any attribute has EnumValues
 	HasPatternValidators   bool   // True if any attribute has Pattern
 	HasListSizeValidators  bool   // True if any attribute has MinItems or MaxItems
+	HasInt64RangeValidators bool
 	HasConflicts           bool   // True if any attribute has ConflictsWith
 	ConflictCheckCode      string // Generated Go code for conflict checks
 }

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -245,6 +245,12 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 		if c.MaxItems > 0 {
 			attr.MaxItems = c.MaxItems
 		}
+		if c.Minimum > 0 {
+			attr.Minimum = c.Minimum
+		}
+		if c.Maximum > 0 {
+			attr.Maximum = c.Maximum
+		}
 	}
 
 	// Prefer x-validation-rules over x-ves-validation-rules when both present

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -264,6 +264,7 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 		HasEnumValidators:      HasEnumValidatorsAny(attributes),
 		HasPatternValidators:   HasPatternValidatorsAny(attributes),
 		HasListSizeValidators:  HasListSizeValidatorsAny(attributes),
+		HasInt64RangeValidators: HasInt64RangeValidatorsAny(attributes),
 		HasConflicts:           conflictCode != "",
 		ConflictCheckCode:      conflictCode,
 	}, nil

--- a/tools/pkg/schema/scan.go
+++ b/tools/pkg/schema/scan.go
@@ -114,6 +114,21 @@ func CollectConflictAttrs(attributes []openapi.TerraformAttribute) ([]conflicts.
 	return result, goNameLookup
 }
 
+// HasInt64RangeValidatorsAny returns true if any attribute or nested attribute has Minimum or Maximum set.
+func HasInt64RangeValidatorsAny(attributes []openapi.TerraformAttribute) bool {
+	for _, attr := range attributes {
+		if attr.Minimum > 0 || attr.Maximum > 0 {
+			return true
+		}
+		for _, nested := range attr.NestedAttributes {
+			if nested.Minimum > 0 || nested.Maximum > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ScanPlanModifierUsage recursively scans attributes to determine which plan modifier imports are needed.
 func ScanPlanModifierUsage(attributes []openapi.TerraformAttribute) (usesBool, usesInt64, usesString bool) {
 	for _, attr := range attributes {

--- a/tools/pkg/schema/scan_test.go
+++ b/tools/pkg/schema/scan_test.go
@@ -128,6 +128,33 @@ func TestCollectConflictAttrs(t *testing.T) {
 	}
 }
 
+func TestHasInt64RangeValidatorsAny(t *testing.T) {
+	withRange := []openapi.TerraformAttribute{
+		{Name: "no_range"},
+		{Name: "has_range", Minimum: 1, Maximum: 16},
+	}
+	if !HasInt64RangeValidatorsAny(withRange) {
+		t.Error("HasInt64RangeValidatorsAny should detect Minimum/Maximum > 0")
+	}
+
+	withoutRange := []openapi.TerraformAttribute{
+		{Name: "no_range"},
+		{Name: "also_no_range"},
+	}
+	if HasInt64RangeValidatorsAny(withoutRange) {
+		t.Error("HasInt64RangeValidatorsAny should return false when no range set")
+	}
+
+	nested := []openapi.TerraformAttribute{
+		{Name: "parent", NestedAttributes: []openapi.TerraformAttribute{
+			{Name: "child_range", Minimum: 1, Maximum: 100},
+		}},
+	}
+	if !HasInt64RangeValidatorsAny(nested) {
+		t.Error("HasInt64RangeValidatorsAny should detect nested Minimum/Maximum")
+	}
+}
+
 func TestScanPlanModifierUsage(t *testing.T) {
 	attrs := []openapi.TerraformAttribute{
 		{Type: "string", PlanModifier: "UseStateForUnknown"},


### PR DESCRIPTION
## Summary

- Fixed `Parse()` to read `deterministic` at top level (real spec location) in addition to `metadata.deterministic`
- Added `Minimum`/`Maximum` fields to `Constraints` struct for numeric range validation
- Added `int64validator.Between()` template path for generating numeric validators
- Added `atmost,atleast` to `.codespellrc` ignore list (valid HashiCorp TF framework function names)

**Result:** 58 resources now have validators (up from 4). All 21 test packages pass, go vet clean.

Closes #388

## Test plan

- [x] All 21 test packages pass
- [x] `go vet` clean
- [x] Pre-commit hooks pass
- [ ] CI checks pass