### PR TITLE
fix: make generators produce lint-clean output for TFLINT, MARKDOWN, and NATURAL_LANGUAGE

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -36,7 +36,12 @@
         "file-?type(s)?",
         "lock[- ]file(s)?",
         "re[- ]export(s|ing|ed)?",
-        "copy[- ]past(e|ed|ing)?"
+        "copy[- ]past(e|ed|ing)?",
+        "[Bb]ase64",
+        "[Cc][Dd][Nn]",
+        "[Cc]lick[Hh]ouse",
+        "[Uu]ser ?[Nn]ame",
+        "[Ii]nternet"
       ]
     }
   }

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T11:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T12:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //

--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -319,6 +319,15 @@ func generateExample(resourceName string, schema *SchemaInfo) string {
 	sb.WriteString(fmt.Sprintf("# %s Resource Example\n", humanName))
 	sb.WriteString(fmt.Sprintf("# %s\n\n", schema.Description))
 
+	sb.WriteString("terraform {\n")
+	sb.WriteString("  required_version = \">= 1.0\"\n\n")
+	sb.WriteString("  required_providers {\n")
+	sb.WriteString("    f5xc = {\n")
+	sb.WriteString("      source = \"f5xc-salesdemos/f5xc\"\n")
+	sb.WriteString("    }\n")
+	sb.WriteString("  }\n")
+	sb.WriteString("}\n\n")
+
 	// Get the appropriate namespace for this resource type
 	_, namespace := getNamespaceForResource(resourceName)
 

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -875,6 +875,9 @@ func transformIndexDoc(filePath string) error {
 	// Normalize multiple blank lines
 	text = normalizeBlankLines(text)
 
+	text = fixUpstreamTerminology(text)
+	text = wrapLongLines(text, 400)
+
 	return os.WriteFile(filePath, []byte(text), 0644)
 }
 
@@ -1224,6 +1227,12 @@ func transformAnchorsOnly(filePath string, content string) error {
 			}
 		}
 	}
+
+	// Fix upstream API terminology to pass textlint
+	result = fixUpstreamTerminology(result)
+
+	// Wrap long lines to pass MD013 (max 400 chars)
+	result = wrapLongLines(result, 400)
 
 	return os.WriteFile(filePath, []byte(result), 0644)
 }
@@ -2207,6 +2216,12 @@ func transformDoc(filePath string) error {
 			}
 		}
 	}
+
+	// Fix upstream API terminology to pass textlint
+	result = fixUpstreamTerminology(result)
+
+	// Wrap long lines to pass MD013 (max 400 chars)
+	result = wrapLongLines(result, 400)
 
 	return os.WriteFile(filePath, []byte(result), 0644)
 }
@@ -3303,6 +3318,62 @@ func enhanceTimeoutsSection(content, resourceName string) string {
 	}
 
 	return strings.Join(result, "\n")
+}
+
+// wrapLongLines breaks lines exceeding maxLen at word boundaries.
+// Lines inside code blocks (``` fences) and table rows (starting with |) are left untouched.
+func wrapLongLines(content string, maxLen int) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+	inCodeBlock := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inCodeBlock = !inCodeBlock
+			result = append(result, line)
+			continue
+		}
+		if inCodeBlock || strings.HasPrefix(strings.TrimSpace(line), "|") || len(line) <= maxLen {
+			result = append(result, line)
+			continue
+		}
+		// Wrap at word boundaries
+		for len(line) > maxLen {
+			cut := maxLen
+			for cut > 0 && line[cut] != ' ' {
+				cut--
+			}
+			if cut == 0 {
+				cut = strings.Index(line[maxLen:], " ")
+				if cut < 0 {
+					break
+				}
+				cut += maxLen
+			}
+			result = append(result, line[:cut])
+			line = line[cut+1:]
+		}
+		result = append(result, line)
+	}
+	return strings.Join(result, "\n")
+}
+
+// fixUpstreamTerminology corrects upstream API terminology to pass textlint rules.
+func fixUpstreamTerminology(content string) string {
+	replacer := strings.NewReplacer(
+		"User Name", "username",
+	)
+	content = replacer.Replace(content)
+
+	cdnRegex := regexp.MustCompile(`\bcdn\b`)
+	content = cdnRegex.ReplaceAllString(content, "CDN")
+
+	clickhouseRegex := regexp.MustCompile(`(?i)\bclickhouse\b`)
+	content = clickhouseRegex.ReplaceAllStringFunc(content, func(_ string) string {
+		return "ClickHouse"
+	})
+
+	return content
 }
 
 // stripAIMetadataFromDescriptions removes AI-generated metadata prefixes from documentation.


### PR DESCRIPTION
## Summary

- Add `terraform { required_version, required_providers }` block to all generated examples to satisfy TFLINT validation
- Add `wrapLongLines()` function in `transform-docs.go` that breaks lines exceeding 400 chars at word boundaries, skipping code blocks and tables (fixes MD013)
- Add `fixUpstreamTerminology()` function to normalize upstream API terms (`cdn` -> `CDN`, `clickhouse` -> `ClickHouse`, `User Name` -> `username`) in generated docs
- Add textlint regex exclusions for upstream terms that cannot be corrected at source (Base64, cdn, clickhouse, User Name, Internet)
- Bump `tools/generate-all-schemas.go` timestamp to re-trigger the regeneration pipeline

Closes #486

## Context

The auto-regeneration PR #485 failed the `Lint Code Base` CI check with errors across three linter categories. This PR fixes the generators so all future regeneration output passes lint cleanly.

Governed file changes (`.textlintrc`) have admin approval; upstream issues filed: docs-control#457 (codespell), docs-control#458 (textlint).

## Test plan

- [ ] CI `Lint Code Base` check passes
- [ ] CI `Check linked issues` check passes
- [ ] Verify generated examples include terraform block (TFLINT)
- [ ] Verify long lines in generated docs are wrapped at 400 chars (MD013)
- [ ] Verify upstream terminology is normalized in generated output