### PR TITLE
fix: resolve remaining lint failures in generators and workflow post-processing

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -392,6 +392,9 @@ jobs:
           term_fixes = {
               'Javascript': 'JavaScript', 'javascript': 'JavaScript',
               'MAC OS': 'macOS', 'Clientside': 'client-side',
+              'Client Side': 'client-side', 'client side': 'client-side',
+              'server side': 'server-side',
+              'sub-class': 'subclass',
           }
           term_regex_fixes = [
               (re.compile(r'\bSdk\b'), 'SDK'),
@@ -403,6 +406,10 @@ jobs:
               (re.compile(r'\bazure\b'), 'Azure'),
               (re.compile(r'\bcassandra\b'), 'Cassandra'),
               (re.compile(r'\bmongodb\b'), 'MongoDB'),
+              (re.compile(r'\bCode Base\b'), 'codebase'),
+              (re.compile(r'\bcode base\b'), 'codebase'),
+              (re.compile(r'(?<![#/])Base64'), 'base64'),
+              (re.compile(r'\bInternet\b'), 'internet'),
           ]
           for root in ['docs', 'examples']:
               for dirpath, _, filenames in os.walk(root):
@@ -446,10 +453,13 @@ jobs:
           # Inject output block into data-source.tf examples missing one (tflint unused declarations)
           for ds_file in glob.glob('examples/data-sources/**/data-source.tf', recursive=True):
               content = open(ds_file).read()
-              if 'output ' not in content:
+              has_uncommented_output = bool(re.search(r'^output\s', content, re.MULTILINE))
+              if not has_uncommented_output:
                   m = re.search(r'data\s+\"f5xc_(\w+)\"\s+\"(\w+)\"', content)
                   if m:
                       res_name, label = m.group(1), m.group(2)
+                      # Remove any commented output block first
+                      content = re.sub(r'\n?# Example: Use the data source.*\n(#[^\n]*\n)*', '\n', content)
                       output_block = f'\noutput \"{res_name}_id\" {{\n  value = data.f5xc_{res_name}.{label}.id\n}}\n'
                       open(ds_file, 'w').write(content.rstrip() + '\n' + output_block)
           "

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+[allowlist]
+  regexTarget = "match"
+  regexes = [
+    '''your-p12-password''',
+    '''your-api-token''',
+    '''var\.f5xc_api_cert''',
+    '''var\.f5xc_api_key''',
+    '''var\.f5xc_p12_password''',
+    '''secrets\.F5XC_''',
+  ]

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -3369,6 +3369,13 @@ func fixUpstreamTerminology(content string) string {
 		"javascript", "JavaScript",
 		"MAC OS", "macOS",
 		"Clientside", "client-side",
+		"Client Side", "client-side",
+		"client side", "client-side",
+		"server side", "server-side",
+		"sub-class", "subclass",
+		"Code Base", "codebase",
+		"code base", "codebase",
+		"Internet", "internet",
 	).Replace(content)
 
 	cdnRegex := regexp.MustCompile(`\bcdn\b`)
@@ -3405,6 +3412,9 @@ func fixUpstreamTerminology(content string) string {
 
 	mongodbRegex := regexp.MustCompile(`\bmongodb\b`)
 	content = mongodbRegex.ReplaceAllString(content, "MongoDB")
+
+	base64Regex := regexp.MustCompile(`Base64`)
+	content = base64Regex.ReplaceAllString(content, "base64")
 
 	return content
 }


### PR DESCRIPTION
## Summary

- Add terminology corrections for ambiguous terms (Client Side, Internet, Base64, Code Base, server side, sub-class) to both `transform-docs.go` and `on-merge.yml` post-processing
- Fix output block injection in `on-merge.yml` to detect commented vs uncommented output blocks, preventing tflint unused-declaration errors
- Add `.gitleaks.toml` allowlist for example placeholder passwords and variable references (false positives)

Closes #531

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify textlint no longer flags ambiguous terminology in regenerated docs
- [ ] Verify tflint no longer flags commented output blocks in data-source examples
- [ ] Verify gitleaks no longer flags placeholder passwords in example files