### PR TITLE
fix: add continue-on-error to notify-mcp-repo job in on-merge.yml

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -254,6 +254,7 @@ jobs:
       needs.tag-release.result == 'success' &&
       needs.tag-release.outputs.tag-created == 'true'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Dispatch to terraform-provider-mcp
         env:


### PR DESCRIPTION
## Summary

The `notify-mcp-repo` job in the On Merge workflow uses `secrets.AUTO_MERGE_TOKEN` to dispatch to terraform-provider-mcp, but that secret is not configured. This causes every On Merge workflow run to fail with exit code 4 ("GH_TOKEN not set"). Adding `continue-on-error: true` makes the dispatch advisory rather than blocking, since it is a cross-repo notification that does not affect this repo's build/release pipeline.

Closes #429

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] On Merge workflow no longer fails when AUTO_MERGE_TOKEN is unavailable