### PR TITLE
fix: re-trigger regeneration pipeline with fixed workflow

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23 - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T05:45Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- The On Merge workflow was fixed in PR #455 (AUTO_MERGE_TOKEN to GITHUB_TOKEN), but the original regeneration run from PR #453 used the old workflow file
- GitHub Actions re-runs use the workflow from the original commit, so re-running did not help
- This minimal timestamp change in `tools/generate-all-schemas.go` (comment only) triggers a fresh On Merge run that uses the corrected workflow

Closes #456

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] After merge, On Merge workflow triggers and successfully creates the regeneration PR using the fixed workflow