### PR TITLE
fix: add codespell auto-fix step to on-merge regeneration workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -386,6 +386,16 @@ jobs:
         run: |
           rm -f terraform-provider-f5xc
 
+      - name: Fix spelling in generated docs
+        run: |
+          pip install codespell --quiet
+          codespell --write-changes docs/ examples/ --quiet-level 2 || true
+          if [ -f tools/codespell-corrections.txt ]; then
+            codespell --write-changes docs/ examples/ \
+              --dictionary tools/codespell-corrections.txt \
+              --quiet-level 2 || true
+          fi
+
       - name: Check for changes
         id: check
         run: |

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T14:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T15:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Add a codespell `--write-changes` step to the on-merge regeneration workflow that auto-corrects upstream API spelling errors in generated `docs/` and `examples/` files
- The step runs codespell with both the built-in dictionary and a custom `tools/codespell-corrections.txt` dictionary (if present), positioned after doc generation and before `git add`
- Update the `tools/generate-all-schemas.go` pipeline verification timestamp to re-trigger end-to-end regeneration

Closes #500

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] On-merge regeneration workflow includes the codespell step
- [ ] Codespell step runs non-destructively (|| true) so it does not block the workflow on unknown words