### PR TITLE
fix: add spec download step to CI regeneration workflows

### DIFF
--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -31,6 +31,31 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      - name: Download specs if not present
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENRICHED_REPO: f5xc-salesdemos/api-specs-enriched
+        run: |
+          SPEC_COUNT=$(find "${{ inputs.spec-dir }}" -name "*.json" -type f 2>/dev/null | wc -l)
+          if [ "$SPEC_COUNT" -eq "0" ]; then
+            echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
+            mkdir -p "${{ inputs.spec-dir }}"
+            ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
+              '[.[0].assets[] | select(.name | startswith("f5xc-api-specs"))] | .[0].id')
+            if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
+              gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
+                -H "Accept: application/octet-stream" > /tmp/specs.zip
+              unzip -o /tmp/specs.zip -d "${{ inputs.spec-dir }}"
+              rm /tmp/specs.zip
+              SPEC_COUNT=$(find "${{ inputs.spec-dir }}" -name "*.json" -type f | wc -l)
+              echo "Downloaded $SPEC_COUNT spec files"
+            else
+              echo "::warning::Could not find spec asset in latest release"
+            fi
+          else
+            echo "Found $SPEC_COUNT existing spec files"
+          fi
+
       - name: Verify specs exist
         id: verify
         run: |

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -299,6 +299,32 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AUTO_MERGE_TOKEN }}
 
+      - name: Download specs if not present
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+          ENRICHED_REPO: f5xc-salesdemos/api-specs-enriched
+        run: |
+          SPEC_DIR="docs/specifications/api"
+          SPEC_COUNT=$(find "$SPEC_DIR" -name "*.json" -type f 2>/dev/null | wc -l)
+          if [ "$SPEC_COUNT" -eq "0" ]; then
+            echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
+            mkdir -p "$SPEC_DIR"
+            ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
+              '[.[0].assets[] | select(.name | startswith("f5xc-api-specs"))] | .[0].id')
+            if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
+              gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
+                -H "Accept: application/octet-stream" > /tmp/specs.zip
+              unzip -o /tmp/specs.zip -d "$SPEC_DIR"
+              rm /tmp/specs.zip
+              SPEC_COUNT=$(find "$SPEC_DIR" -name "*.json" -type f | wc -l)
+              echo "Downloaded $SPEC_COUNT spec files"
+            else
+              echo "::warning::Could not find spec asset in latest release"
+            fi
+          else
+            echo "Found $SPEC_COUNT existing spec files"
+          fi
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

- The `docs/specifications/api/` directory is gitignored (since commit 4f1212c3) but regeneration workflows need spec files to function
- When only `tools/` files change, the pipeline finds 0 spec files and silently skips generation, so generator bug fixes never take effect until the next spec sync PR
- Adds a "Download specs if not present" step to `_generate-provider.yml` and `on-merge.yml` that fetches the latest release asset from `f5xc-salesdemos/api-specs-enriched` when the spec directory is empty

Closes #439

## Test plan

- [ ] CI checks pass
- [ ] Verify the new download step runs when specs are not present in the tree
- [ ] Verify the step is skipped when specs are already available
- [ ] Verify regeneration works end-to-end when only tools/ files change