### PR TITLE
feat: update generator verification to api-specs-enriched v2.1.104

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2025-12-15 - Full end-to-end workflow validation #488
+// Pipeline Verification: 2026-05-23 - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Update pipeline verification marker in `tools/generate-all-schemas.go` to trigger CI regeneration against api-specs-enriched v2.1.104
- v2.1.104 is a breaking release: 40 unused schemas removed, operationId deduplication, new metadata fields, full enrichment coverage (4,802 conflicts-with, 23,907 required-for, 285 server-default properties)
- CI regeneration will download v2.1.104 (latest release) and regenerate all 104 resources + 11 read-only data sources

Closes #452

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Generate workflow triggers and completes successfully
- [ ] Generator produces 104 resources + 11 read-only data sources
- [ ] go build succeeds
- [ ] All test packages pass