### PR TITLE
fix: correct test configs, invalid regex validation, and Required+Computed conflict

### DIFF
--- a/internal/provider/certificate_data_source_test.go
+++ b/internal/provider/certificate_data_source_test.go
@@ -60,15 +60,9 @@ resource "f5xc_certificate" "test" {
   name       = %[2]q
   namespace  = f5xc_namespace.test.name
 
-  certificate_url = "string:///%[3]s"
-
-  private_key {
-    clear_secret_info {
-      url = "string:///%[4]s"
-    }
-  }
-
-  disable_ocsp_stapling {}
+  certificate_url       = "string:///%[3]s"
+  private_key           = "string:///%[4]s"
+  disable_ocsp_stapling = "true"
 }
 
 data "f5xc_certificate" "test" {

--- a/internal/provider/certificate_resource_test.go
+++ b/internal/provider/certificate_resource_test.go
@@ -64,8 +64,6 @@ func testAccCertificateImportStateIdFunc(resourceName string) resource.ImportSta
 }
 
 func testAccCertificateConfig_basic(nsName, name string, certs *acctest.TestCertificates) string {
-	// Use dynamically generated certificates for CI/CD compatibility
-	// F5 XC API requires certificate_url in "string:///BASE64_ENCODED_CERT" format
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
@@ -83,15 +81,9 @@ resource "f5xc_certificate" "test" {
   name       = %[2]q
   namespace  = f5xc_namespace.test.name
 
-  certificate_url = "string:///%[3]s"
-
-  private_key {
-    clear_secret_info {
-      url = "string:///%[4]s"
-    }
-  }
-
-  disable_ocsp_stapling {}
+  certificate_url       = "string:///%[3]s"
+  private_key           = "string:///%[4]s"
+  disable_ocsp_stapling = "true"
 }
 `, nsName, name, certs.ServerCertBase64, certs.ServerKeyBase64))
 }

--- a/internal/provider/fast_acl_data_source_test.go
+++ b/internal/provider/fast_acl_data_source_test.go
@@ -36,15 +36,14 @@ func TestAccFastAclDataSource_basic(t *testing.T) {
 }
 
 func testAccFastAclDataSourceConfig_basic(name string) string {
-	// Fast ACL must be in system namespace and requires site_choice (re_acl or site_acl)
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
 resource "f5xc_fast_acl" "test" {
   name      = %[1]q
   namespace = "system"
-
-  re_acl {}
+  action    = "policer_action"
+  prefix    = "10.0.0.0/8"
 }
 
 data "f5xc_fast_acl" "test" {

--- a/internal/provider/fast_acl_resource_test.go
+++ b/internal/provider/fast_acl_resource_test.go
@@ -58,16 +58,15 @@ func testAccFastACLImportStateIdFunc(resourceName string) resource.ImportStateId
 }
 
 func testAccFastACLConfig_basic(nsName, name string) string {
-	// Fast ACL must be in system namespace and requires site_choice (re_acl or site_acl)
-	_ = nsName // unused but kept for test signature consistency
+	_ = nsName
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
 resource "f5xc_fast_acl" "test" {
   name      = %[1]q
   namespace = "system"
-
-  re_acl {}
+  action    = "policer_action"
+  prefix    = "10.0.0.0/8"
 }
 `, name))
 }

--- a/tools/pkg/constraints/constraints.go
+++ b/tools/pkg/constraints/constraints.go
@@ -2,6 +2,8 @@
 
 package constraints
 
+import "regexp"
+
 // Parsed represents extracted x-f5xc-constraints data.
 type Parsed struct {
 	MinLength int
@@ -54,7 +56,9 @@ func Parse(raw map[string]interface{}) *Parsed {
 		p.MaxLength = int(v)
 	}
 	if v, ok := raw["pattern"].(string); ok {
-		p.Pattern = v
+		if _, err := regexp.Compile(v); err == nil {
+			p.Pattern = v
+		}
 	}
 
 	// List/array constraints

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -325,8 +325,9 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	}
 
 	// Add server default note to description (x-f5xc-server-default extension)
-	// This indicates fields where F5XC server applies sensible defaults when omitted
-	if schema.XF5XCServerDefault {
+	// This indicates fields where F5XC server applies sensible defaults when omitted.
+	// Only Optional fields become Computed — Required fields cannot be both Required+Computed.
+	if schema.XF5XCServerDefault && !attr.Required {
 		attr.Computed = true
 		if attr.PlanModifier == "" {
 			attr.PlanModifier = "UseStateForUnknown"

--- a/tools/pkg/schema/convert_test.go
+++ b/tools/pkg/schema/convert_test.go
@@ -308,7 +308,7 @@ func TestConvertToTerraformAttribute_ServerDefault(t *testing.T) {
 	}
 }
 
-func TestConvertToTerraformAttribute_ServerDefault_RequiredNotOverridden(t *testing.T) {
+func TestConvertToTerraformAttribute_ServerDefault_RequiredSkipsComputed(t *testing.T) {
 	schema := openapi.Schema{
 		Type:               "string",
 		Description:        "Required but server has default",
@@ -316,11 +316,11 @@ func TestConvertToTerraformAttribute_ServerDefault_RequiredNotOverridden(t *test
 	}
 	spec := &openapi.Spec{Components: openapi.Components{Schemas: map[string]openapi.Schema{}}}
 	attr := ConvertToTerraformAttributeWithDepth("name", schema, true, "", spec, 0, "name")
-	if !attr.Computed {
-		t.Error("Expected Computed=true for server-default field")
+	if attr.Computed {
+		t.Error("Required fields should NOT be Computed (Terraform rejects Required+Computed)")
 	}
 	if !attr.Required {
-		t.Error("Required should not be overridden when field is in OpenAPI required array")
+		t.Error("Required should be preserved")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **constraints.go**: Skip OpenAPI patterns that fail `regexp.Compile()` instead of emitting invalid regex that panics at provider startup (e.g., backtick-containing patterns from api_discovery spec)
- **convert.go**: Guard server-default `Computed=true` with `!attr.Required` — Terraform rejects the `Required+Computed` combination
- **Test configs**: Fix FastACL tests (replaced invalid `re_acl {}` block with valid `action`/`prefix` string attributes) and Certificate tests (replaced block syntax for string attributes with string values)

Closes #402

## Test plan

- [ ] CI checks pass (lint + super-linter)
- [ ] All 11 tools/pkg packages pass unit tests
- [ ] Provider builds cleanly after CI regeneration
- [ ] FastACL and Certificate acceptance test configs are valid HCL