### PR TITLE
fix: update test skip messages with precise generator diagnostics

### DIFF
--- a/internal/provider/certificate_data_source_test.go
+++ b/internal/provider/certificate_data_source_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccCertificateDataSource_basic(t *testing.T) {
-	t.Skip("Skipping: upstream spec gap — missing private_key. See api-specs-enriched#430")
+	t.Skip("Skipping: generated regex on private_key.clear_secret_info.url rejects string:/// scheme — needs generator fix")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 

--- a/internal/provider/certificate_resource_test.go
+++ b/internal/provider/certificate_resource_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccCertificateResource_basic(t *testing.T) {
-	t.Skip("Skipping: upstream spec gap — missing private_key/disable_ocsp_stapling. See api-specs-enriched#430")
+	t.Skip("Skipping: generated regex on private_key.clear_secret_info.url rejects string:/// scheme — needs generator fix")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 

--- a/internal/provider/fast_acl_data_source_test.go
+++ b/internal/provider/fast_acl_data_source_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccFastAclDataSource_basic(t *testing.T) {
-	t.Skip("Skipping: upstream spec gap — missing site_choice. See api-specs-enriched#429")
+	t.Skip("Skipping: generator matches wrong schema (schemafast_acl prefix) — re_acl/site_acl not in generated resource")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 

--- a/internal/provider/fast_acl_resource_test.go
+++ b/internal/provider/fast_acl_resource_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccFastACLResource_basic(t *testing.T) {
-	t.Skip("Skipping: upstream spec gap — missing site_choice (re_acl/site_acl). See api-specs-enriched#429")
+	t.Skip("Skipping: generator matches wrong schema (schemafast_acl prefix) — re_acl/site_acl not in generated resource")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 


### PR DESCRIPTION
## Summary

- Updated test skip messages in certificate and fast_acl test files to reflect the actual blockers (generator bugs) now that upstream spec enrichment issues are resolved in api-specs-enriched v2.1.103
- Certificate tests: skip message now references the regex validator rejecting `string:///` URL scheme on `private_key.clear_secret_info.url`
- Fast ACL tests: skip message now references the `schemafast_acl` prefix causing wrong schema matching in the generator

Closes #433

## Test plan

- [ ] CI checks pass
- [ ] Verify the 4 test files have updated skip messages pointing to generator-level bugs
- [ ] Confirm no functional test changes (skip messages only)