### PR TITLE
fix: resolve all 120 actionlint warnings and fix MCP tarball missing directories

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -119,9 +119,9 @@ jobs:
         if: always()
         run: |
           if [ "${{ job.status }}" == "success" ]; then
-            echo "success=true" >> $GITHUB_OUTPUT
+            echo "success=true" >> "$GITHUB_OUTPUT"
           else
-            echo "success=false" >> $GITHUB_OUTPUT
+            echo "success=false" >> "$GITHUB_OUTPUT"
           fi
 
   lint:
@@ -143,8 +143,8 @@ jobs:
       - name: Install golangci-lint
         run: |
           # Install golangci-lint binary directly (no Node.js dependencies)
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m ./internal/... .

--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Verify specs exist
         id: verify
         run: |
-          SPEC_COUNT=$(find ${{ inputs.spec-dir }} -name "*.json" -type f 2>/dev/null | wc -l)
+          SPEC_COUNT=$(find "${{ inputs.spec-dir }}" -name "*.json" -type f 2>/dev/null | wc -l)
           echo "Found ${SPEC_COUNT} OpenAPI spec files in ${{ inputs.spec-dir }}"
           if [ "$SPEC_COUNT" -eq "0" ]; then
             echo "No spec files found - skipping generation"
-            echo "has_specs=false" >> $GITHUB_OUTPUT
+            echo "has_specs=false" >> "$GITHUB_OUTPUT"
           else
-            echo "has_specs=true" >> $GITHUB_OUTPUT
+            echo "has_specs=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Go
@@ -136,10 +136,10 @@ jobs:
         run: |
           git add -A
           if git diff --cached --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No provider code changes"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Provider code changes detected:"
             git diff --cached --stat
             git reset HEAD

--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -52,24 +52,24 @@ jobs:
         id: get_tag
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "Latest tag: $LATEST_TAG"
 
       - name: Calculate next version
         id: version
         run: |
-          LATEST_TAG=${{ steps.get_tag.outputs.latest_tag }}
+          LATEST_TAG="${{ steps.get_tag.outputs.latest_tag }}"
 
           # Remove 'v' prefix
           VERSION=${LATEST_TAG#v}
 
           # Split version into parts
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          PATCH=$(echo $VERSION | cut -d. -f3)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
 
           # Get commit messages since last tag
-          COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
+          COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
 
           # Determine version bump based on conventional commits
           if echo "$COMMITS" | grep -qE "^BREAKING CHANGE:|^[a-z]+!:"; then
@@ -77,24 +77,24 @@ jobs:
             MAJOR=$((MAJOR + 1))
             MINOR=0
             PATCH=0
-            echo "bump=major" >> $GITHUB_OUTPUT
+            echo "bump=major" >> "$GITHUB_OUTPUT"
           elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
             # Minor version bump for features
             MINOR=$((MINOR + 1))
             PATCH=0
-            echo "bump=minor" >> $GITHUB_OUTPUT
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
           elif echo "$COMMITS" | grep -qE "^(fix|perf|refactor)(\(.+\))?:"; then
             # Patch version bump for fixes, performance, refactoring
             PATCH=$((PATCH + 1))
-            echo "bump=patch" >> $GITHUB_OUTPUT
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
           else
             # Default to patch bump for any other commits
             PATCH=$((PATCH + 1))
-            echo "bump=patch" >> $GITHUB_OUTPUT
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
           fi
 
           NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
           echo "Next version: $NEW_TAG"
 
       - name: Version Diagnostics
@@ -112,36 +112,38 @@ jobs:
       - name: Check if tag exists
         id: check
         run: |
-          NEW_TAG=${{ steps.version.outputs.new_tag }}
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
           if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Tag $NEW_TAG already exists"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Tag $NEW_TAG does not exist"
           fi
 
       - name: Create and push tag
         id: create
         if: steps.check.outputs.exists == 'false'
+        env:
+          LATEST_TAG: ${{ steps.get_tag.outputs.latest_tag }}
         run: |
-          NEW_TAG=${{ steps.version.outputs.new_tag }}
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Create annotated tag with release notes
-          COMMITS=$(git log ${{ steps.get_tag.outputs.latest_tag }}..HEAD --pretty=format:"- %s" 2>/dev/null || git log --pretty=format:"- %s" -10)
+          COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s" 2>/dev/null || git log --pretty=format:"- %s" -10)
 
           git tag -a "$NEW_TAG" -m "Release $NEW_TAG
 
-          Changes since ${{ steps.get_tag.outputs.latest_tag }}:
+          Changes since ${LATEST_TAG}:
           $COMMITS
 
           🤖 Auto-generated tag"
 
           git push origin "$NEW_TAG"
-          echo "created=true" >> $GITHUB_OUTPUT
+          echo "created=true" >> "$GITHUB_OUTPUT"
           echo "Created and pushed tag: $NEW_TAG"
 
   release:
@@ -177,23 +179,38 @@ jobs:
 
           echo "Creating MCP data tarball for v${VERSION}..."
 
-          # Create tarball with documentation, OpenAPI specs, and metadata
-          tar czf "mcp-data-${VERSION}.tar.gz" \
-            --transform 's,^,mcp-data/,' \
+          # Build file list — include only directories/files that exist
+          INCLUDES=()
+          for path in \
             docs/resources/ \
             docs/data-sources/ \
             docs/functions/ \
             docs/guides/ \
             docs/index.md \
             docs/specifications/api/ \
-            tools/metadata/ \
-            tools/subscription-tiers.json
+            tools/subscription-tiers.json \
+            tools/minimum-configs.json; do
+            if [ -e "$path" ]; then
+              INCLUDES+=("$path")
+            else
+              echo "Skipping (not found): $path"
+            fi
+          done
+
+          if [ ${#INCLUDES[@]} -eq 0 ]; then
+            echo "No files found for MCP tarball — skipping"
+            exit 0
+          fi
+
+          tar czf "mcp-data-${VERSION}.tar.gz" \
+            --transform 's,^,mcp-data/,' \
+            "${INCLUDES[@]}"
 
           echo "Tarball contents:"
           tar tzf "mcp-data-${VERSION}.tar.gz" | head -20
           echo "..."
           echo "Total files: $(tar tzf "mcp-data-${VERSION}.tar.gz" | wc -l)"
-          echo "Size: $(ls -lh "mcp-data-${VERSION}.tar.gz" | awk '{print $5}')"
+          echo "Size: $(du -h "mcp-data-${VERSION}.tar.gz" | cut -f1)"
 
       - name: Upload to GitHub Release
         env:

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -164,8 +164,8 @@ jobs:
           PASSED=$(jq -r '.total_passed // 0' test-reports/mock-tests.json)
           FAILED=$(jq -r '.total_failed // 0' test-reports/mock-tests.json)
 
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
 
       - name: Upload mock test reports
         uses: actions/upload-artifact@v7
@@ -210,7 +210,6 @@ jobs:
       - name: Check runner availability
         run: |
           echo "Running on self-hosted runner: ${{ runner.name }}"
-          echo "Runner labels: ${{ join(runner.labels, ', ') }}"
           echo ""
           echo "Verifying F5 XC API connectivity..."
 
@@ -242,10 +241,10 @@ jobs:
           # Check which auth method is configured
           if [ -n "$F5XC_API_TOKEN" ]; then
             echo "✓ Using API Token authentication (recommended)"
-            echo "auth_method=token" >> $GITHUB_OUTPUT
+            echo "auth_method=token" >> "$GITHUB_OUTPUT"
           elif [ -n "$F5XC_P12_BASE64" ] && [ -n "$F5XC_P12_PASSWORD" ]; then
             echo "✓ Using P12 certificate authentication"
-            echo "auth_method=p12" >> $GITHUB_OUTPUT
+            echo "auth_method=p12" >> "$GITHUB_OUTPUT"
           else
             echo "::error::No authentication configured!"
             echo "Configure either:"
@@ -274,8 +273,8 @@ jobs:
           fi
 
           echo "✓ P12 certificate decoded to temporary file"
-          echo "p12_file=$P12_FILE" >> $GITHUB_OUTPUT
-          echo "p12_dir=$P12_DIR" >> $GITHUB_OUTPUT
+          echo "p12_file=$P12_FILE" >> "$GITHUB_OUTPUT"
+          echo "p12_dir=$P12_DIR" >> "$GITHUB_OUTPUT"
 
       - name: Run real API tests
         id: run-tests
@@ -319,9 +318,11 @@ jobs:
           FAILED=$(jq -r '.total_failed // 0' test-reports/real-tests.json)
           TRANSIENT=$(jq -r '[.transient_errors[]?.count // 0] | add // 0' test-reports/real-tests.json)
 
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
-          echo "transient=$TRANSIENT" >> $GITHUB_OUTPUT
+          {
+            echo "passed=$PASSED"
+            echo "failed=$FAILED"
+            echo "transient=$TRANSIENT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Cleanup P12 certificate
         if: always() && steps.verify-creds.outputs.auth_method == 'p12'
@@ -381,13 +382,13 @@ jobs:
           # Determine which authentication method is configured
           if [ -n "$F5XC_API_TOKEN" ]; then
             echo "✓ Using API Token authentication"
-            echo "auth_method=token" >> $GITHUB_OUTPUT
+            echo "auth_method=token" >> "$GITHUB_OUTPUT"
           elif [ -n "$F5XC_P12_BASE64" ] && [ -n "$F5XC_P12_PASSWORD" ]; then
             echo "✓ Using P12 certificate authentication"
-            echo "auth_method=p12" >> $GITHUB_OUTPUT
+            echo "auth_method=p12" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::No authentication configured for cleanup"
-            echo "auth_method=none" >> $GITHUB_OUTPUT
+            echo "auth_method=none" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup P12 certificate (if using P12 auth)
@@ -410,8 +411,8 @@ jobs:
           fi
 
           echo "✓ P12 certificate decoded to temporary file"
-          echo "p12_file=$P12_FILE" >> $GITHUB_OUTPUT
-          echo "p12_dir=$P12_DIR" >> $GITHUB_OUTPUT
+          echo "p12_file=$P12_FILE" >> "$GITHUB_OUTPUT"
+          echo "p12_dir=$P12_DIR" >> "$GITHUB_OUTPUT"
 
       - name: Run sweepers
         id: sweep
@@ -431,7 +432,7 @@ jobs:
 
           # Count swept resources (for summary)
           NAMESPACE_COUNT=$(grep -c "Successfully deleted namespace" sweep-output.txt || echo "0")
-          echo "swept_namespaces=$NAMESPACE_COUNT" >> $GITHUB_OUTPUT
+          echo "swept_namespaces=$NAMESPACE_COUNT" >> "$GITHUB_OUTPUT"
 
           # Report results
           echo ""
@@ -454,11 +455,13 @@ jobs:
 
       - name: Post cleanup summary
         run: |
-          echo "## Resource Cleanup" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Sweepers ran to clean up test resources left behind by acceptance tests." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- Namespaces cleaned: ${{ steps.sweep.outputs.swept_namespaces || '0' }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Resource Cleanup"
+            echo ""
+            echo "Sweepers ran to clean up test resources left behind by acceptance tests."
+            echo ""
+            echo "- Namespaces cleaned: ${{ steps.sweep.outputs.swept_namespaces || '0' }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Mock vs Real Comparison - Ensures mock server behavioral consistency
@@ -508,17 +511,17 @@ jobs:
           # Check if both JSON reports exist
           if [[ ! -f "mock-reports/mock-tests.json" ]]; then
             echo "::warning::Mock test JSON report not found"
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [[ ! -f "real-reports/real-tests.json" ]]; then
             echo "::warning::Real API test JSON report not found"
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "available=true" >> $GITHUB_OUTPUT
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
           # Run the comparison tool
           go run tools/compare-test-results/main.go \
@@ -538,11 +541,15 @@ jobs:
           if [[ -f "comparison-reports/comparison.json" ]]; then
             CONSISTENT=$(jq -r '.summary.consistent // 0' comparison-reports/comparison.json)
             NEEDS_FIX=$(jq -r '.summary.mock_needs_fix // 0' comparison-reports/comparison.json)
-            echo "consistent=$CONSISTENT" >> $GITHUB_OUTPUT
-            echo "needs_fix=$NEEDS_FIX" >> $GITHUB_OUTPUT
+            {
+              echo "consistent=$CONSISTENT"
+              echo "needs_fix=$NEEDS_FIX"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "consistent=0" >> $GITHUB_OUTPUT
-            echo "needs_fix=0" >> $GITHUB_OUTPUT
+            {
+              echo "consistent=0"
+              echo "needs_fix=0"
+            } >> "$GITHUB_OUTPUT"
           fi
 
           # Comparison tool exits non-zero if mock needs fixing
@@ -561,13 +568,15 @@ jobs:
       - name: Post comparison to step summary
         if: steps.compare.outputs.available == 'true'
         run: |
-          echo "## Mock vs Real API Comparison" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Mock vs Real API Comparison"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ -f "comparison-reports/comparison.md" ]]; then
-            cat "comparison-reports/comparison.md" >> $GITHUB_STEP_SUMMARY
+            cat "comparison-reports/comparison.md" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "⚠️ Comparison report not generated" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Comparison report not generated" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # ═══════════════════════════════════════════════════════════════════════════
@@ -587,91 +596,110 @@ jobs:
         continue-on-error: true
 
       - name: Generate summary
+        env:
+          MOCK_TESTS_RESULT: ${{ needs.mock-tests.result }}
+          MOCK_PASSED: ${{ needs.mock-tests.outputs.mock_passed || 'N/A' }}
+          MOCK_FAILED: ${{ needs.mock-tests.outputs.mock_failed || 'N/A' }}
+          REAL_TESTS_RESULT: ${{ needs.real-api-tests.result }}
+          REAL_PASSED: ${{ needs.real-api-tests.outputs.real_passed || 'N/A' }}
+          REAL_FAILED: ${{ needs.real-api-tests.outputs.real_failed || 'N/A' }}
+          REAL_TRANSIENT: ${{ needs.real-api-tests.outputs.transient_errors || '0' }}
+          COMPARE_RESULT: ${{ needs.compare-results.result }}
+          COMPARE_AVAILABLE: ${{ needs.compare-results.outputs.comparison_available }}
+          COMPARE_CONSISTENT: ${{ needs.compare-results.outputs.mock_consistent || 0 }}
+          COMPARE_NEEDS_FIX: ${{ needs.compare-results.outputs.mock_needs_fix || 0 }}
+          CLEANUP_RESULT: ${{ needs.cleanup.result }}
+          RUN_NUMBER: ${{ github.run_number }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          TEST_MODE: ${{ github.event.inputs.mode || 'pr-subset' }}
         run: |
-          echo "## Acceptance Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Workflow Run:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
-          echo "**Triggered by:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Mode:** ${{ github.event.inputs.mode || 'pr-subset' }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Acceptance Test Results"
+            echo ""
+            echo "**Workflow Run:** [#${RUN_NUMBER}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID})"
+            echo "**Triggered by:** ${EVENT_NAME}"
+            echo "**Mode:** ${TEST_MODE}"
+            echo ""
 
-          # Mock test results
-          echo "### Mock Tests (Parallel)" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ needs.mock-tests.result }}" == "success" ]]; then
-            echo "- Status: ✅ Completed" >> $GITHUB_STEP_SUMMARY
-            echo "- Passed: ${{ needs.mock-tests.outputs.mock_passed || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
-            echo "- Failed: ${{ needs.mock-tests.outputs.mock_failed || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.mock-tests.result }}" == "skipped" ]]; then
-            echo "- Status: ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- Status: ❌ Failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Real API test results
-          echo "### Real API Tests (Sequential)" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ needs.real-api-tests.result }}" == "success" ]]; then
-            echo "- Status: ✅ Completed" >> $GITHUB_STEP_SUMMARY
-            echo "- Passed: ${{ needs.real-api-tests.outputs.real_passed || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
-            echo "- Failed: ${{ needs.real-api-tests.outputs.real_failed || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
-            echo "- Transient Errors: ${{ needs.real-api-tests.outputs.transient_errors || '0' }}" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.real-api-tests.result }}" == "skipped" ]]; then
-            echo "- Status: ⏭️ Skipped (PR mode or mock-only)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- Status: ❌ Failed or runner unavailable" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Mock vs Real comparison results
-          echo "### Mock vs Real Comparison" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ needs.compare-results.result }}" == "success" ]]; then
-            if [[ "${{ needs.compare-results.outputs.comparison_available }}" == "true" ]]; then
-              CONSISTENT="${{ needs.compare-results.outputs.mock_consistent || 0 }}"
-              NEEDS_FIX="${{ needs.compare-results.outputs.mock_needs_fix || 0 }}"
-              echo "- Status: ✅ Comparison completed" >> $GITHUB_STEP_SUMMARY
-              echo "- Mock Consistent: $CONSISTENT tests" >> $GITHUB_STEP_SUMMARY
-              if [[ "$NEEDS_FIX" -gt 0 ]]; then
-                echo "- ⚠️ Mock Needs Fix: $NEEDS_FIX tests" >> $GITHUB_STEP_SUMMARY
-              else
-                echo "- Mock Needs Fix: 0 tests ✅" >> $GITHUB_STEP_SUMMARY
-              fi
+            # Mock test results
+            echo "### Mock Tests (Parallel)"
+            if [[ "$MOCK_TESTS_RESULT" == "success" ]]; then
+              echo "- Status: ✅ Completed"
+              echo "- Passed: ${MOCK_PASSED}"
+              echo "- Failed: ${MOCK_FAILED}"
+            elif [[ "$MOCK_TESTS_RESULT" == "skipped" ]]; then
+              echo "- Status: ⏭️ Skipped"
             else
-              echo "- Status: ⚠️ Reports not available for comparison" >> $GITHUB_STEP_SUMMARY
+              echo "- Status: ❌ Failed"
             fi
-          elif [[ "${{ needs.compare-results.result }}" == "skipped" ]]; then
-            echo "- Status: ⏭️ Skipped (requires both mock and real tests)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- Status: ❌ Comparison failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+            echo ""
 
-          # Resource cleanup results
-          echo "### Resource Cleanup" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ needs.cleanup.result }}" == "success" ]]; then
-            echo "- Status: ✅ Cleanup completed" >> $GITHUB_STEP_SUMMARY
-            echo "- Sweepers ran after tests to clean up leftover resources" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.cleanup.result }}" == "skipped" ]]; then
-            echo "- Status: ⏭️ Skipped (real API tests did not run)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- Status: ⚠️ Cleanup had issues (check logs)" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+            # Real API test results
+            echo "### Real API Tests (Sequential)"
+            if [[ "$REAL_TESTS_RESULT" == "success" ]]; then
+              echo "- Status: ✅ Completed"
+              echo "- Passed: ${REAL_PASSED}"
+              echo "- Failed: ${REAL_FAILED}"
+              echo "- Transient Errors: ${REAL_TRANSIENT}"
+            elif [[ "$REAL_TESTS_RESULT" == "skipped" ]]; then
+              echo "- Status: ⏭️ Skipped (PR mode or mock-only)"
+            else
+              echo "- Status: ❌ Failed or runner unavailable"
+            fi
+            echo ""
 
-          # Include markdown report if available
-          if [[ -f "all-reports/mock-test-reports/mock-tests.md" ]]; then
-            echo "### Detailed Mock Test Report" >> $GITHUB_STEP_SUMMARY
-            cat "all-reports/mock-test-reports/mock-tests.md" >> $GITHUB_STEP_SUMMARY
-          fi
+            # Mock vs Real comparison results
+            echo "### Mock vs Real Comparison"
+            if [[ "$COMPARE_RESULT" == "success" ]]; then
+              if [[ "$COMPARE_AVAILABLE" == "true" ]]; then
+                echo "- Status: ✅ Comparison completed"
+                echo "- Mock Consistent: ${COMPARE_CONSISTENT} tests"
+                if [[ "$COMPARE_NEEDS_FIX" -gt 0 ]]; then
+                  echo "- ⚠️ Mock Needs Fix: ${COMPARE_NEEDS_FIX} tests"
+                else
+                  echo "- Mock Needs Fix: 0 tests ✅"
+                fi
+              else
+                echo "- Status: ⚠️ Reports not available for comparison"
+              fi
+            elif [[ "$COMPARE_RESULT" == "skipped" ]]; then
+              echo "- Status: ⏭️ Skipped (requires both mock and real tests)"
+            else
+              echo "- Status: ❌ Comparison failed"
+            fi
+            echo ""
 
-          if [[ -f "all-reports/real-api-test-reports/real-tests.md" ]]; then
-            echo "### Detailed Real API Test Report" >> $GITHUB_STEP_SUMMARY
-            cat "all-reports/real-api-test-reports/real-tests.md" >> $GITHUB_STEP_SUMMARY
-          fi
+            # Resource cleanup results
+            echo "### Resource Cleanup"
+            if [[ "$CLEANUP_RESULT" == "success" ]]; then
+              echo "- Status: ✅ Cleanup completed"
+              echo "- Sweepers ran after tests to clean up leftover resources"
+            elif [[ "$CLEANUP_RESULT" == "skipped" ]]; then
+              echo "- Status: ⏭️ Skipped (real API tests did not run)"
+            else
+              echo "- Status: ⚠️ Cleanup had issues (check logs)"
+            fi
+            echo ""
 
-          if [[ -f "all-reports/comparison-reports/comparison.md" ]]; then
-            echo "### Detailed Mock vs Real Comparison Report" >> $GITHUB_STEP_SUMMARY
-            cat "all-reports/comparison-reports/comparison.md" >> $GITHUB_STEP_SUMMARY
-          fi
+            # Include markdown report if available
+            if [[ -f "all-reports/mock-test-reports/mock-tests.md" ]]; then
+              echo "### Detailed Mock Test Report"
+              cat "all-reports/mock-test-reports/mock-tests.md"
+            fi
+
+            if [[ -f "all-reports/real-api-test-reports/real-tests.md" ]]; then
+              echo "### Detailed Real API Test Report"
+              cat "all-reports/real-api-test-reports/real-tests.md"
+            fi
+
+            if [[ -f "all-reports/comparison-reports/comparison.md" ]]; then
+              echo "### Detailed Mock vs Real Comparison Report"
+              cat "all-reports/comparison-reports/comparison.md"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check overall status
         run: |

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Check runner availability
         run: |
           echo "Running on self-hosted runner: ${{ runner.name }}"
-          echo "Runner labels: ${{ join(runner.labels, ', ') }}"
           echo ""
           echo "Verifying VPN connectivity..."
           # The self-hosted runner should have VPN configured
@@ -149,8 +148,8 @@ jobs:
           DISCOVERED=$(grep -o 'Discovered: [0-9]*' discovery.log | grep -o '[0-9]*' || echo "0")
           FAILED=$(grep -o 'Failed: [0-9]*' discovery.log | grep -o '[0-9]*' || echo "0")
 
-          echo "resources_discovered=$DISCOVERED" >> $GITHUB_OUTPUT
-          echo "resources_failed=$FAILED" >> $GITHUB_OUTPUT
+          echo "resources_discovered=$DISCOVERED" >> "$GITHUB_OUTPUT"
+          echo "resources_failed=$FAILED" >> "$GITHUB_OUTPUT"
 
           echo "Discovery complete: $DISCOVERED resources discovered, $FAILED failed"
 
@@ -167,11 +166,11 @@ jobs:
         run: |
           if git diff --quiet tools/api-defaults.json internal/mocks/generated_defaults.go; then
             echo "No changes detected"
-            echo "changes_detected=false" >> $GITHUB_OUTPUT
+            echo "changes_detected=false" >> "$GITHUB_OUTPUT"
           else
             echo "Changes detected in:"
             git diff --name-only tools/api-defaults.json internal/mocks/generated_defaults.go
-            echo "changes_detected=true" >> $GITHUB_OUTPUT
+            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run tests

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           PR_COUNT=$(gh pr list --search "in:title \"${{ env.PR_TITLE }}\"" --state open --json number --jq length)
           if [ "$PR_COUNT" -gt "0" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Found existing open PR - skipping"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine spec source and version
@@ -80,7 +80,7 @@ jobs:
           SPEC_VERSION="${{ env.SPEC_VERSION }}"
 
           echo "Spec source: $SPEC_SOURCE"
-          echo "spec_source=$SPEC_SOURCE" >> $GITHUB_OUTPUT
+          echo "spec_source=$SPEC_SOURCE" >> "$GITHUB_OUTPUT"
 
           if [ "$SPEC_SOURCE" = "v2" ]; then
             # Determine v2 version
@@ -90,19 +90,19 @@ jobs:
               if [ -z "$LATEST" ]; then
                 echo "::warning::Could not determine latest v2 release, falling back to v1"
                 SPEC_SOURCE="v1"
-                echo "spec_source=v1" >> $GITHUB_OUTPUT
+                echo "spec_source=v1" >> "$GITHUB_OUTPUT"
               else
                 SPEC_VERSION="$LATEST"
                 echo "Using latest v2 release: $SPEC_VERSION"
               fi
             fi
-            echo "spec_version=$SPEC_VERSION" >> $GITHUB_OUTPUT
+            echo "spec_version=$SPEC_VERSION" >> "$GITHUB_OUTPUT"
 
             # Build v2 download URL
             if [ "$SPEC_SOURCE" = "v2" ]; then
               DOWNLOAD_URL="https://github.com/${{ env.ENRICHED_REPO }}/releases/download/${SPEC_VERSION}/f5xc-api-specs-${SPEC_VERSION}.zip"
               echo "V2 download URL: $DOWNLOAD_URL"
-              echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
+              echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -110,8 +110,8 @@ jobs:
             # V1 legacy URL
             DOWNLOAD_URL="https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
             echo "V1 download URL: $DOWNLOAD_URL"
-            echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
-            echo "spec_version=v1" >> $GITHUB_OUTPUT
+            echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
+            echo "spec_version=v1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download OpenAPI specs
@@ -163,11 +163,11 @@ jobs:
               echo "::error::V2 spec structure invalid: domains/ directory not found"
               exit 1
             fi
-            DOMAIN_COUNT=$(ls -1 ${{ env.SPEC_DIR }}/domains/*.json 2>/dev/null | wc -l)
+            DOMAIN_COUNT=$(find "${{ env.SPEC_DIR }}/domains" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l)
             echo "V2 structure verified: index.json + $DOMAIN_COUNT domain files"
           else
             echo "Verifying v1 spec structure..."
-            SPEC_COUNT=$(ls -1 ${{ env.SPEC_DIR }}/docs-cloud-f5-com.*.ves-swagger.json 2>/dev/null | wc -l)
+            SPEC_COUNT=$(find "${{ env.SPEC_DIR }}" -maxdepth 1 -name 'docs-cloud-f5-com.*.ves-swagger.json' 2>/dev/null | wc -l)
             if [ "$SPEC_COUNT" -eq "0" ]; then
               echo "::error::V1 spec structure invalid: no *.ves-swagger.json files found"
               exit 1
@@ -181,10 +181,10 @@ jobs:
         run: |
           git add -A
           if git diff --cached --quiet; then
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected in OpenAPI specs"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Changes detected in OpenAPI specs"
             git reset HEAD
           fi
@@ -234,7 +234,7 @@ jobs:
             echo "Using swagger-cli for v1 spec validation..."
             npm install -g @apidevtools/swagger-cli
             VALID=true
-            for file in $(find ${{ env.SPEC_DIR }} -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \)); do
+            find "${{ env.SPEC_DIR }}" -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \) | while IFS= read -r file; do
               if grep -q -E "(openapi|swagger).*['\"]?[0-9]+\.[0-9]+" "$file" 2>/dev/null; then
                 echo "Validating: $file"
                 if swagger-cli validate "$file"; then
@@ -255,7 +255,7 @@ jobs:
       - name: Get current date
         if: steps.changes.outputs.changed == 'true'
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Create branch and commit
         if: steps.changes.outputs.changed == 'true'
@@ -410,7 +410,7 @@ jobs:
             --label "$LABELS")
 
           PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-          echo "number=$PR_NUM" >> $GITHUB_OUTPUT
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
           echo "Created PR #$PR_NUM"
 
       - name: Enable auto-merge


### PR DESCRIPTION
## Summary

- Fixed all 120 actionlint/shellcheck warnings across 6 workflow files
- Primary fixes: SC2086 (quote variables), SC2129 (group redirects), SC2012 (use find instead of ls), SC2044 (use while read instead of for loop)
- Root issue: MCP tarball step in `_tag-release.yml` now dynamically checks which paths exist before including them
- Removed deleted `tools/metadata/` reference that was causing failures

## Test plan

- [ ] CI checks pass (actionlint, yamllint, shellcheck)
- [ ] Verify actionlint reports zero warnings locally: `actionlint .github/workflows/*.yml`
- [ ] Confirm `_tag-release.yml` MCP tarball step handles missing directories gracefully

Closes #411

---
Generated with [Claude Code](https://claude.com/claude-code)