### PR TITLE
refactor: deduplicate DefaultTimeout constant between blindfold and client packages

### DIFF
--- a/internal/blindfold/auth.go
+++ b/internal/blindfold/auth.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/client"
 )
@@ -72,8 +71,8 @@ const (
 // DefaultAPIURL is the default F5XC API URL.
 const DefaultAPIURL = "https://console.ves.volterra.io"
 
-// DefaultTimeout is the default HTTP client timeout.
-const DefaultTimeout = 30 * time.Second
+// DefaultTimeout reuses the client package's standard HTTP timeout.
+const DefaultTimeout = client.DefaultTimeout
 
 // GetAuthConfigFromEnv reads authentication configuration from environment variables.
 // It checks for API token first, then falls back to P12 certificate authentication.


### PR DESCRIPTION
## Summary

- Replace the duplicate `DefaultTimeout` constant (`30*time.Second`) in `internal/blindfold/auth.go` with a reference to `client.DefaultTimeout`
- Remove unused `time` import from `internal/blindfold/auth.go`
- No new dependency introduced — `blindfold` already imports `client` (from the P12 refactor in PR #447)

Closes #11

## Test plan

- [x] All tests pass including `internal/blindfold` (252s — long because it includes P12 authentication tests)
- [ ] CI checks pass
- [ ] Verify `client.DefaultTimeout` is still defined as `30 * time.Second` in `internal/client/client.go`