### PR TITLE
fix: re-trigger regeneration pipeline with updated AUTO_MERGE_TOKEN

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T07:30Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T08:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Updated pipeline verification timestamp in `tools/generate-all-schemas.go` to trigger a fresh On Merge regeneration workflow run
- The AUTO_MERGE_TOKEN secret has been updated with a PAT that has the required admin and push access
- Validates the full regeneration pipeline end-to-end: download specs, regenerate, push branch with PAT, create issue, create PR, auto-merge

Closes #468

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] On Merge workflow triggers after squash merge to main
- [ ] Regeneration pipeline completes without 403 push errors
- [ ] Auto-merge PR is created successfully by the regeneration workflow