### PR TITLE
fix: clean build artifacts before committing in regeneration workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -380,6 +380,10 @@ jobs:
           scripts/go-retry.sh 3 tfplugindocs generate
           go run tools/transform-docs.go
 
+      - name: Clean build artifacts
+        run: |
+          rm -f terraform-provider-f5xc
+
       - name: Check for changes
         id: check
         run: |


### PR DESCRIPTION
## Summary

- Add a "Clean build artifacts" step to the regeneration job in `on-merge.yml` that removes the `terraform-provider-f5xc` binary before `git add -A`
- Prevents the ~45-51 MB Go binary from being committed into regeneration PRs

Closes #458

## Test plan

- [ ] CI checks pass
- [ ] Verify the regeneration workflow no longer stages the binary by inspecting the next automated regeneration PR