### PR TITLE
fix: add final invariant guard to prevent Required+Computed combination

### DIFF
--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -444,6 +444,12 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 		}
 	}
 
+	// Final invariant: Terraform rejects Required+Computed. If both are set, clear Computed.
+	if attr.Required && attr.Computed {
+		attr.Computed = false
+		attr.PlanModifier = ""
+	}
+
 	return attr
 }
 


### PR DESCRIPTION
## Summary

- Add final invariant guard in `ConvertToTerraformAttributeWithDepth` to prevent invalid `Required+Computed` attribute combinations
- If both `Required` and `Computed` are true, clear `Computed` and its `PlanModifier`
- Ensures generator never produces schemas that Terraform Plugin Framework rejects

Closes #423

## Test plan

- [ ] CI checks pass
- [ ] Verify generator produces valid schemas for enriched API specs
- [ ] Confirm no regression in existing resource generation