### PR TITLE
fix: correct heading level in blindfold function descriptions (MD001)

### DIFF
--- a/internal/functions/blindfold.go
+++ b/internal/functions/blindfold.go
@@ -45,7 +45,7 @@ Returns a sealed secret string suitable for use in ` + "`blindfold_secret_info.l
 **Security**: The encryption happens locally using the public key fetched from F5XC.
 The plaintext secret is **never** transmitted to F5XC during encryption.
 
-### Example
+## Example
 
 ` + "```hcl" + `
 resource "f5xc_http_loadbalancer" "example" {

--- a/internal/functions/blindfold_file.go
+++ b/internal/functions/blindfold_file.go
@@ -51,7 +51,7 @@ provider::f5xc::blindfold(base64encode(file(path)), policy_name, namespace)
 **Security**: The encryption happens locally using the public key fetched from F5XC.
 The file contents are **never** transmitted to F5XC during encryption.
 
-### Example
+## Example
 
 ` + "```hcl" + `
 resource "f5xc_http_loadbalancer" "example" {


### PR DESCRIPTION
## Summary

- Fix MD001 (heading-increment) violation in generated docs by changing `### Example` to `## Example` in blindfold function description strings
- Affects `internal/functions/blindfold.go` and `internal/functions/blindfold_file.go`
- Unblocks regen PR #534 which fails the MARKDOWN linter due to this heading level issue

Closes #535

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Regenerated `docs/functions/blindfold.md` passes markdownlint MD001