### PR TITLE
fix: re-trigger regeneration pipeline after workflow fixes

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T05:45Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T06:20Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Update pipeline verification timestamp in `tools/generate-all-schemas.go` to trigger the `generate.yml` On Merge workflow
- Previous regen attempts failed due to workflow bugs (AUTO_MERGE_TOKEN in PR #453, missing labels and 51MB binary in PR #457) that have since been fixed (PR #455, PR #459)
- This change triggers a fresh pipeline run using the fully corrected workflow

Closes #460

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] On Merge workflow triggers after PR merge and produces a clean regeneration PR
- [ ] Regeneration PR does not contain the 51MB `terraform-provider-f5xc` binary