### PR TITLE
fix: disable persist-credentials on checkout to allow PAT push

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -299,6 +299,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          persist-credentials: false
 
       - name: Download specs if not present
         env:

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T09:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T09:30Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Set `persist-credentials: false` on the `actions/checkout` step in the on-merge regeneration job so the credential helper does not intercept git push and override the PAT
- Update pipeline verification timestamp in `tools/generate-all-schemas.go` to trigger a fresh regeneration run

Closes #476

## Test plan

- [ ] CI checks pass
- [ ] On-merge regeneration workflow uses the PAT for git push (CI workflows trigger on the regen PR)