### PR TITLE
feat: comprehensive TDD tests for rate_limiter, service_policy, user_identification, malicious_user_mitigation

### DIFF
--- a/internal/provider/malicious_user_mitigation_resource_test.go
+++ b/internal/provider/malicious_user_mitigation_resource_test.go
@@ -620,6 +620,199 @@ resource "f5xc_malicious_user_mitigation" "test" {
 `, nsName, mumName, annotationsStr)
 }
 
+// =============================================================================
+// DOMAIN-SPECIFIC TESTS — mitigation action variants
+// =============================================================================
+
+func TestAccMaliciousUserMitigationResource_captchaChallenge(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_malicious_user_mitigation.test"
+	rName := acctest.RandomName("tf-test-mum")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckMaliciousUserMitigationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaliciousUserMitigationConfig_captchaSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccMaliciousUserMitigationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccMaliciousUserMitigationResource_jsChallenge(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_malicious_user_mitigation.test"
+	rName := acctest.RandomName("tf-test-mum")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckMaliciousUserMitigationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaliciousUserMitigationConfig_jsChallengeSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccMaliciousUserMitigationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccMaliciousUserMitigationResource_switchAction(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_malicious_user_mitigation.test"
+	rName := acctest.RandomName("tf-test-mum")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckMaliciousUserMitigationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaliciousUserMitigationConfig_blockSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+			{
+				Config: testAccMaliciousUserMitigationConfig_captchaSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+			{
+				Config: testAccMaliciousUserMitigationConfig_jsChallengeSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccMaliciousUserMitigationResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_malicious_user_mitigation.test"
+	rName := acctest.RandomName("tf-test-mum")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckMaliciousUserMitigationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaliciousUserMitigationConfig_blockSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccMaliciousUserMitigationImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccMaliciousUserMitigationConfig_captchaSystem(rName),
+				Check:  acctest.CheckMaliciousUserMitigationExists(resourceName),
+			},
+			{
+				Config: testAccMaliciousUserMitigationConfig_captchaSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// DOMAIN-SPECIFIC CONFIG HELPERS — system namespace
+// =============================================================================
+
+func testAccMaliciousUserMitigationConfig_blockSystem(mumName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_malicious_user_mitigation" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  mitigation_type {
+    rules {
+      threat_level {
+        high {}
+      }
+      mitigation_action {
+        block_temporarily {}
+      }
+    }
+  }
+}
+`, mumName)
+}
+
+func testAccMaliciousUserMitigationConfig_captchaSystem(mumName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_malicious_user_mitigation" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  mitigation_type {
+    rules {
+      threat_level {
+        high {}
+      }
+      mitigation_action {
+        captcha_challenge {}
+      }
+    }
+  }
+}
+`, mumName)
+}
+
+func testAccMaliciousUserMitigationConfig_jsChallengeSystem(mumName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_malicious_user_mitigation" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  mitigation_type {
+    rules {
+      threat_level {
+        medium {}
+      }
+      mitigation_action {
+        javascript_challenge {}
+      }
+    }
+  }
+}
+`, mumName)
+}
+
 func testAccMaliciousUserMitigationResourceConfig_withMitigationType(nsName, mumName string) string {
 	return fmt.Sprintf(`
 resource "f5xc_namespace" "test" {

--- a/internal/provider/rate_limiter_resource_test.go
+++ b/internal/provider/rate_limiter_resource_test.go
@@ -522,6 +522,195 @@ resource "f5xc_rate_limiter" "test" {
 `, rlName, annotationsStr)
 }
 
+// =============================================================================
+// DOMAIN-SPECIFIC TESTS
+// =============================================================================
+
+func TestAccRateLimiterResource_tokenBucket(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_rate_limiter.test"
+	rName := acctest.RandomName("tf-test-rl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckRateLimiterDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRateLimiterConfig_tokenBucketSystem(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckRateLimiterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.total_number", "50"),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.unit", "SECOND"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccRateLimiterImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccRateLimiterResource_switchAlgorithm(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_rate_limiter.test"
+	rName := acctest.RandomName("tf-test-rl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckRateLimiterDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRateLimiterConfig_withLimitsSystem(rName),
+				Check:  acctest.CheckRateLimiterExists(resourceName),
+			},
+			{
+				Config: testAccRateLimiterConfig_tokenBucketSystem(rName),
+				Check:  acctest.CheckRateLimiterExists(resourceName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccRateLimiterConfig_tokenBucketSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRateLimiterResource_unitVariations(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_rate_limiter.test"
+	rName := acctest.RandomName("tf-test-rl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckRateLimiterDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRateLimiterConfig_unitSystem(rName, "SECOND", 1000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckRateLimiterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.unit", "SECOND"),
+				),
+			},
+			{
+				Config: testAccRateLimiterConfig_unitSystem(rName, "MINUTE", 100),
+				Check:  resource.TestCheckResourceAttr(resourceName, "limits.0.unit", "MINUTE"),
+			},
+			{
+				Config: testAccRateLimiterConfig_unitSystem(rName, "HOUR", 5000),
+				Check:  resource.TestCheckResourceAttr(resourceName, "limits.0.unit", "HOUR"),
+			},
+		},
+	})
+}
+
+func TestAccRateLimiterResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_rate_limiter.test"
+	rName := acctest.RandomName("tf-test-rl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckRateLimiterDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRateLimiterConfig_withLimitsSystem(rName),
+				Check:  acctest.CheckRateLimiterExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccRateLimiterImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccRateLimiterConfig_tokenBucketSystem(rName),
+				Check:  acctest.CheckRateLimiterExists(resourceName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccRateLimiterConfig_tokenBucketSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccRateLimiterConfig_basicSystem(rName),
+				Check:  acctest.CheckRateLimiterExists(resourceName),
+			},
+		},
+	})
+}
+
+// =============================================================================
+// CONFIG HELPERS - Domain-specific
+// =============================================================================
+
+func testAccRateLimiterConfig_tokenBucketSystem(rlName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_rate_limiter" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  limits {
+    total_number     = 50
+    unit             = "SECOND"
+    burst_multiplier = 5
+
+    token_bucket {}
+  }
+}
+`, rlName)
+}
+
+func testAccRateLimiterConfig_unitSystem(rlName, unit string, totalNumber int) string {
+	return fmt.Sprintf(`
+resource "f5xc_rate_limiter" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  limits {
+    total_number     = %[3]d
+    unit             = %[2]q
+    burst_multiplier = 2
+
+    leaky_bucket {}
+  }
+}
+`, rlName, unit, totalNumber)
+}
+
 func testAccRateLimiterConfig_withLimitsSystem(rlName string) string {
 	return fmt.Sprintf(`
 resource "f5xc_rate_limiter" "test" {

--- a/internal/provider/service_policy_resource_test.go
+++ b/internal/provider/service_policy_resource_test.go
@@ -4,10 +4,14 @@ package provider_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
 )
@@ -208,6 +212,283 @@ func testAccServicePolicyImportStateIdFunc(resourceName string) resource.ImportS
 }
 
 // =============================================================================
+// TEST: All attributes
+// =============================================================================
+func TestAccServicePolicyResource_allAttributes(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_withLabelsSystem(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckServicePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test service policy"),
+					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts", "disable", "description"},
+				ImportStateIdFunc:       testAccServicePolicyImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Plan checks (create, update, noop)
+// =============================================================================
+func TestAccServicePolicyResource_planChecks(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_basicSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccServicePolicyConfig_withLabelsSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccServicePolicyConfig_withLabelsSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Known values
+// =============================================================================
+func TestAccServicePolicyResource_knownValues(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_basicSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("name"), knownvalue.StringExact(rName)),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("namespace"), knownvalue.StringExact("system")),
+					},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Name validation
+// =============================================================================
+func TestAccServicePolicyResource_invalidName(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccServicePolicyConfig_basicSystem("Invalid-NAME"),
+				ExpectError: regexp.MustCompile(`(?i)(invalid|name|must)`),
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Requires replace
+// =============================================================================
+func TestAccServicePolicyResource_requiresReplace(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName1 := acctest.RandomName("tf-test-sp")
+	rName2 := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_basicSystem(rName1),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+			},
+			{
+				Config: testAccServicePolicyConfig_basicSystem(rName2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Switch policy type (allow → deny → allowList)
+// =============================================================================
+func TestAccServicePolicyResource_switchType(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_basicSystem(rName),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+			},
+			{
+				Config: testAccServicePolicyConfig_denyAllSystem(rName),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccServicePolicyConfig_allowListSystem(rName),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Deny list with IP prefixes
+// =============================================================================
+func TestAccServicePolicyResource_denyList(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_denyListSystem(rName),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts", "deny_list.prefix_list.prefixes.#", "deny_list.prefix_list.prefixes.0"},
+				ImportStateIdFunc:       testAccServicePolicyImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Full lifecycle
+// =============================================================================
+func TestAccServicePolicyResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_service_policy.test"
+	rName := acctest.RandomName("tf-test-sp")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckServicePolicyDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServicePolicyConfig_withLabelsSystem(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckServicePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test service policy"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts", "disable", "description"},
+				ImportStateIdFunc:       testAccServicePolicyImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccServicePolicyConfig_denyAllSystem(rName),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccServicePolicyConfig_denyAllSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccServicePolicyConfig_basicSystem(rName),
+				Check:  acctest.CheckServicePolicyExists(resourceName),
+			},
+		},
+	})
+}
+
+// =============================================================================
 // CONFIG HELPERS - Use "system" namespace
 // =============================================================================
 
@@ -257,6 +538,24 @@ resource "f5xc_service_policy" "test" {
   deny_all_requests {}
 
   # Apply to any server
+  any_server {}
+}
+`, name)
+}
+
+func testAccServicePolicyConfig_denyListSystem(name string) string {
+	return fmt.Sprintf(`
+resource "f5xc_service_policy" "test" {
+  name       = %[1]q
+  namespace  = "system"
+
+  deny_list {
+    prefix_list {
+      prefixes = ["172.16.0.0/12"]
+    }
+    default_action_allow {}
+  }
+
   any_server {}
 }
 `, name)

--- a/internal/provider/user_identification_resource_test.go
+++ b/internal/provider/user_identification_resource_test.go
@@ -540,6 +540,210 @@ resource "f5xc_user_identification" "test" {
 `, uiName, annotationsStr)
 }
 
+// =============================================================================
+// DOMAIN-SPECIFIC TESTS
+// =============================================================================
+
+func TestAccUserIdentificationResource_cookieRule(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_user_identification.test"
+	rName := acctest.RandomName("tf-test-uid")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckUserIdentificationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserIdentificationConfig_cookieSystem(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckUserIdentificationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.cookie_name", "session_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccUserIdentificationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccUserIdentificationResource_httpHeaderRule(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_user_identification.test"
+	rName := acctest.RandomName("tf-test-uid")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckUserIdentificationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserIdentificationConfig_httpHeaderSystem(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckUserIdentificationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.http_header_name", "X-Forwarded-For"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccUserIdentificationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccUserIdentificationResource_tlsFingerprintRule(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_user_identification.test"
+	rName := acctest.RandomName("tf-test-uid")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckUserIdentificationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserIdentificationConfig_tlsFingerprintSystem(rName),
+				Check:  acctest.CheckUserIdentificationExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccUserIdentificationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccUserIdentificationResource_switchRuleType(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_user_identification.test"
+	rName := acctest.RandomName("tf-test-uid")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckUserIdentificationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserIdentificationConfig_withRulesSystem(rName),
+				Check:  acctest.CheckUserIdentificationExists(resourceName),
+			},
+			{
+				Config: testAccUserIdentificationConfig_cookieSystem(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckUserIdentificationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "rules.0.cookie_name", "session_id"),
+				),
+			},
+			{
+				Config: testAccUserIdentificationConfig_httpHeaderSystem(rName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "rules.0.http_header_name", "X-Forwarded-For"),
+			},
+		},
+	})
+}
+
+func TestAccUserIdentificationResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_user_identification.test"
+	rName := acctest.RandomName("tf-test-uid")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckUserIdentificationDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserIdentificationConfig_cookieSystem(rName),
+				Check:  acctest.CheckUserIdentificationExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccUserIdentificationImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccUserIdentificationConfig_httpHeaderSystem(rName),
+				Check:  acctest.CheckUserIdentificationExists(resourceName),
+			},
+			{
+				Config: testAccUserIdentificationConfig_httpHeaderSystem(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// DOMAIN-SPECIFIC CONFIG HELPERS
+// =============================================================================
+
+func testAccUserIdentificationConfig_cookieSystem(uiName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_user_identification" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  rules {
+    cookie_name = "session_id"
+  }
+}
+`, uiName)
+}
+
+func testAccUserIdentificationConfig_httpHeaderSystem(uiName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_user_identification" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  rules {
+    http_header_name = "X-Forwarded-For"
+  }
+}
+`, uiName)
+}
+
+func testAccUserIdentificationConfig_tlsFingerprintSystem(uiName string) string {
+	return fmt.Sprintf(`
+resource "f5xc_user_identification" "test" {
+  name      = %[1]q
+  namespace = "system"
+
+  rules {
+    tls_fingerprint {}
+  }
+}
+`, uiName)
+}
+
 func testAccUserIdentificationConfig_withRulesSystem(uiName string) string {
 	return fmt.Sprintf(`
 resource "f5xc_user_identification" "test" {


### PR DESCRIPTION
## Summary

- Batch 2 of TDD expansion for HTTP load balancer dependency resources
- Adds 21 new acceptance tests across 4 resource types (rate_limiter, service_policy, user_identification, malicious_user_mitigation)
- All 69 tests pass against live staging API with real CRUD operations — zero skips

Closes #563

## Test Coverage

| Resource | Tests | New Tests | Coverage |
|----------|-------|-----------|----------|
| rate_limiter | 18/18 | 4 | token_bucket, unit switching, algorithm switching, full lifecycle |
| service_policy | 14/14 | 8 | all attributes, plan checks, known values, invalid name, requires replace, type switching, deny_list, full lifecycle |
| user_identification | 19/19 | 5 | cookie rule, HTTP header rule, TLS fingerprint rule, rule type switching, full lifecycle |
| malicious_user_mitigation | 18/18 | 4 | captcha_challenge, javascript_challenge, action switching, full lifecycle |

## API Finding

`service_policy` `deny_list.prefix_list.prefixes` is not round-tripped on import (provider Read bug in generated code — needs separate generator fix).

## Test plan

- [x] All 69 tests pass against live staging API (nferreira.staging.volterra.us)
- [x] Zero test skips
- [x] Real CRUD operations verified
- [ ] CI checks pass