### PR TITLE
fix: re-trigger regeneration with verified AUTO_MERGE_TOKEN

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T09:30Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T10:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- The AUTO_MERGE_TOKEN secret has been updated with a new PAT that has verified `contents:write` scope (successfully created and deleted a test branch via the GitHub API)
- This timestamp touch in `tools/generate-all-schemas.go` triggers a fresh On Merge run to validate the complete regeneration pipeline end-to-end with the corrected token

Closes #478

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] On Merge regeneration workflow triggers after squash merge
- [ ] Regeneration workflow completes successfully with the new AUTO_MERGE_TOKEN