### PR TITLE
fix: use token-authenticated URL for regeneration branch push

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -448,7 +448,8 @@ jobs:
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
 
-          # Push the branch
+          # Push the branch (use token-authenticated URL so push triggers CI)
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH_NAME"
 
           # Create a tracking issue (required by "Check linked issues" CI check)

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T08:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T08:30Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

The on-merge regeneration workflow fails with 403 when pushing the auto-regenerate branch. Even though `actions/checkout` is configured with `AUTO_MERGE_TOKEN`, `git push` can still default to credentials that lack permission to trigger workflows on the pushed branch.

This PR adds the well-known `git remote set-url` pattern to explicitly set the remote URL to `https://x-access-token:${GH_TOKEN}@github.com/...` before pushing, ensuring the PAT is used for authentication.

### Changes

- **`.github/workflows/on-merge.yml`** — Add `git remote set-url origin` with token-authenticated URL before `git push`
- **`tools/generate-all-schemas.go`** — Update pipeline verification timestamp to trigger a fresh regeneration run

Closes #472

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] On-merge workflow regeneration job successfully pushes the auto-regenerate branch
- [ ] Pushed branch triggers downstream CI workflows