### PR TITLE
feat: add minimum configs for k8s_cluster, network_firewall, enhanced_firewall_policy

### DIFF
--- a/tools/minimum-configs.json
+++ b/tools/minimum-configs.json
@@ -155,5 +155,26 @@
       "spec.site_selector"
     ],
     "example_yaml": "metadata:\n  name: my-virtual-site\n  namespace: default\nspec:\n  site_type: REGIONAL_EDGE\n  site_selector:\n    expressions:\n      - \"ves.io/siteName=any\""
+  },
+  "k8s_cluster": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "metadata:\n  name: my-k8s-cluster\n  namespace: system\nspec: {}"
+  },
+  "network_firewall": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "metadata:\n  name: my-network-firewall\n  namespace: system\nspec: {}"
+  },
+  "enhanced_firewall_policy": {
+    "required_fields": [
+      "metadata.name",
+      "metadata.namespace"
+    ],
+    "example_yaml": "metadata:\n  name: my-efp\n  namespace: default\nspec: {}"
   }
 }


### PR DESCRIPTION
## Summary

- Adds 3 new CRUD-verified resources to `tools/minimum-configs.json`: `k8s_cluster`, `network_firewall`, `enhanced_firewall_policy`
- All accept empty specs with server-applied defaults
- Keeps in sync with upstream api-specs-enriched PR #451, bringing total to 22 resources

Closes #419

## Test plan

- [ ] CI checks pass
- [ ] JSON is valid and well-formed
- [ ] New entries follow same structure as existing resources