### PR TITLE
fix: load spelling corrections from JSON to avoid codespell flagging workflow file

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -389,11 +389,25 @@ jobs:
       - name: Fix spelling in generated docs
         run: |
           pip install codespell --quiet
+          # Auto-fix unambiguous typos
           codespell --write-changes docs/ examples/ --quiet-level 2 || true
-          if [ -f tools/codespell-corrections.txt ]; then
-            codespell --write-changes docs/ examples/ \
-              --dictionary tools/codespell-corrections.txt \
-              --quiet-level 2 || true
+          # Fix ambiguous typos that codespell skips (loaded from JSON corrections file)
+          if [ -f tools/codespell-corrections.json ]; then
+            python3 -c "
+          import json, os, re
+          with open('tools/codespell-corrections.json') as f:
+              data = json.load(f)
+          for wrong, right in data.get('corrections', {}).items():
+              for root in ['docs', 'examples']:
+                  for dirpath, _, filenames in os.walk(root):
+                      for fn in filenames:
+                          if fn.endswith(('.md', '.tf')):
+                              fp = os.path.join(dirpath, fn)
+                              txt = open(fp).read()
+                              fixed = txt.replace(wrong, right)
+                              if fixed != txt:
+                                  open(fp, 'w').write(fixed)
+          "
           fi
 
       - name: Check for changes

--- a/tools/codespell-corrections.json
+++ b/tools/codespell-corrections.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Upstream API spelling corrections for generated docs. Used by on-merge.yml to fix ambiguous typos that codespell --write-changes skips. Format: misspelling -> correction.",
+  "corrections": {
+    "Sevice": "Service",
+    "sevice": "service",
+    " ADN ": " AND ",
+    "Cahce": "Cache",
+    "assesment": "assessment",
+    "expresssions": "expressions",
+    "detination": "destination",
+    "positve": "positive",
+    " bellow ": " below ",
+    " withing ": " within ",
+    "Nework": "Network",
+    " inclusing ": " including ",
+    " lables ": " labels ",
+    " Lables ": " Labels ",
+    " checkin ": " checking ",
+    " Checkin ": " Checking ",
+    " defin ": " define "
+  }
+}

--- a/tools/codespell-corrections.txt
+++ b/tools/codespell-corrections.txt
@@ -1,9 +1,0 @@
-# Codespell dictionary for ambiguous upstream API typos
-# Format: misspelling->correction
-# Used by on-merge.yml to auto-fix generated docs before committing
-sevice->service
-Sevice->Service
-adn->and
-ADN->AND
-hashi->hash
-Hashi->Hash

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T15:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-23T16:00Z - Verified against api-specs-enriched v2.1.104
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Moved ambiguous spelling corrections from inline sed patterns in the workflow YAML to a dedicated `tools/codespell-corrections.json` file (JSON files are in codespell's skip list)
- The workflow now reads corrections via a Python script instead of hardcoded sed expressions containing misspelled words
- Deleted the old `tools/codespell-corrections.txt` file that was superseded
- Updated timestamp in `tools/generate-all-schemas.go` to re-trigger regeneration

Closes #504

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify codespell pre-commit hook no longer flags the workflow file
- [ ] Verify on-merge regeneration still applies spelling corrections correctly