### PR TITLE
feat: unskip certificate and fast_acl tests, expand staging suite to 11 resources

### DIFF
--- a/internal/acctest/staging.go
+++ b/internal/acctest/staging.go
@@ -9,7 +9,7 @@ import (
 
 // StagingTestRegex is the Go test regex matching the curated staging test subset.
 // These are representative basic lifecycle tests across all domains.
-const StagingTestRegex = "^TestAcc(Namespace|Healthcheck|OriginPool|AppFirewall|VirtualSite|AlertPolicy|AlertReceiver|ServicePolicy|GlobalLogReceiver)Resource_basic$"
+const StagingTestRegex = "^TestAcc(Namespace|Healthcheck|OriginPool|AppFirewall|VirtualSite|AlertPolicy|AlertReceiver|ServicePolicy|GlobalLogReceiver|FastACL|Certificate)Resource_basic$"
 
 // StagingPreCheck verifies staging-specific prerequisites.
 // Requires F5XC_API_URL and F5XC_API_TOKEN (token auth for staging).

--- a/internal/provider/certificate_data_source_test.go
+++ b/internal/provider/certificate_data_source_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccCertificateDataSource_basic(t *testing.T) {
-	t.Skip("Skipping: generated regex on private_key.clear_secret_info.url rejects string:/// scheme — needs generator fix")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 

--- a/internal/provider/certificate_resource_test.go
+++ b/internal/provider/certificate_resource_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAccCertificateResource_basic(t *testing.T) {
-	t.Skip("Skipping: generated regex on private_key.clear_secret_info.url rejects string:/// scheme — needs generator fix")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 
@@ -82,9 +81,15 @@ resource "f5xc_certificate" "test" {
   name       = %[2]q
   namespace  = f5xc_namespace.test.name
 
-  certificate_url       = "string:///%[3]s"
-  private_key           = "string:///%[4]s"
-  disable_ocsp_stapling = "true"
+  certificate_url = "string:///%[3]s"
+
+  private_key {
+    clear_secret_info {
+      url = "string:///%[4]s"
+    }
+  }
+
+  disable_ocsp_stapling {}
 }
 `, nsName, name, certs.ServerCertBase64, certs.ServerKeyBase64))
 }

--- a/internal/provider/fast_acl_data_source_test.go
+++ b/internal/provider/fast_acl_data_source_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccFastAclDataSource_basic(t *testing.T) {
-	t.Skip("Skipping: generator matches wrong schema (schemafast_acl prefix) — re_acl/site_acl not in generated resource")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 

--- a/internal/provider/fast_acl_resource_test.go
+++ b/internal/provider/fast_acl_resource_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAccFastACLResource_basic(t *testing.T) {
-	t.Skip("Skipping: generator matches wrong schema (schemafast_acl prefix) — re_acl/site_acl not in generated resource")
 	acctest.SkipIfNotAccTest(t)
 	acctest.PreCheck(t)
 
@@ -66,8 +65,8 @@ func testAccFastACLConfig_basic(nsName, name string) string {
 resource "f5xc_fast_acl" "test" {
   name      = %[1]q
   namespace = "system"
-  action    = "policer_action"
-  prefix    = "10.0.0.0/8"
+
+  re_acl {}
 }
 `, name))
 }


### PR DESCRIPTION
## Summary

- Unskip certificate resource and data source tests, update config to use block syntax for `private_key`
- Unskip fast_acl resource and data source tests, update config to use `re_acl` block
- Expand `StagingTestRegex` from 9 to 11 resources

With PR #438 (generator schema prefix fix + discovery pattern skip), these resources now generate correctly from the enriched specs.

Closes #441

## Test plan

- [ ] CI checks pass
- [ ] All 11 staging tests pass: AlertPolicy, AlertReceiver, AppFirewall, Certificate, FastACL, GlobalLogReceiver, Healthcheck, Namespace, OriginPool, ServicePolicy, VirtualSite