### PR TITLE
chore: trigger provider regeneration with lint governance sync

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -10,7 +10,7 @@
 //   Changes to this file trigger the generate.yml workflow which regenerates all
 //   provider resources from the latest OpenAPI specifications.
 //
-// Pipeline Verification: 2026-05-23T18:00Z - Verified against api-specs-enriched v2.1.104
+// Pipeline Verification: 2026-05-24T01:00Z - Trigger regen with lint governance sync complete
 //
 // Usage: go run tools/generate-all-schemas.go [--spec-dir=/path/to/specs] [--dry-run]
 //


### PR DESCRIPTION
## Summary

- Update pipeline verification timestamp in `tools/generate-all-schemas.go` to trigger the On Merge regeneration workflow
- Governance lint config (`.codespellrc`, `.textlintrc`) has been synced from docs-control, so the regenerated provider code should now pass all lint gates
- Previous stale regen PR #516 was closed; this triggers a fresh regeneration against v2.1.104 API specs

Closes #521

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] On Merge workflow triggers provider regeneration after squash merge
- [ ] Regenerated PR passes codespell, textlint, markdownlint, and tflint checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)