### PR TITLE
fix: update sync-openapi.yml to use new spec repo and gh api download

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -3,7 +3,7 @@
 # The on-merge.yml workflow handles regeneration when this PR merges
 #
 # Supports two spec sources:
-# - V2: Enriched API specs from f5xc-api-enriched repository (38 domain files + index.json)
+# - V2: Enriched API specs from api-specs-enriched repository (38 domain files + index.json)
 # - V1 (legacy): Original specs from docs.cloud.f5.com (269 individual files)
 name: Sync OpenAPI Specs
 
@@ -42,7 +42,7 @@ env:
   SPEC_DIR: docs/specifications/api
   PR_TITLE: "feat: update F5 Distributed Cloud OpenAPI specifications"
   # V2 spec source configuration
-  ENRICHED_REPO: robinmordasiewicz/f5xc-api-enriched
+  ENRICHED_REPO: f5xc-salesdemos/api-specs-enriched
   # Default to v2 specs unless overridden
   SPEC_SOURCE: ${{ inputs.spec_source || 'v2' }}
   SPEC_VERSION: ${{ inputs.spec_version || 'latest' }}
@@ -80,76 +80,99 @@ jobs:
           SPEC_VERSION="${{ env.SPEC_VERSION }}"
 
           echo "Spec source: $SPEC_SOURCE"
-          echo "spec_source=$SPEC_SOURCE" >> "$GITHUB_OUTPUT"
 
           if [ "$SPEC_SOURCE" = "v2" ]; then
             # Determine v2 version
             if [ "$SPEC_VERSION" = "latest" ] || [ -z "$SPEC_VERSION" ]; then
-              # Get latest release from enriched repo
-              LATEST=$(gh release list --repo "${{ env.ENRICHED_REPO }}" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+              # Get latest release from enriched repo via gh api (works for private repos)
+              LATEST=$(gh api "repos/${{ env.ENRICHED_REPO }}/releases" --jq '.[0].tag_name' 2>/dev/null || echo "")
               if [ -z "$LATEST" ]; then
                 echo "::warning::Could not determine latest v2 release, falling back to v1"
                 SPEC_SOURCE="v1"
-                echo "spec_source=v1" >> "$GITHUB_OUTPUT"
               else
                 SPEC_VERSION="$LATEST"
                 echo "Using latest v2 release: $SPEC_VERSION"
               fi
             fi
-            echo "spec_version=$SPEC_VERSION" >> "$GITHUB_OUTPUT"
 
-            # Build v2 download URL
             if [ "$SPEC_SOURCE" = "v2" ]; then
-              DOWNLOAD_URL="https://github.com/${{ env.ENRICHED_REPO }}/releases/download/${SPEC_VERSION}/f5xc-api-specs-${SPEC_VERSION}.zip"
-              echo "V2 download URL: $DOWNLOAD_URL"
-              echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
+              {
+                echo "spec_source=$SPEC_SOURCE"
+                echo "spec_version=$SPEC_VERSION"
+                echo "download_method=gh_api"
+              } >> "$GITHUB_OUTPUT"
             fi
           fi
 
           if [ "$SPEC_SOURCE" = "v1" ]; then
-            # V1 legacy URL
             DOWNLOAD_URL="https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
             echo "V1 download URL: $DOWNLOAD_URL"
-            echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
-            echo "spec_version=v1" >> "$GITHUB_OUTPUT"
+            {
+              echo "spec_source=v1"
+              echo "spec_version=v1"
+              echo "download_method=curl"
+              echo "download_url=$DOWNLOAD_URL"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download OpenAPI specs
         if: steps.existing_pr.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p ${{ env.SPEC_DIR }}
+          mkdir -p "${{ env.SPEC_DIR }}"
 
-          DOWNLOAD_URL="${{ steps.spec_config.outputs.download_url }}"
+          DOWNLOAD_METHOD="${{ steps.spec_config.outputs.download_method }}"
           SPEC_SOURCE="${{ steps.spec_config.outputs.spec_source }}"
 
-          echo "Downloading specs from: $DOWNLOAD_URL"
+          if [ "$DOWNLOAD_METHOD" = "gh_api" ]; then
+            # V2: Download via gh api (supports private repos)
+            echo "Downloading v2 specs via gh api..."
+            ASSET_ID=$(gh api "repos/${{ env.ENRICHED_REPO }}/releases" --jq \
+              '[.[0].assets[] | select(.name | startswith("f5xc-api-specs"))] | .[0].id')
+            gh api "repos/${{ env.ENRICHED_REPO }}/releases/assets/${ASSET_ID}" \
+              -H "Accept: application/octet-stream" > openapi.zip
+            echo "Download successful"
 
-          # Retry logic with exponential backoff
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "::group::Download attempt $attempt of $max_attempts"
-            if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip "$DOWNLOAD_URL"; then
-              echo "Download successful"
+            # Also download api-catalog.json standalone asset if available
+            CATALOG_ID=$(gh api "repos/${{ env.ENRICHED_REPO }}/releases" --jq \
+              '[.[0].assets[] | select(.name=="api-catalog.json")] | .[0].id')
+            if [ -n "$CATALOG_ID" ] && [ "$CATALOG_ID" != "null" ]; then
+              gh api "repos/${{ env.ENRICHED_REPO }}/releases/assets/${CATALOG_ID}" \
+                -H "Accept: application/octet-stream" > "${{ env.SPEC_DIR }}/api-catalog.json"
+              echo "Downloaded api-catalog.json"
+            fi
+          else
+            # V1: Download via curl with retry logic
+            DOWNLOAD_URL="${{ steps.spec_config.outputs.download_url }}"
+            echo "Downloading specs from: $DOWNLOAD_URL"
+
+            max_attempts=3
+            attempt=1
+            while [ "$attempt" -le "$max_attempts" ]; do
+              echo "::group::Download attempt $attempt of $max_attempts"
+              if curl -sL --fail --retry 2 --retry-delay 5 -o openapi.zip "$DOWNLOAD_URL"; then
+                echo "Download successful"
+                echo "::endgroup::"
+                break
+              fi
               echo "::endgroup::"
-              break
-            fi
-            echo "::endgroup::"
-            attempt=$((attempt + 1))
-            if [ $attempt -le $max_attempts ]; then
-              sleep_time=$((2 ** attempt * 5))
-              echo "::warning::Download failed, retrying in ${sleep_time}s..."
-              sleep $sleep_time
-            else
-              echo "::error::All $max_attempts download attempts failed"
-              exit 1
-            fi
-          done
+              attempt=$((attempt + 1))
+              if [ "$attempt" -le "$max_attempts" ]; then
+                sleep_time=$((2 ** attempt * 5))
+                echo "::warning::Download failed, retrying in ${sleep_time}s..."
+                sleep "$sleep_time"
+              else
+                echo "::error::All $max_attempts download attempts failed"
+                exit 1
+              fi
+            done
+          fi
 
           # Clear existing specs before extracting
-          rm -rf ${{ env.SPEC_DIR }}/*
+          rm -rf "${{ env.SPEC_DIR }}"/*
 
-          unzip -o openapi.zip -d ${{ env.SPEC_DIR }}
+          unzip -o openapi.zip -d "${{ env.SPEC_DIR }}"
           rm openapi.zip
 
           # Verify spec structure based on source type
@@ -163,11 +186,11 @@ jobs:
               echo "::error::V2 spec structure invalid: domains/ directory not found"
               exit 1
             fi
-            DOMAIN_COUNT=$(find "${{ env.SPEC_DIR }}/domains" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l)
+            DOMAIN_COUNT=$(find "${{ env.SPEC_DIR }}/domains" -maxdepth 1 -name '*.json' | wc -l)
             echo "V2 structure verified: index.json + $DOMAIN_COUNT domain files"
           else
             echo "Verifying v1 spec structure..."
-            SPEC_COUNT=$(find "${{ env.SPEC_DIR }}" -maxdepth 1 -name 'docs-cloud-f5-com.*.ves-swagger.json' 2>/dev/null | wc -l)
+            SPEC_COUNT=$(find "${{ env.SPEC_DIR }}" -maxdepth 1 -name 'docs-cloud-f5-com.*.ves-swagger.json' | wc -l)
             if [ "$SPEC_COUNT" -eq "0" ]; then
               echo "::error::V1 spec structure invalid: no *.ves-swagger.json files found"
               exit 1
@@ -200,7 +223,7 @@ jobs:
         run: |
           SPEC_SOURCE="${{ steps.spec_config.outputs.spec_source }}"
 
-          # V2 specs from f5xc-api-enriched are pre-validated in that repository
+          # V2 specs from api-specs-enriched are pre-validated in that repository
           # They use x-f5xc-* vendor extensions which strict validators may reject
           # We perform basic structure validation here
           if [ "$SPEC_SOURCE" = "v2" ]; then
@@ -215,7 +238,7 @@ jobs:
 
             # Verify each domain file exists and has basic OpenAPI structure
             VALID=true
-            for file in ${{ env.SPEC_DIR }}/domains/*.json; do
+            for file in "${{ env.SPEC_DIR }}"/domains/*.json; do
               if [ -f "$file" ]; then
                 if jq -e '.openapi or .swagger' "$file" > /dev/null 2>&1; then
                   echo "✅ $(basename "$file") has valid OpenAPI structure"
@@ -234,7 +257,7 @@ jobs:
             echo "Using swagger-cli for v1 spec validation..."
             npm install -g @apidevtools/swagger-cli
             VALID=true
-            find "${{ env.SPEC_DIR }}" -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \) | while IFS= read -r file; do
+            while IFS= read -r file; do
               if grep -q -E "(openapi|swagger).*['\"]?[0-9]+\.[0-9]+" "$file" 2>/dev/null; then
                 echo "Validating: $file"
                 if swagger-cli validate "$file"; then
@@ -244,7 +267,7 @@ jobs:
                   VALID=false
                 fi
               fi
-            done
+            done < <(find "${{ env.SPEC_DIR }}" -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \))
             if [ "$VALID" = false ]; then
               echo "::error::Some OpenAPI specs failed validation"
               exit 1
@@ -265,7 +288,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b openapi-update-${{ steps.date.outputs.date }}
+          git checkout -b "openapi-update-${{ steps.date.outputs.date }}"
           git add -A
 
           if [ "$SPEC_SOURCE" = "v2" ]; then
@@ -292,7 +315,7 @@ jobs:
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
-          git push --force origin openapi-update-${{ steps.date.outputs.date }}
+          git push --force origin "openapi-update-${{ steps.date.outputs.date }}"
 
       - name: Find or create tracking issue
         if: steps.changes.outputs.changed == 'true'
@@ -418,4 +441,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
-          gh pr merge ${{ steps.create_pr.outputs.number }} --auto --squash
+          gh pr merge "${{ steps.create_pr.outputs.number }}" --auto --squash


### PR DESCRIPTION
## Summary

- Updates `ENRICHED_REPO` from `robinmordasiewicz/f5xc-api-enriched` to `f5xc-salesdemos/api-specs-enriched`
- Replaces `curl` download with `gh api` asset download for private repository compatibility
- Downloads `api-catalog.json` standalone asset during sync when available
- Fixes ShellCheck SC2129 (groups multiple `>>` redirects with `{ }` blocks)
- Fixes ShellCheck SC2086 (quotes variables in arithmetic comparisons)
- Uses process substitution for `find|while` loop to avoid subshell variable loss
- Quotes all path arguments consistently

Closes #364

Supersedes #365, which had the same functional changes but failed the `GITHUB_ACTIONS` linter due to SC2129.

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify `ENRICHED_REPO` env var points to `f5xc-salesdemos/api-specs-enriched`
- [ ] Verify `gh api` is used for v2 spec downloads instead of `curl`
- [ ] Verify `api-catalog.json` download logic is present
- [ ] Confirm no ShellCheck warnings in the workflow file