### PR TITLE
fix: use AUTO_MERGE_TOKEN for regeneration PR to trigger CI

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -298,11 +298,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
 
       - name: Download specs if not present
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
           ENRICHED_REPO: f5xc-salesdemos/api-specs-enriched
         run: |
           SPEC_DIR="docs/specifications/api"
@@ -405,7 +405,7 @@ jobs:
       - name: Close stale auto-regenerate PRs
         if: steps.check.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
           # Find and close any open auto-regenerate PRs (they're superseded by this new regeneration)
           echo "Checking for stale auto-regenerate PRs..."
@@ -427,7 +427,7 @@ jobs:
         id: create-pr
         if: steps.check.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
           # Create a unique branch name
           BRANCH_NAME="auto-regenerate/${{ github.sha }}"

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T07:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T07:30Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Switch the `Create Regeneration PR` job in `on-merge.yml` to use `AUTO_MERGE_TOKEN` (PAT) instead of `GITHUB_TOKEN` for checkout, spec download, stale PR cleanup, and PR creation
- Regeneration PRs created with `GITHUB_TOKEN` never trigger CI workflows due to GitHub's anti-loop protection, which prevents required checks from running and blocks auto-merge
- Bump pipeline verification timestamp in `tools/generate-all-schemas.go` to trigger a fresh regeneration run validating the full pipeline

Closes #466

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge, the on-merge workflow creates a regeneration PR using `AUTO_MERGE_TOKEN`
- [ ] The regeneration PR triggers CI checks (Check linked issues, Lint Code Base)
- [ ] Auto-merge proceeds once required checks pass on the regeneration PR