### PR TITLE
fix: handle allOf-wrapped $ref, switch to goimports, fix Required+Computed guards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	golang.org/x/crypto v0.46.0
 	golang.org/x/text v0.32.0
+	golang.org/x/tools v0.40.0
 )
 
 require (
@@ -56,7 +57,6 @@ require (
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
-	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251213004720-97cd9d5aeac2 // indirect
 	google.golang.org/grpc v1.77.0 // indirect

--- a/tools/pkg/codegen/generate.go
+++ b/tools/pkg/codegen/generate.go
@@ -8,11 +8,12 @@ package codegen
 import (
 	"bytes"
 	"fmt"
-	"go/format"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"golang.org/x/tools/imports"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/tools/pkg/openapi"
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/tools/pkg/schema"
@@ -59,7 +60,7 @@ func GenerateResourceFile(resource *openapi.ResourceTemplate, outputDir string) 
 	}
 
 	// Format the generated code with gofmt
-	formatted, err := format.Source(buf.Bytes())
+	formatted, err := imports.Process(outputPath, buf.Bytes(), nil)
 	if err != nil {
 		// If formatting fails, write unformatted code with warning
 		fmt.Printf("Warning: gofmt failed for %s: %v (writing unformatted)\n", outputPath, err)
@@ -93,7 +94,7 @@ func GenerateClientTypes(resource *openapi.ResourceTemplate, clientDir string) e
 	}
 
 	// Format the generated code with gofmt
-	formatted, err := format.Source(buf.Bytes())
+	formatted, err := imports.Process(outputPath, buf.Bytes(), nil)
 	if err != nil {
 		// If formatting fails, write unformatted code with warning
 		fmt.Printf("Warning: gofmt failed for %s: %v (writing unformatted)\n", outputPath, err)
@@ -120,7 +121,7 @@ func GenerateDataSource(resource *openapi.ResourceTemplate, outputDir string) er
 	}
 
 	// Format the generated code with gofmt
-	formatted, err := format.Source(buf.Bytes())
+	formatted, err := imports.Process(outputPath, buf.Bytes(), nil)
 	if err != nil {
 		// If formatting fails, write unformatted code with warning
 		fmt.Printf("Warning: gofmt failed for %s: %v (writing unformatted)\n", outputPath, err)

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -38,6 +38,8 @@ type Schema struct {
 	Ref                  string            `json:"$ref"`
 	Required             []string          `json:"required"`
 	AdditionalProperties interface{}       `json:"additionalProperties"`
+	// AllOf wraps $ref for OAS3 compliance (x-ves-* sibling preservation pattern)
+	AllOf                []Schema          `json:"allOf"`
 
 	// Original F5 vendor extensions (x-ves-*) - technical metadata from upstream
 	XDisplayName        string            `json:"x-displayname"`

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -121,6 +121,11 @@ func PromoteMinConfigRequired(attrs []openapi.TerraformAttribute, minFields map[
 		if minFields[attrs[i].TfsdkTag] && attrs[i].Optional && !attrs[i].Required {
 			attrs[i].Required = true
 			attrs[i].Optional = false
+			// Clear Computed — Terraform rejects Required+Computed
+			if attrs[i].Computed {
+				attrs[i].Computed = false
+				attrs[i].PlanModifier = ""
+			}
 		}
 	}
 }
@@ -160,6 +165,16 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	validationRules := schema.XVesValidationRules
 	complexity := schema.XF5XCComplexity
 	useCases := schema.XF5XCUseCases
+
+	// Handle allOf-wrapped $ref (OAS3 pattern for preserving sibling extensions alongside $ref)
+	if schema.Ref == "" && len(schema.AllOf) > 0 {
+		for _, item := range schema.AllOf {
+			if item.Ref != "" {
+				schema.Ref = item.Ref
+				break
+			}
+		}
+	}
 
 	if schema.Ref != "" {
 		schema = ResolveRef(schema.Ref, spec)

--- a/tools/pkg/schema/convert_test.go
+++ b/tools/pkg/schema/convert_test.go
@@ -405,3 +405,64 @@ func TestConvertToTerraformAttribute_RecommendedValue_Nil(t *testing.T) {
 		t.Errorf("Description should not contain Recommended when no value set, got: %s", attr.Description)
 	}
 }
+
+func TestConvertToTerraformAttribute_AllOfRef_ObjectBecomesBlock(t *testing.T) {
+	// allOf: [{$ref: "#/components/schemas/SomeObject"}] where SomeObject is an object
+	// The generator should treat this as a block, not a string attribute
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"SomeObject": {
+					Type: "object",
+					Properties: map[string]openapi.Schema{
+						"mode": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+	// Property with allOf wrapping a $ref
+	schema := openapi.Schema{
+		AllOf: []openapi.Schema{
+			{Ref: "#/components/schemas/SomeObject"},
+		},
+	}
+	attr := ConvertToTerraformAttribute("my_setting", schema, false, "", spec)
+
+	if attr.Type != "object" {
+		t.Errorf("allOf-wrapped $ref to object should produce Type=object, got %q", attr.Type)
+	}
+	if !attr.IsBlock {
+		t.Error("allOf-wrapped $ref to object should produce IsBlock=true")
+	}
+	// Must not produce Required+Computed (Terraform rejects this)
+	if attr.Required && attr.Computed {
+		t.Error("allOf-wrapped $ref must not produce Required=true AND Computed=true")
+	}
+}
+
+func TestConvertToTerraformAttribute_AllOfRef_PreservesExtensions(t *testing.T) {
+	// Extensions on the property (like x-f5xc-description-short) should be preserved
+	// even when the actual type comes from allOf $ref
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"StringType": {Type: "string"},
+			},
+		},
+	}
+	schema := openapi.Schema{
+		XF5XCDescriptionShort: "My field description",
+		AllOf: []openapi.Schema{
+			{Ref: "#/components/schemas/StringType"},
+		},
+	}
+	attr := ConvertToTerraformAttribute("my_field", schema, false, "", spec)
+
+	if !strings.Contains(attr.Description, "My field description") {
+		t.Errorf("Property-level extensions should be preserved after allOf resolution, got: %s", attr.Description)
+	}
+	if attr.Type != "string" {
+		t.Errorf("allOf-wrapped $ref to string should produce Type=string, got %q", attr.Type)
+	}
+}

--- a/tools/pkg/schema/scan.go
+++ b/tools/pkg/schema/scan.go
@@ -114,14 +114,15 @@ func CollectConflictAttrs(attributes []openapi.TerraformAttribute) ([]conflicts.
 	return result, goNameLookup
 }
 
-// HasInt64RangeValidatorsAny returns true if any attribute or nested attribute has Minimum or Maximum set.
+// HasInt64RangeValidatorsAny returns true if any non-block int64 attribute has Minimum or Maximum set.
+// Block attributes are excluded because blocks use nested schema types that don't support int64validator.
 func HasInt64RangeValidatorsAny(attributes []openapi.TerraformAttribute) bool {
 	for _, attr := range attributes {
-		if attr.Minimum > 0 || attr.Maximum > 0 {
+		if !attr.IsBlock && (attr.Minimum > 0 || attr.Maximum > 0) {
 			return true
 		}
 		for _, nested := range attr.NestedAttributes {
-			if nested.Minimum > 0 || nested.Maximum > 0 {
+			if !nested.IsBlock && (nested.Minimum > 0 || nested.Maximum > 0) {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

- **AllOf+$ref handling** (types.go + convert.go): Added `AllOf` field to Schema struct and unwrapping logic — when a property uses `allOf: [{$ref: ...}]` (OAS3 pattern for sibling extension preservation), the generator now resolves the $ref correctly. Previously these produced invalid string attributes for object schemas.
- **goimports** (generate.go): Switched from `go/format` to `golang.org/x/tools/imports` so unused imports (`int64validator`, `listplanmodifier`) are automatically removed from generated code instead of causing build failures.
- **Required+Computed guards** (convert.go + scan.go): Fixed `PromoteMinConfigRequired` to clear Computed when promoting Optional fields to Required (the promotion happens AFTER per-attribute conversion, so the existing invariant guard couldn't catch it). Also fixed `HasInt64RangeValidatorsAny` to exclude block attributes.

Closes #425

## Test plan

- [ ] CI checks pass
- [ ] Provider regenerates cleanly with latest enriched specs (v2.1.103+)
- [ ] All 9 staging tests pass
- [ ] All 11 tools/pkg packages pass