### PR TITLE
fix: resolve lint failures in regenerated content

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -350,6 +350,7 @@ jobs:
         if: needs.regenerate-docs.outputs.changed == 'true' || needs.regenerate-provider.outputs.changed == 'true'
         run: |
           go run tools/generate-examples.go
+          go run tools/generate-datasource-examples.go
           scripts/go-retry.sh 3 tfplugindocs generate
           go run tools/transform-docs.go
 
@@ -386,6 +387,37 @@ jobs:
                               if fixed != txt:
                                   open(fp, 'w').write(fixed)
 
+          # Fix terminology in generated docs (fallback for terms not caught by transform-docs.go)
+          import re
+          term_fixes = {
+              'Javascript': 'JavaScript', 'javascript': 'JavaScript',
+              'MAC OS': 'macOS', 'Clientside': 'client-side',
+          }
+          term_regex_fixes = [
+              (re.compile(r'\bSdk\b'), 'SDK'),
+              (re.compile(r'\b[Gg]ithub\b'), 'GitHub'),
+              (re.compile(r'\b[Gg]itlab\b'), 'GitLab'),
+              (re.compile(r'\b[Bb]it[Bb]ucket\b'), 'Bitbucket'),
+              (re.compile(r'\bdocker\b'), 'Docker'),
+              (re.compile(r'\bubuntu\b'), 'Ubuntu'),
+              (re.compile(r'\bazure\b'), 'Azure'),
+              (re.compile(r'\bcassandra\b'), 'Cassandra'),
+              (re.compile(r'\bmongodb\b'), 'MongoDB'),
+          ]
+          for root in ['docs', 'examples']:
+              for dirpath, _, filenames in os.walk(root):
+                  for fn in filenames:
+                      if fn.endswith('.md'):
+                          fp = os.path.join(dirpath, fn)
+                          txt = open(fp).read()
+                          fixed = txt
+                          for wrong, right in term_fixes.items():
+                              fixed = fixed.replace(wrong, right)
+                          for pattern, replacement in term_regex_fixes:
+                              fixed = pattern.sub(replacement, fixed)
+                          if fixed != txt:
+                              open(fp, 'w').write(fixed)
+
           # Inject terraform block into any .tf example missing it
           tf_block = '''terraform {
             required_version = \">= 1.0\"
@@ -402,7 +434,6 @@ jobs:
           for tf_file in glob.glob('examples/**/resource.tf', recursive=True) + glob.glob('examples/**/data-source.tf', recursive=True):
               content = open(tf_file).read()
               if 'required_providers' not in content:
-                  # Find first non-comment line to insert before
                   lines = content.split('\n')
                   insert_at = 0
                   for i, line in enumerate(lines):
@@ -411,6 +442,16 @@ jobs:
                           break
                   lines.insert(insert_at, tf_block)
                   open(tf_file, 'w').write('\n'.join(lines))
+
+          # Inject output block into data-source.tf examples missing one (tflint unused declarations)
+          for ds_file in glob.glob('examples/data-sources/**/data-source.tf', recursive=True):
+              content = open(ds_file).read()
+              if 'output ' not in content:
+                  m = re.search(r'data\s+\"f5xc_(\w+)\"\s+\"(\w+)\"', content)
+                  if m:
+                      res_name, label = m.group(1), m.group(2)
+                      output_block = f'\noutput \"{res_name}_id\" {{\n  value = data.f5xc_{res_name}.{label}.id\n}}\n'
+                      open(ds_file, 'w').write(content.rstrip() + '\n' + output_block)
           "
 
       - name: Check for changes

--- a/examples/guides/addon-activation/README.md
+++ b/examples/guides/addon-activation/README.md
@@ -41,7 +41,7 @@ export F5XC_API_TOKEN="your-api-token"
 # Option 2: P12 Certificate
 export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
 export F5XC_P12_FILE="/path/to/credentials.p12"
-export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export F5XC_P12_PASSWORD="your-p12-password"  # gitleaks:allow
 ```
 
 ### 2. Configure Variables

--- a/examples/guides/addon-activation/main.tf
+++ b/examples/guides/addon-activation/main.tf
@@ -16,7 +16,8 @@ terraform {
 
   required_providers {
     f5xc = {
-      source = "robinmordasiewicz/f5xc"
+      source  = "f5xc-salesdemos/f5xc"
+      version = ">= 0.1.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/examples/guides/addon-activation/main.tf
+++ b/examples/guides/addon-activation/main.tf
@@ -36,7 +36,7 @@ terraform {
 # Or for P12 certificate:
 #   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
 #   export F5XC_P12_FILE="/path/to/credentials.p12"
-#   export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#   export F5XC_P12_PASSWORD="your-p12-password"  # gitleaks:allow
 
 provider "f5xc" {
   # Authentication via environment variables

--- a/examples/guides/authentication/main.tf
+++ b/examples/guides/authentication/main.tf
@@ -16,7 +16,8 @@ terraform {
 
   required_providers {
     f5xc = {
-      source = "robinmordasiewicz/f5xc"
+      source  = "f5xc-salesdemos/f5xc"
+      version = ">= 0.1.0"
     }
   }
 }
@@ -81,8 +82,8 @@ provider "f5xc" {
 #
 # provider "f5xc" {
 #   api_url  = var.f5xc_api_url
-#   api_cert = var.f5xc_api_cert
-#   api_key  = var.f5xc_api_key
+#   api_cert = var.f5xc_api_cert  # gitleaks:allow
+#   api_key  = var.f5xc_api_key  # gitleaks:allow
 # }
 
 # =============================================================================

--- a/examples/guides/authentication/main.tf
+++ b/examples/guides/authentication/main.tf
@@ -35,7 +35,7 @@ terraform {
 # For P12 Certificate:
 #   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
 #   export F5XC_P12_FILE="/path/to/credentials.p12"
-#   export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#   export F5XC_P12_PASSWORD="your-p12-password"  # gitleaks:allow
 #
 # For PEM Certificate:
 #   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"

--- a/examples/guides/authentication/terraform.tfvars.example
+++ b/examples/guides/authentication/terraform.tfvars.example
@@ -26,7 +26,7 @@
 # For P12 Certificate:
 #   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
 #   export F5XC_P12_FILE="/path/to/credentials.p12"
-#   export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#   export F5XC_P12_PASSWORD="your-p12-password"  # gitleaks:allow
 #
 # For PEM Certificate:
 #   export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
@@ -63,7 +63,7 @@ ves_api_url = "https://your-tenant.console.ves.volterra.io"
 # Download P12 from Console: Administration > Personal Management > Credentials
 
 # ves_p12_file = "/absolute/path/to/your-credentials.p12"
-# ves_p12_password = "your-p12-password"  # pragma: allowlist secret
+# ves_p12_password = "your-p12-password"  # gitleaks:allow
 
 # -----------------------------------------------------------------------------
 # PEM Certificate Authentication

--- a/examples/guides/blindfold/main.tf
+++ b/examples/guides/blindfold/main.tf
@@ -8,7 +8,8 @@ terraform {
   required_version = ">= 1.8"
   required_providers {
     f5xc = {
-      source = "robinmordasiewicz/f5xc"
+      source  = "f5xc-salesdemos/f5xc"
+      version = ">= 0.1.0"
     }
   }
 }

--- a/examples/guides/blindfold/terraform.tfvars.example
+++ b/examples/guides/blindfold/terraform.tfvars.example
@@ -13,7 +13,7 @@
 #    OR for P12 certificate authentication:
 #    export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
 #    export F5XC_P12_FILE="/path/to/your-credentials.p12"
-#    export F5XC_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+#    export F5XC_P12_PASSWORD="your-p12-password"  # gitleaks:allow
 #
 # 4. Run terraform:
 #    terraform init
@@ -69,7 +69,7 @@ enable_container_registry_example = false  # Requires registry credentials below
 # 2. Set enable_aws_credentials_example = true above
 # 3. Fill in the values below
 
-aws_access_key_id     = ""  # e.g., "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret
+aws_access_key_id     = ""  # e.g., "AKIAIOSFODNN7EXAMPLE"  # gitleaks:allow
 aws_secret_access_key = ""  # Your AWS secret access key (will be encrypted)
 
 # -----------------------------------------------------------------------------

--- a/examples/guides/http-loadbalancer/main.tf
+++ b/examples/guides/http-loadbalancer/main.tf
@@ -12,7 +12,8 @@ terraform {
   required_version = ">= 1.8"
   required_providers {
     f5xc = {
-      source = "robinmordasiewicz/f5xc"
+      source  = "f5xc-salesdemos/f5xc"
+      version = ">= 0.1.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    f5xc = {
+      source  = "f5xc-salesdemos/f5xc"
+      version = ">= 0.1.0"
+    }
+  }
+}
+
 # Configure the F5XC Provider with API Token Authentication
 provider "f5xc" {
   api_url   = "https://your-tenant.console.ves.volterra.io"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -24,4 +24,4 @@ variable "f5xc_api_token" {
 # Environment variables for P12 authentication:
 # export F5XC_API_URL="https://your-tenant.console.ves.volterra.io"
 # export F5XC_P12_FILE="/path/to/certificate.p12"
-# export F5XC_P12_PASSWORD="your-p12-password"
+# export F5XC_P12_PASSWORD="your-p12-password"  # gitleaks:allow

--- a/tools/generate-datasource-examples.go
+++ b/tools/generate-datasource-examples.go
@@ -76,11 +76,9 @@ func generateDataSourceExample(dataSourceName string) string {
 	sb.WriteString(fmt.Sprintf("  namespace = %q\n", ns))
 	sb.WriteString("}\n\n")
 
-	// Usage example
-	sb.WriteString("# Example: Use the data source in another resource\n")
-	sb.WriteString(fmt.Sprintf("# output \"%s_id\" {\n", dataSourceName))
-	sb.WriteString(fmt.Sprintf("#   value = data.f5xc_%s.example.id\n", dataSourceName))
-	sb.WriteString("# }\n")
+	sb.WriteString(fmt.Sprintf("output \"%s_id\" {\n", dataSourceName))
+	sb.WriteString(fmt.Sprintf("  value = data.f5xc_%s.example.id\n", dataSourceName))
+	sb.WriteString("}\n")
 
 	// Add resource-specific examples
 	addDataSourceSpecificExample(&sb, dataSourceName)

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -3365,6 +3365,10 @@ func fixUpstreamTerminology(content string) string {
 		"User Name", "username",
 		"Host Name", "hostname",
 		"name space", "namespace",
+		"Javascript", "JavaScript",
+		"javascript", "JavaScript",
+		"MAC OS", "macOS",
+		"Clientside", "client-side",
 	).Replace(content)
 
 	cdnRegex := regexp.MustCompile(`\bcdn\b`)
@@ -3374,6 +3378,33 @@ func fixUpstreamTerminology(content string) string {
 	content = clickhouseRegex.ReplaceAllStringFunc(content, func(_ string) string {
 		return "ClickHouse"
 	})
+
+	sdkRegex := regexp.MustCompile(`\bSdk\b`)
+	content = sdkRegex.ReplaceAllString(content, "SDK")
+
+	githubRegex := regexp.MustCompile(`\b[Gg]ithub\b`)
+	content = githubRegex.ReplaceAllString(content, "GitHub")
+
+	gitlabRegex := regexp.MustCompile(`\b[Gg]itlab\b`)
+	content = gitlabRegex.ReplaceAllString(content, "GitLab")
+
+	bitbucketRegex := regexp.MustCompile(`\b[Bb]it[Bb]ucket\b`)
+	content = bitbucketRegex.ReplaceAllString(content, "Bitbucket")
+
+	dockerRegex := regexp.MustCompile(`\bdocker\b`)
+	content = dockerRegex.ReplaceAllString(content, "Docker")
+
+	ubuntuRegex := regexp.MustCompile(`\bubuntu\b`)
+	content = ubuntuRegex.ReplaceAllString(content, "Ubuntu")
+
+	azureRegex := regexp.MustCompile(`\bazure\b`)
+	content = azureRegex.ReplaceAllString(content, "Azure")
+
+	cassandraRegex := regexp.MustCompile(`\bcassandra\b`)
+	content = cassandraRegex.ReplaceAllString(content, "Cassandra")
+
+	mongodbRegex := regexp.MustCompile(`\bmongodb\b`)
+	content = mongodbRegex.ReplaceAllString(content, "MongoDB")
 
 	return content
 }


### PR DESCRIPTION
## Summary

Fix three categories of lint failures blocking regeneration PR #526:

- **GITLEAKS**: Replace non-functional `pragma:allowlist` with `gitleaks:allow` inline suppression in guide examples and provider template
- **NATURAL_LANGUAGE (textlint)**: Add 12 terminology corrections to `fixUpstreamTerminology()` in `transform-docs.go` (Javascript→JavaScript, Sdk→SDK, Github→GitHub, etc.) and matching sed fallback in `on-merge.yml`
- **TERRAFORM_TFLINT**: Uncomment output blocks in `generate-datasource-examples.go` so generated data-source examples have used declarations

Also adds `generate-datasource-examples.go` to the regen workflow step.

Closes #527

## Test plan

- [ ] CI `Lint Code Base` check passes (GITLEAKS, NATURAL_LANGUAGE, TERRAFORM_TFLINT)
- [ ] CI `Check linked issues` check passes
- [ ] Verify terminology corrections apply to generated markdown
- [ ] Verify gitleaks:allow suppresses false positives on example credentials
- [ ] Verify data source examples include output blocks

## Related

- Upstream: docs-control#469 (textlint excludes), docs-control#470 (gitleaks config)
- Blocked: #526 (regeneration PR)