### PR TITLE
fix: generator determinism — sort map keys and fix disable field collision

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/tools/pkg/codegen"
@@ -355,17 +356,26 @@ func extractResourceSchemaByName(spec *OpenAPI3Spec, resourceName string) (*Sche
 		}
 	}
 
+	// Sort schema names for deterministic fallback matching (map order is random in Go)
+	sortedNames := make([]string, 0, len(spec.Components.Schemas))
+	for name := range spec.Components.Schemas {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Strings(sortedNames)
+
 	// Try case-insensitive match for legacy .Object suffix
 	lowerName := strings.ToLower(resourceName)
-	for name, schema := range spec.Components.Schemas {
+	for _, name := range sortedNames {
 		if strings.Contains(strings.ToLower(name), lowerName) && strings.HasSuffix(name, ".Object") {
+			schema := spec.Components.Schemas[name]
 			return &schema, name
 		}
 	}
 
 	// Try case-insensitive match for v2 CreateSpecType suffix
-	for name, schema := range spec.Components.Schemas {
+	for _, name := range sortedNames {
 		if strings.Contains(strings.ToLower(name), lowerName) && strings.HasSuffix(name, "CreateSpecType") {
+			schema := spec.Components.Schemas[name]
 			return &schema, name
 		}
 	}
@@ -381,7 +391,14 @@ func extractAPIPathForResource(spec *OpenAPI3Spec, resourceName string) string {
 		plural = strings.TrimSuffix(resourceName, "y") + "ies"
 	}
 
+	// Sort paths for deterministic matching (map order is random in Go)
+	paths := make([]string, 0, len(spec.Paths))
 	for path := range spec.Paths {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
 		if strings.Contains(path, "/"+plural) {
 			return path
 		}
@@ -502,8 +519,16 @@ func parseOpenAPISpec(specFile string) (*OpenAPI3Spec, error) {
 func extractAPIPath(spec *OpenAPI3Spec, resourceName string) (basePath string, itemPath string, hasNamespace bool) {
 	resourcePlural := resourceName + "s"
 
+	// Sort path keys for deterministic matching (map order is random in Go)
+	sortedPaths := make([]string, 0, len(spec.Paths))
+	for path := range spec.Paths {
+		sortedPaths = append(sortedPaths, path)
+	}
+	sort.Strings(sortedPaths)
+
 	// Look for CRUD paths in the spec
-	for path, pathObj := range spec.Paths {
+	for _, path := range sortedPaths {
+		pathObj := spec.Paths[path]
 		pathMap, ok := pathObj.(map[string]interface{})
 		if !ok {
 			continue

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -25,6 +25,12 @@ import (
 {{- if .UsesInt64PlanModifier}}
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 {{- end}}
+{{- if .UsesListPlanModifier}}
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+{{- end}}
+{{- if .UsesMapPlanModifier}}
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+{{- end}}
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 {{- if .HasBlocks}}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -170,6 +170,8 @@ type ResourceTemplate struct {
 	UsesBoolPlanModifier   bool   // True if any bool attribute uses a plan modifier
 	UsesInt64PlanModifier  bool   // True if any int64 attribute uses a plan modifier
 	UsesStringPlanModifier bool   // True if any string attribute uses a plan modifier
+	UsesListPlanModifier   bool   // True if any list attribute uses a plan modifier
+	UsesMapPlanModifier    bool   // True if any map attribute uses a plan modifier
 
 	// ---- SP-1 additions: generation control flags ----
 	HasBlocks              bool   // True if any attribute is a block

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -66,6 +66,7 @@ func IsMetadataField(name string) bool {
 		"description": true,
 		"id":          true,
 		"timeouts":    true,
+		"disable":     true,
 	}
 	return metadataFields[name]
 }
@@ -202,6 +203,10 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	if strings.ToLower(name) == "description" {
 		goName = "DescriptionSpec"
 		tfsdkName = "description_spec"
+	}
+	if strings.ToLower(name) == "disable" {
+		goName = "DisableSpec"
+		tfsdkName = "disable_spec"
 	}
 
 	attr := openapi.TerraformAttribute{

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -30,7 +30,15 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	var found bool
 	var createSpecKey string
 
-	for key, schema := range spec.Components.Schemas {
+	// Sort schema keys for deterministic iteration (map order is random in Go)
+	schemaKeys := make([]string, 0, len(spec.Components.Schemas))
+	for key := range spec.Components.Schemas {
+		schemaKeys = append(schemaKeys, key)
+	}
+	sort.Strings(schemaKeys)
+
+	for _, key := range schemaKeys {
+		schema := spec.Components.Schemas[key]
 		keyLower := strings.ToLower(key)
 		if strings.Contains(keyLower, strings.ToLower(resourceName)) &&
 			strings.Contains(keyLower, "createspectype") {
@@ -231,7 +239,7 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	apiPath, apiPathItem, hasNamespace := extractAPIPath(spec, resourceName)
 
 	// Scan attributes to determine which plan modifier imports are needed
-	usesBool, usesInt64, usesString := ScanPlanModifierUsage(attributes)
+	usesBool, usesInt64, usesString, usesList, usesMap := ScanPlanModifierUsage(attributes)
 
 	// Check if the resource has any nested models that would generate AttrTypes
 	// AttrTypes (which use attr.Type) are generated for any block with nested attributes
@@ -259,6 +267,8 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 		UsesBoolPlanModifier:   usesBool,
 		UsesInt64PlanModifier:  usesInt64,
 		UsesStringPlanModifier: usesString,
+		UsesListPlanModifier:   usesList,
+		UsesMapPlanModifier:    usesMap,
 		HasBlocks:              hasBlocks,
 		HasMaxLengthValidators: hasMaxLengthValidators,
 		HasEnumValidators:      HasEnumValidatorsAny(attributes),

--- a/tools/pkg/schema/scan.go
+++ b/tools/pkg/schema/scan.go
@@ -130,9 +130,9 @@ func HasInt64RangeValidatorsAny(attributes []openapi.TerraformAttribute) bool {
 }
 
 // ScanPlanModifierUsage recursively scans attributes to determine which plan modifier imports are needed.
-func ScanPlanModifierUsage(attributes []openapi.TerraformAttribute) (usesBool, usesInt64, usesString bool) {
+func ScanPlanModifierUsage(attributes []openapi.TerraformAttribute) (usesBool, usesInt64, usesString, usesList, usesMap bool) {
 	for _, attr := range attributes {
-		if attr.PlanModifier != "" {
+		if attr.PlanModifier != "" && !attr.IsBlock {
 			switch attr.Type {
 			case "bool":
 				usesBool = true
@@ -140,14 +140,19 @@ func ScanPlanModifierUsage(attributes []openapi.TerraformAttribute) (usesBool, u
 				usesInt64 = true
 			case "string":
 				usesString = true
+			case "list", "set":
+				usesList = true
+			case "map":
+				usesMap = true
 			}
 		}
-		// Recursively scan nested attributes
 		if len(attr.NestedAttributes) > 0 {
-			nestedBool, nestedInt64, nestedString := ScanPlanModifierUsage(attr.NestedAttributes)
-			usesBool = usesBool || nestedBool
-			usesInt64 = usesInt64 || nestedInt64
-			usesString = usesString || nestedString
+			nb, ni, ns, nl, nm := ScanPlanModifierUsage(attr.NestedAttributes)
+			usesBool = usesBool || nb
+			usesInt64 = usesInt64 || ni
+			usesString = usesString || ns
+			usesList = usesList || nl
+			usesMap = usesMap || nm
 		}
 	}
 	return

--- a/tools/pkg/schema/scan_test.go
+++ b/tools/pkg/schema/scan_test.go
@@ -164,7 +164,7 @@ func TestScanPlanModifierUsage(t *testing.T) {
 			{Type: "int64", PlanModifier: "UseStateForUnknown"},
 		}},
 	}
-	usesBool, usesInt64, usesString := ScanPlanModifierUsage(attrs)
+	usesBool, usesInt64, usesString, usesList, usesMap := ScanPlanModifierUsage(attrs)
 	if !usesBool {
 		t.Error("Should detect bool plan modifier")
 	}
@@ -173,5 +173,35 @@ func TestScanPlanModifierUsage(t *testing.T) {
 	}
 	if !usesString {
 		t.Error("Should detect string plan modifier")
+	}
+	if usesList {
+		t.Error("Should not detect list plan modifier (none present)")
+	}
+	if usesMap {
+		t.Error("Should not detect map plan modifier (none present)")
+	}
+}
+
+func TestScanPlanModifierUsage_ListAndMap(t *testing.T) {
+	attrs := []openapi.TerraformAttribute{
+		{Type: "list", PlanModifier: "UseStateForUnknown"},
+		{Type: "map", PlanModifier: "UseStateForUnknown"},
+	}
+	_, _, _, usesList, usesMap := ScanPlanModifierUsage(attrs)
+	if !usesList {
+		t.Error("Should detect list plan modifier")
+	}
+	if !usesMap {
+		t.Error("Should detect map plan modifier")
+	}
+}
+
+func TestScanPlanModifierUsage_SkipsBlocks(t *testing.T) {
+	attrs := []openapi.TerraformAttribute{
+		{Type: "list", PlanModifier: "UseStateForUnknown", IsBlock: true},
+	}
+	_, _, _, usesList, _ := ScanPlanModifierUsage(attrs)
+	if usesList {
+		t.Error("Should not detect list plan modifier on block attributes")
 	}
 }


### PR DESCRIPTION
## Summary

- Sort map keys before all first-match loops in `extractResourceSchemaByName`, `extractAPIPathForResource`, `extractAPIPath`, and `ExtractResourceSchema` to ensure consecutive generator runs produce byte-identical output
- Fix `segment_resource.go` compilation error by renaming duplicate `disable` field to `disable_spec` (matching existing `description_spec` pattern)
- Add `UsesListPlanModifier`/`UsesMapPlanModifier` to `ResourceTemplate` with conditional imports to prevent unused import errors

Closes #398

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] Three consecutive generator runs produce byte-identical output (zero diff)
- [ ] All 11 `tools/pkg` packages pass tests
- [ ] Generated `internal/provider` builds cleanly