### PR TITLE
fix: add issues:write permission to on-merge workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -43,6 +43,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: on-merge-${{ github.sha }}

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T06:20Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T07:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Add `issues: write` permission to `.github/workflows/on-merge.yml` so the Create Regeneration PR job can call `gh issue create` without getting "Resource not accessible by integration"
- Update pipeline verification timestamp in `tools/generate-all-schemas.go` to trigger a fresh On Merge run with the corrected permissions

Closes #462

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] After merge, the On Merge workflow triggers and the Create Regeneration PR job can create issues without permission errors