### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,atmost,atleast,pecified,adn,assesment,bellow,cahce,checkin,contol,defin,detination,expresssions,hashi,inclusing,lables,nework,positve,refering,sevice,virutal,withing
+skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify,opps,pecified,atmost,atleast

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -30,6 +30,9 @@ jobs:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,20 @@ docs/api-reference/
 .etag
 .github_release
 
+# Autoresearch session artifacts
+autoresearch.sh
+autoresearch.md
+autoresearch.program.md
+autoresearch.checks.sh
+autoresearch-loop.sh
+autoresearch.ideas.md
+autoresearch-queries.txt
+autoresearch.jsonl
+.autoresearch/
+
+# Session-resume files
+handoff.md
+
 # Union from xcsh fork (promoted 2026-04-19)
 .npm/
 packages/*/dist/

--- a/.textlintrc
+++ b/.textlintrc
@@ -36,30 +36,7 @@
         "file-?type(s)?",
         "lock[- ]file(s)?",
         "re[- ]export(s|ing|ed)?",
-        "copy[- ]past(e|ed|ing)?",
-        "[Bb]ase64",
-        "[Cc][Dd][Nn]",
-        "[Cc]lick[Hh]ouse",
-        "[Uu]ser ?[Nn]ame",
-        "[Ii]nternet",
-        "[Aa]zure",
-        "[Bb]it[Bb]ucket",
-        "[Cc]assandra",
-        "[Cc]lient[- ]?[Ss]ide",
-        "[Cc]ode[- ]?[Bb]ase",
-        "[Dd]ocker",
-        "[Gg]it[Hh]ub",
-        "[Gg]it[Ll]ab",
-        "[Jj]ava[Ss]cript",
-        "[Mm][Aa][Cc] ?[Oo][Ss]",
-        "OS X",
-        "[Mm]ongo[Dd][Bb]",
-        "[Nn]ame ?[Ss]pace",
-        "[Ss]erver[- ]?[Ss]ide",
-        "[Ss]ub[- ]?[Cc]lass",
-        "[Ss][Dd][Kk]",
-        "[Uu]buntu",
-        "[Hh]ost ?[Nn]ame"
+        "copy[- ]past(e|ed|ing)?"
       ]
     }
   }


### PR DESCRIPTION
Closes #492

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- .gitignore
- .textlintrc
- .codespellrc