### PR TITLE
fix: remove undeclared secrets from enforce-repo-settings workflow

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -30,9 +30,6 @@ jobs:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
-      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main


### PR DESCRIPTION
## Summary

- Remove `ORG_NPM_TOKEN`, `ORG_RELEASE_TOKEN`, and `ORG_REPO_SYNC_TOKEN` from the `enforce-settings` job's secrets block
- These secrets were removed from the reusable workflow declaration in docs-control#464, causing `startup_failure` on every run since 2026-05-23T22:35Z
- This is a managed file — the governance sync would normally auto-fix it, but the sync itself runs inside this broken workflow (chicken-and-egg deadlock)

Closes #514

## Test plan

- [ ] Verify `Enforce Repository Settings` workflow no longer gets `startup_failure`
- [ ] Verify governance sync runs and pushes updated `.codespellrc` and `.textlintrc`
- [ ] Verify auto-regenerate PR #511 CI passes after configs sync