### PR TITLE
fix: handle schema-prefixed CreateSpecType and skip discovery-inferred URL patterns

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -329,10 +329,14 @@ func processSpecFileForResource(specFile string, resourceName string, category s
 func extractResourceSchemaByName(spec *OpenAPI3Spec, resourceName string) (*SchemaDefinition, string) {
 	// V2 schema naming patterns (e.g., app_firewallCreateSpecType)
 	// The resource name is used as a prefix with CreateSpecType or GetSpecType suffix
+	// Some specs use a "schema" prefix (e.g., schemafast_aclCreateSpecType)
 	v2Patterns := []string{
 		fmt.Sprintf("%sCreateSpecType", resourceName),
+		fmt.Sprintf("schema%sCreateSpecType", resourceName),
 		fmt.Sprintf("%sGetSpecType", resourceName),
+		fmt.Sprintf("schema%sGetSpecType", resourceName),
 		fmt.Sprintf("%sReplaceSpecType", resourceName),
+		fmt.Sprintf("schema%sReplaceSpecType", resourceName),
 	}
 
 	// Legacy schema naming patterns (ves.io.schema format still used in some v2 specs)

--- a/tools/pkg/constraints/constraints.go
+++ b/tools/pkg/constraints/constraints.go
@@ -56,8 +56,18 @@ func Parse(raw map[string]interface{}) *Parsed {
 		p.MaxLength = int(v)
 	}
 	if v, ok := raw["pattern"].(string); ok {
-		if _, err := regexp.Compile(v); err == nil {
-			p.Pattern = v
+		// Skip discovery-inferred patterns (e.g., format:uri → ^(https?|ftp)://)
+		// which may reject vendor-specific schemes like string:///
+		source := ""
+		if meta, ok := raw["metadata"].(map[string]interface{}); ok {
+			if s, ok := meta["source"].(string); ok {
+				source = s
+			}
+		}
+		if source != "discovery" {
+			if _, err := regexp.Compile(v); err == nil {
+				p.Pattern = v
+			}
 		}
 	}
 

--- a/tools/pkg/constraints/constraints_test.go
+++ b/tools/pkg/constraints/constraints_test.go
@@ -204,6 +204,54 @@ func TestParse_NumericConstraints(t *testing.T) {
 	}
 }
 
+func TestParse_DiscoverySourcePatternSkipped(t *testing.T) {
+	// discovery-inferred URL patterns (e.g., format:uri → ^(https?|ftp)://)
+	// must be skipped because they reject F5 XC-specific schemes like string:///
+	input := map[string]interface{}{
+		"constraintType": "string",
+		"category":       "discovery",
+		"format":         "uri",
+		"pattern":        `^(https?|ftp)://[^\s/$.?#].[^\s]*$`,
+		"maxLength":      float64(131072),
+		"deterministic":  true,
+		"metadata": map[string]interface{}{
+			"source":     "discovery",
+			"confidence": float64(0.99),
+		},
+	}
+	result := Parse(input)
+	if result == nil {
+		t.Fatal("Parse() returned nil, want non-nil Parsed with no pattern")
+	}
+	if result.Pattern != "" {
+		t.Errorf("Pattern = %q, want empty string (discovery patterns should be skipped)", result.Pattern)
+	}
+	if result.MaxLength != 131072 {
+		t.Errorf("MaxLength = %d, want 131072", result.MaxLength)
+	}
+}
+
+func TestParse_NonDiscoveryPatternKept(t *testing.T) {
+	// non-discovery patterns (naming, network, etc.) should still be applied
+	input := map[string]interface{}{
+		"constraintType": "string",
+		"category":       "naming",
+		"pattern":        `^[a-z]([-a-z0-9]*[a-z0-9])?$`,
+		"deterministic":  true,
+		"metadata": map[string]interface{}{
+			"source":     "api-probed",
+			"confidence": float64(0.99),
+		},
+	}
+	result := Parse(input)
+	if result == nil {
+		t.Fatal("Parse() returned nil for naming pattern")
+	}
+	if result.Pattern != `^[a-z]([-a-z0-9]*[a-z0-9])?$` {
+		t.Errorf("Pattern = %q, want naming regex", result.Pattern)
+	}
+}
+
 func TestParse_ConfidenceInMetadata_NoDeterministic(t *testing.T) {
 	input := map[string]interface{}{
 		"constraintType": "string",

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -30,22 +30,37 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	var found bool
 	var createSpecKey string
 
-	// Sort schema keys for deterministic iteration (map order is random in Go)
-	schemaKeys := make([]string, 0, len(spec.Components.Schemas))
-	for key := range spec.Components.Schemas {
-		schemaKeys = append(schemaKeys, key)
+	// Try exact match first (most specs), then schema-prefixed variant
+	exactPatterns := []string{
+		resourceName + "CreateSpecType",
+		"schema" + resourceName + "CreateSpecType",
 	}
-	sort.Strings(schemaKeys)
-
-	for _, key := range schemaKeys {
-		schema := spec.Components.Schemas[key]
-		keyLower := strings.ToLower(key)
-		if strings.Contains(keyLower, strings.ToLower(resourceName)) &&
-			strings.Contains(keyLower, "createspectype") {
+	for _, pattern := range exactPatterns {
+		if schema, ok := spec.Components.Schemas[pattern]; ok {
 			createSpec = schema
-			createSpecKey = key
+			createSpecKey = pattern
 			found = true
 			break
+		}
+	}
+
+	if !found {
+		// Sort schema keys for deterministic fallback (map order is random in Go)
+		schemaKeys := make([]string, 0, len(spec.Components.Schemas))
+		for key := range spec.Components.Schemas {
+			schemaKeys = append(schemaKeys, key)
+		}
+		sort.Strings(schemaKeys)
+
+		for _, key := range schemaKeys {
+			keyLower := strings.ToLower(key)
+			if strings.Contains(keyLower, strings.ToLower(resourceName)) &&
+				strings.Contains(keyLower, "createspectype") {
+				createSpec = spec.Components.Schemas[key]
+				createSpecKey = key
+				found = true
+				break
+			}
 		}
 	}
 

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -77,6 +77,41 @@ func TestExtractResourceSchema_NoCreateSpecType(t *testing.T) {
 	}
 }
 
+func TestExtractResourceSchema_SchemaPrefixMatch(t *testing.T) {
+	// Specs like fast_acl use "schemafast_aclCreateSpecType" (with "schema" prefix).
+	// The generator must match this before a shorter name like "fast_acl_ruleCreateSpecType".
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"fast_acl_ruleCreateSpecType": {
+					Type:       "object",
+					Properties: map[string]openapi.Schema{"action": {Type: "string"}},
+				},
+				"schemafast_aclCreateSpecType": {
+					Type:       "object",
+					Properties: map[string]openapi.Schema{"re_acl": {Type: "object"}, "site_acl": {Type: "object"}},
+				},
+			},
+		},
+	}
+	extractAPIPath := func(spec *openapi.Spec, resourceName string) (string, string, bool) {
+		return "/api/config/namespaces/%s/fast_acls", "/api/config/namespaces/%s/fast_acls/%s", true
+	}
+	result, err := ExtractResourceSchema(spec, "fast_acl", extractAPIPath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	foundReAcl := false
+	for _, attr := range result.Attributes {
+		if attr.Name == "re_acl" {
+			foundReAcl = true
+		}
+	}
+	if !foundReAcl {
+		t.Error("Expected 're_acl' attribute (from schemafast_aclCreateSpecType), got fast_acl_rule schema instead")
+	}
+}
+
 func TestExtractResourceSchema_Basic(t *testing.T) {
 	spec := &openapi.Spec{
 		Components: openapi.Components{


### PR DESCRIPTION
## Summary

- Add "schema" prefix variants to exact-match patterns in `generate-all-schemas.go` and `extract.go` so that upstream schemas like `schemafast_aclCreateSpecType` resolve correctly instead of falling through to a wrong case-insensitive match
- Skip constraint patterns where `metadata.source=="discovery"` in `constraints.go` to prevent auto-inferred `^(https?|ftp)://` regex from rejecting F5 XC's `string:///` inline secret scheme
- Add unit tests for both fixes in `extract_test.go` and `constraints_test.go`

Closes #437

## Test plan

- [x] Unit tests added for schema prefix matching (`extract_test.go`)
- [x] Unit tests added for discovery pattern skipping (`constraints_test.go`)
- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] All 17 test packages pass