### PR TITLE
fix: clear checkout extraheader before PAT-authenticated push

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -448,7 +448,8 @@ jobs:
 
           Co-Authored-By: Claude <noreply@anthropic.com>"
 
-          # Push the branch (use token-authenticated URL so push triggers CI)
+          # Push the branch (clear checkout extraheader and use PAT so push triggers CI)
+          git config --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH_NAME"
 

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T08:30Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T09:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Clear the `http.https://github.com/.extraheader` git config set by `actions/checkout` before configuring the PAT-authenticated remote URL in the on-merge workflow, fixing 403 errors on push
- Update `tools/generate-all-schemas.go` pipeline verification timestamp to trigger a fresh regeneration run

Closes #474

## Test plan

- [ ] CI checks pass
- [ ] On-merge workflow successfully pushes the regeneration branch using the PAT token