### PR TITLE
fix: correct service_policy_rule test assertions and remove golangci formatter exclusions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,17 +27,6 @@ linters:
 formatters:
   enable:
     - gofmt
-  exclusions:
-    # Temporarily exclude generated files until CI regenerates them with gofmt formatting.
-    # TODO: Remove these exclusions after the regeneration PR is merged.
-    # See: https://github.com/robinmordasiewicz/terraform-provider-f5xc/issues/321
-    paths:
-      - internal/provider/.*_resource\.go
-      - internal/provider/.*_data_source\.go
-      - internal/provider/.*_resource_test\.go
-      - internal/provider/.*_data_source_test\.go
-      - internal/provider/provider\.go
   settings:
     gofmt:
-      # Simplify code: gofmt with -s option
       simplify: true

--- a/internal/provider/address_allocator_data_source_test.go
+++ b/internal/provider/address_allocator_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/alert_policy_data_source_test.go
+++ b/internal/provider/alert_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccAlertPolicyDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAlertPolicyDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/alert_receiver_data_source_test.go
+++ b/internal/provider/alert_receiver_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccAlertReceiverDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAlertReceiverDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/alert_receiver_resource_test.go
+++ b/internal/provider/alert_receiver_resource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )

--- a/internal/provider/api_crawler_data_source_test.go
+++ b/internal/provider/api_crawler_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccApiCrawlerDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccApiCrawlerDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/api_definition_data_source_test.go
+++ b/internal/provider/api_definition_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccApiDefinitionDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccApiDefinitionDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/api_discovery_data_source_test.go
+++ b/internal/provider/api_discovery_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccApiDiscoveryDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccApiDiscoveryDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/api_testing_data_source_test.go
+++ b/internal/provider/api_testing_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccApiTestingDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccApiTestingDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/apm_data_source_test.go
+++ b/internal/provider/apm_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/app_api_group_data_source_test.go
+++ b/internal/provider/app_api_group_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccAppApiGroupDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAppApiGroupDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/app_firewall_data_source_test.go
+++ b/internal/provider/app_firewall_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccAppFirewallDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAppFirewallDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/aws_tgw_site_data_source_test.go
+++ b/internal/provider/aws_tgw_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccAwsTgwSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAwsTgwSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/aws_vpc_site_data_source_test.go
+++ b/internal/provider/aws_vpc_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccAwsVpcSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAwsVpcSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/azure_vnet_site_data_source_test.go
+++ b/internal/provider/azure_vnet_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccAzureVnetSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccAzureVnetSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/bgp_asn_set_data_source_test.go
+++ b/internal/provider/bgp_asn_set_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccBgpAsnSetDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccBgpAsnSetDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/bot_defense_app_infrastructure_data_source_test.go
+++ b/internal/provider/bot_defense_app_infrastructure_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/cdn_cache_rule_data_source_test.go
+++ b/internal/provider/cdn_cache_rule_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccCdnCacheRuleDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCdnCacheRuleDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/cloud_connect_data_source_test.go
+++ b/internal/provider/cloud_connect_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccCloudConnectDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCloudConnectDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/cloud_credentials_data_source_test.go
+++ b/internal/provider/cloud_credentials_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/cloud_credentials_resource_test.go
+++ b/internal/provider/cloud_credentials_resource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )

--- a/internal/provider/cloud_elastic_ip_data_source_test.go
+++ b/internal/provider/cloud_elastic_ip_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccCloudElasticIpDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCloudElasticIpDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/cloud_link_data_source_test.go
+++ b/internal/provider/cloud_link_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccCloudLinkDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCloudLinkDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/cluster_data_source_test.go
+++ b/internal/provider/cluster_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccClusterDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccClusterDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/cminstance_data_source_test.go
+++ b/internal/provider/cminstance_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/code_base_integration_data_source_test.go
+++ b/internal/provider/code_base_integration_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccCodeBaseIntegrationDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCodeBaseIntegrationDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/container_registry_data_source_test.go
+++ b/internal/provider/container_registry_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccContainerRegistryDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccContainerRegistryDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/data_group_data_source_test.go
+++ b/internal/provider/data_group_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccDataGroupDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccDataGroupDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/data_type_data_source_test.go
+++ b/internal/provider/data_type_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccDataTypeDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccDataTypeDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/dc_cluster_group_data_source_test.go
+++ b/internal/provider/dc_cluster_group_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -44,7 +43,6 @@ func TestAccDcClusterGroupDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccDcClusterGroupDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/discovery_data_source_test.go
+++ b/internal/provider/discovery_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -43,7 +42,6 @@ func TestAccDiscoveryDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccDiscoveryDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/dns_compliance_checks_data_source_test.go
+++ b/internal/provider/dns_compliance_checks_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccDnsComplianceChecksDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccDnsComplianceChecksDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/enhanced_firewall_policy_data_source_test.go
+++ b/internal/provider/enhanced_firewall_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccEnhancedFirewallPolicyDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccEnhancedFirewallPolicyDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/fast_acl_rule_resource_test.go
+++ b/internal/provider/fast_acl_rule_resource_test.go
@@ -23,7 +23,7 @@ func TestAccFastACLRuleResource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy: acctest.CheckResourceDestroyed("f5xc_fast_acl_rule"),
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_fast_acl_rule"),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFastACLRuleConfig_basic(nsName, rName),

--- a/internal/provider/filter_set_data_source_test.go
+++ b/internal/provider/filter_set_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccFilterSetDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccFilterSetDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/forward_proxy_policy_resource_test.go
+++ b/internal/provider/forward_proxy_policy_resource_test.go
@@ -23,7 +23,7 @@ func TestAccForwardProxyPolicyResource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy: acctest.CheckResourceDestroyed("f5xc_forward_proxy_policy"),
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_forward_proxy_policy"),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccForwardProxyPolicyConfig_basic(nsName, rName),

--- a/internal/provider/forwarding_class_data_source_test.go
+++ b/internal/provider/forwarding_class_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/gcp_vpc_site_data_source_test.go
+++ b/internal/provider/gcp_vpc_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccGcpVpcSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccGcpVpcSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/healthcheck_data_source_test.go
+++ b/internal/provider/healthcheck_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccHealthcheckDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccHealthcheckDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/ip_prefix_set_data_source_test.go
+++ b/internal/provider/ip_prefix_set_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccIpPrefixSetDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccIpPrefixSetDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/irule_data_source_test.go
+++ b/internal/provider/irule_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccIruleDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccIruleDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/malicious_user_mitigation_data_source_test.go
+++ b/internal/provider/malicious_user_mitigation_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccMaliciousUserMitigationDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccMaliciousUserMitigationDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/namespace_data_source_test.go
+++ b/internal/provider/namespace_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -34,7 +33,6 @@ func TestAccNamespaceDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccNamespaceDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -474,7 +474,7 @@ func TestAccNamespaceResource_invalidName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Name with invalid characters (uppercase)
-				Config: testAccNamespaceResourceConfig_basic("Invalid-NAME-Test"),
+				Config:      testAccNamespaceResourceConfig_basic("Invalid-NAME-Test"),
 				ExpectError: regexp.MustCompile(`(?i)(invalid|name|must)`),
 			},
 		},

--- a/internal/provider/network_connector_resource_test.go
+++ b/internal/provider/network_connector_resource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )

--- a/internal/provider/origin_pool_data_source_test.go
+++ b/internal/provider/origin_pool_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccOriginPoolDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccOriginPoolDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/policer_data_source_test.go
+++ b/internal/provider/policer_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccPolicerDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccPolicerDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/protocol_inspection_data_source_test.go
+++ b/internal/provider/protocol_inspection_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/protocol_policer_data_source_test.go
+++ b/internal/provider/protocol_policer_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/rate_limiter_data_source_test.go
+++ b/internal/provider/rate_limiter_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccRateLimiterDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccRateLimiterDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/rate_limiter_policy_data_source_test.go
+++ b/internal/provider/rate_limiter_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccRateLimiterPolicyDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccRateLimiterPolicyDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/rate_limiter_resource_test.go
+++ b/internal/provider/rate_limiter_resource_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )

--- a/internal/provider/route_data_source_test.go
+++ b/internal/provider/route_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/securemesh_site_data_source_test.go
+++ b/internal/provider/securemesh_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccSecuremeshSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccSecuremeshSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/segment_data_source_test.go
+++ b/internal/provider/segment_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccSegmentDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccSegmentDataSourceConfig_basic(name string) string {
 	// Segment must be in system namespace

--- a/internal/provider/segment_resource_test.go
+++ b/internal/provider/segment_resource_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )
 
 func TestAccSegmentResource_basic(t *testing.T) {

--- a/internal/provider/sensitive_data_policy_data_source_test.go
+++ b/internal/provider/sensitive_data_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccSensitiveDataPolicyDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccSensitiveDataPolicyDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/service_policy_data_source_test.go
+++ b/internal/provider/service_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccServicePolicyDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccServicePolicyDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/service_policy_rule_resource_test.go
+++ b/internal/provider/service_policy_rule_resource_test.go
@@ -97,11 +97,10 @@ func TestAccServicePolicyRuleResource_allAttributes(t *testing.T) {
 				Config: testAccServicePolicyRuleResourceConfig_allAttributes(nsName, name, description),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceExists(resourceName),
-					// Verify all attributes in Terraform state
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "namespace", nsName),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "system"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "action", "ALLOW"),
+					resource.TestCheckResourceAttr(resourceName, "action", "DENY"),
 					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
 					resource.TestCheckResourceAttr(resourceName, "labels.managed_by", "terraform-acceptance-test"),
 					resource.TestCheckResourceAttr(resourceName, "annotations.purpose", "acceptance-testing"),

--- a/internal/provider/site_mesh_group_data_source_test.go
+++ b/internal/provider/site_mesh_group_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/subnet_data_source_test.go
+++ b/internal/provider/subnet_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccSubnetDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccSubnetDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )
 
 func TestAccSubnetResource_basic(t *testing.T) {

--- a/internal/provider/tenant_configuration_data_source_test.go
+++ b/internal/provider/tenant_configuration_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/trusted_ca_list_data_source_test.go
+++ b/internal/provider/trusted_ca_list_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccTrustedCaListDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccTrustedCaListDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/udp_loadbalancer_data_source_test.go
+++ b/internal/provider/udp_loadbalancer_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/usb_policy_data_source_test.go
+++ b/internal/provider/usb_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )

--- a/internal/provider/user_identification_data_source_test.go
+++ b/internal/provider/user_identification_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccUserIdentificationDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccUserIdentificationDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/virtual_host_data_source_test.go
+++ b/internal/provider/virtual_host_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccVirtualHostDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccVirtualHostDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/virtual_network_data_source_test.go
+++ b/internal/provider/virtual_network_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -35,7 +34,6 @@ func TestAccVirtualNetworkDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccVirtualNetworkDataSourceConfig_basic(name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/virtual_site_data_source_test.go
+++ b/internal/provider/virtual_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -39,7 +38,6 @@ func TestAccVirtualSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccVirtualSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/voltstack_site_data_source_test.go
+++ b/internal/provider/voltstack_site_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"fmt"
 	"testing"
@@ -40,7 +39,6 @@ func TestAccVoltstackSiteDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccVoltstackSiteDataSourceConfig_basic(nsName, name string) string {
 	return acctest.ConfigCompose(

--- a/internal/provider/waf_exclusion_policy_data_source_test.go
+++ b/internal/provider/waf_exclusion_policy_data_source_test.go
@@ -2,7 +2,6 @@
 
 package provider_test
 
-
 import (
 	"testing"
 )


### PR DESCRIPTION
## Summary

- Fix `TestAccServicePolicyRuleResource_allAttributes` test assertions to match actual config and API behavior
- Remove `.golangci.yml` formatters exclusion paths that are no longer needed

### Test Fix Details

The test was asserting:
- `namespace == nsName` (variable) — but config hardcodes `namespace = "system"` (required for service_policy_rule)
- `action == "ALLOW"` — but config does not set action, and API defaults to `"DENY"`

Fixed assertions to match reality. Test now passes against staging API.

### Formatter Exclusions Removal

The exclusions for generated files (`internal/provider/*_resource.go`, `*_data_source.go`, etc.) were added in issue #321 as a temporary workaround. Since PR #428, the generator uses `goimports` and all generated files are gofmt-clean. The exclusions are no longer needed.

Closes #443

## Test plan

- [x] Unit tests pass locally
- [ ] CI checks pass
- [x] Verified service_policy_rule test passes against staging API
- [x] Verified golangci-lint runs without formatter exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)