### PR TITLE
feat: wire x-f5xc-recommended-value into descriptions and add minimum config docs

### DIFF
--- a/tools/minimum-configs.json
+++ b/tools/minimum-configs.json
@@ -1,0 +1,133 @@
+{
+  "http_loadbalancer": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.domains"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: http_loadbalancer\nmetadata:\n  name: example-app\n  namespace: default\nspec:\n  domains:\n    - example.com\n  https_auto_cert:\n    port: 443\n    tls_config:\n      default_security: {}\n  advertise_on_public_default_vip: {}\n  routes:\n    - prefix: \"/\"\n      origin_pool:\n        pool_name: backend-pool\n"
+  },
+  "origin_pool": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.origin_servers",
+      "spec.port"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: origin_pool\nmetadata:\n  name: backend-pool\n  namespace: default\nspec:\n  origin_servers:\n    - public_name:\n        dns_name: backend1.example.com\n    - public_name:\n        dns_name: backend2.example.com\n  port: 8080\n"
+  },
+  "tcp_loadbalancer": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.origin_pools"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: tcp_loadbalancer\nmetadata:\n  name: database-lb\n  namespace: default\nspec:\n  listener:\n    port: 5432\n    protocol: \"TCP\"\n  origin_pools:\n    - pool_name: postgres-cluster\n  advertise:\n    - public_ip: true\n"
+  },
+  "healthcheck": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.interval",
+      "spec.timeout",
+      "spec.healthy_threshold",
+      "spec.unhealthy_threshold"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: healthcheck\nmetadata:\n  name: http-health\n  namespace: default\nspec:\n  http_health_check:\n    path: /health\n    use_origin_server_name: {}\n  interval: 15\n  timeout: 3\n  unhealthy_threshold: 1\n  healthy_threshold: 3\n  jitter_percent: 30\n"
+  },
+  "app_firewall": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: app_firewall\nmetadata:\n  name: default-waf\n  namespace: default\nspec:\n  blocking: {}\n"
+  },
+  "service_policy": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: service_policy\nmetadata:\n  name: allow-all\n  namespace: default\nspec:\n  allow_all_requests: {}\n"
+  },
+  "certificate": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.certificate_url",
+      "spec.private_key"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: certificate\nmetadata:\n  name: example-cert\n  namespace: default\nspec:\n  certificate_url: \"string:///BASE64_ENCODED_CERTIFICATE\"\n  private_key:\n    clear_secret_info:\n      url: \"string:///BASE64_ENCODED_PRIVATE_KEY\"\n      provider: \"\"\n"
+  },
+  "api_definition": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: api_definition\nmetadata:\n  name: example-api\n  namespace: default\nspec: {}\n"
+  },
+  "api_discovery": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.user_defined_api_discovery_policy"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: api_discovery\nmetadata:\n  name: example-discovery\n  namespace: default\nspec:\n  user_defined_api_discovery_policy: {}\n"
+  },
+  "policer": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.burst_size",
+      "spec.committed_information_rate"
+    ],
+    "example_yaml": ""
+  },
+  "rate_limiter_policy": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.burst_size",
+      "spec.committed_information_rate"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: rate_limiter_policy\nmetadata:\n  name: example-rl\n  namespace: default\nspec:\n  burst_size: 1\n  committed_information_rate: 1\n"
+  },
+  "waf_exclusion_policy": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.waf_exclusion_rules"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: waf_exclusion_policy\nmetadata:\n  name: example-waf-exclusion\n  namespace: default\nspec:\n  waf_exclusion_rules:\n    - metadata:\n        name: exclude-health\n      exact_path: \"/health\"\n"
+  },
+  "user_identification": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.rules"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: user_identification\nmetadata:\n  name: example-user-id\n  namespace: default\nspec:\n  rules:\n    - client_ip: {}\n"
+  },
+  "malicious_user_mitigation": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: malicious_user_mitigation\nmetadata:\n  name: example-mitigation\n  namespace: default\nspec: {}\n"
+  },
+  "sensitive_data_policy": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: sensitive_data_policy\nmetadata:\n  name: example-sensitive-data\n  namespace: default\nspec: {}\n"
+  },
+  "protocol_inspection": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace",
+      "spec.enable_disable_compliance_checks",
+      "spec.enable_disable_signatures"
+    ],
+    "example_yaml": "apiVersion: v1\nkind: protocol_inspection\nmetadata:\n  name: example-inspection\n  namespace: default\nspec:\n  enable_disable_compliance_checks:\n    disable_compliance_checks: {}\n  enable_disable_signatures:\n    enable_signature: {}\n"
+  }
+}

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -335,6 +335,24 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 		attr.Description += " Server applies default when omitted."
 	}
 
+	// Append recommended value hint from x-f5xc-recommended-value
+	if schema.XF5XCRecommendedValue != nil {
+		switch v := schema.XF5XCRecommendedValue.(type) {
+		case float64:
+			if v == float64(int64(v)) {
+				attr.Description += fmt.Sprintf(" Recommended: `%d`.", int64(v))
+			} else {
+				attr.Description += fmt.Sprintf(" Recommended: `%g`.", v)
+			}
+		case string:
+			if v != "" {
+				attr.Description += fmt.Sprintf(" Recommended: `%s`.", v)
+			}
+		case bool:
+			attr.Description += fmt.Sprintf(" Recommended: `%t`.", v)
+		}
+	}
+
 	// Determine type and extract nested attributes
 	switch schema.Type {
 	case "string":

--- a/tools/pkg/schema/convert_test.go
+++ b/tools/pkg/schema/convert_test.go
@@ -3,6 +3,7 @@
 package schema
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/tools/pkg/openapi"
@@ -361,5 +362,46 @@ func TestMaxNestedDepthGuard(t *testing.T) {
 	attrs := ExtractNestedAttributes(s, spec, MaxNestedDepth+1, "")
 	if attrs != nil {
 		t.Error("ExtractNestedAttributes should return nil when depth exceeds MaxNestedDepth")
+	}
+}
+
+func TestConvertToTerraformAttribute_RecommendedValue_Numeric(t *testing.T) {
+	schema := openapi.Schema{
+		Type:                  "integer",
+		Description:           "Health check interval in seconds.",
+		XF5XCRecommendedValue: float64(15),
+	}
+	spec := &openapi.Spec{Components: openapi.Components{Schemas: map[string]openapi.Schema{}}}
+	attr := ConvertToTerraformAttributeWithDepth("interval", schema, false, "", spec, 0, "interval")
+
+	if !strings.Contains(attr.Description, "Recommended: `15`") {
+		t.Errorf("Description should contain recommended value, got: %s", attr.Description)
+	}
+}
+
+func TestConvertToTerraformAttribute_RecommendedValue_String(t *testing.T) {
+	schema := openapi.Schema{
+		Type:                  "string",
+		Description:           "Backend port.",
+		XF5XCRecommendedValue: "443",
+	}
+	spec := &openapi.Spec{Components: openapi.Components{Schemas: map[string]openapi.Schema{}}}
+	attr := ConvertToTerraformAttributeWithDepth("port", schema, false, "", spec, 0, "port")
+
+	if !strings.Contains(attr.Description, "Recommended: `443`") {
+		t.Errorf("Description should contain recommended value, got: %s", attr.Description)
+	}
+}
+
+func TestConvertToTerraformAttribute_RecommendedValue_Nil(t *testing.T) {
+	schema := openapi.Schema{
+		Type:        "string",
+		Description: "No recommendation.",
+	}
+	spec := &openapi.Spec{Components: openapi.Components{Schemas: map[string]openapi.Schema{}}}
+	attr := ConvertToTerraformAttributeWithDepth("field", schema, false, "", spec, 0, "field")
+
+	if strings.Contains(attr.Description, "Recommended:") {
+		t.Errorf("Description should not contain Recommended when no value set, got: %s", attr.Description)
 	}
 }

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -71,6 +71,8 @@ type V2ResourceMetadata struct {
 	ConfirmationRequired bool     // x-f5xc-confirmation-required
 	BestPractices        string   // x-f5xc-best-practices summary
 	RequiredDependencies []string // dependencies from index.json primary-resources
+	MinimumConfigYAML    string   // minimum config example from tools/minimum-configs.json
+	MinimumConfigFields  []string // required fields for minimum config
 }
 
 // v2MetadataCache stores metadata from v2 spec x-f5xc-* extensions.
@@ -115,6 +117,41 @@ func loadV2SpecMetadata() {
 			}
 		}
 	}
+
+	// Load minimum configuration examples from tools/minimum-configs.json
+	loadMinimumConfigs()
+}
+
+// loadMinimumConfigs reads tools/minimum-configs.json and injects minimum config
+// examples into the v2 metadata cache for each resource that has one.
+func loadMinimumConfigs() {
+	type minConfigEntry struct {
+		RequiredFields []string `json:"required_fields"`
+		ExampleYAML    string   `json:"example_yaml"`
+	}
+	data, err := os.ReadFile("tools/minimum-configs.json")
+	if err != nil {
+		return
+	}
+	var configs map[string]minConfigEntry
+	if err := json.Unmarshal(data, &configs); err != nil {
+		return
+	}
+	count := 0
+	for resourceName, mc := range configs {
+		if mc.ExampleYAML == "" && len(mc.RequiredFields) == 0 {
+			continue
+		}
+		meta := v2MetadataCache[resourceName]
+		meta.MinimumConfigYAML = mc.ExampleYAML
+		for _, f := range mc.RequiredFields {
+			tf := strings.TrimPrefix(strings.TrimPrefix(f, "metadata."), "spec.")
+			meta.MinimumConfigFields = append(meta.MinimumConfigFields, tf)
+		}
+		v2MetadataCache[resourceName] = meta
+		count++
+	}
+	fmt.Printf("Loaded minimum configs for %d resources\n", count)
 }
 
 // loadV2MetadataFromDomains loads metadata from v2 domain-organized specs.
@@ -1542,6 +1579,19 @@ func transformDoc(filePath string) error {
 		}
 		if len(meta.RequiredDependencies) > 0 {
 			output.WriteString("~> **Dependencies** — This resource requires: `" + strings.Join(meta.RequiredDependencies, "`, `") + "`.\n\n")
+		}
+		if meta.MinimumConfigYAML != "" {
+			output.WriteString("### Minimum Configuration\n\n")
+			if len(meta.MinimumConfigFields) > 0 {
+				output.WriteString("Required fields:\n\n")
+				for _, field := range meta.MinimumConfigFields {
+					output.WriteString(fmt.Sprintf("- `%s`\n", field))
+				}
+				output.WriteString("\n")
+			}
+			output.WriteString("**Example (API format):**\n\n```yaml\n")
+			output.WriteString(meta.MinimumConfigYAML)
+			output.WriteString("\n```\n\n")
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Wire `x-f5xc-recommended-value` extension into resource/attribute descriptions, showing "Recommended: `value`" for 20 spec fields
- Add minimum configuration documentation for 16 resources loaded from `tools/minimum-configs.json`
- Fix trailing newline in `tools/minimum-configs.json`

Closes #409

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] `go test ./tools/pkg/schema/...` passes with new test cases for recommended value rendering
- [ ] Generated docs include "Recommended:" annotations for fields with `x-f5xc-recommended-value`
- [ ] Minimum config sections render correctly in resource documentation