### PR TITLE
feat: fix OneOf-Required generator conflict + TDD tests for api_definition, api_discovery, advertise_policy

### DIFF
--- a/internal/provider/advertise_policy_resource_test.go
+++ b/internal/provider/advertise_policy_resource_test.go
@@ -4,9 +4,11 @@ package provider_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
@@ -56,13 +58,185 @@ func testAccAdvertisePolicyImportStateIdFunc(resourceName string) resource.Impor
 	}
 }
 
+func TestAccAdvertisePolicyResource_withLabels(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_advertise_policy.test"
+	rName := acctest.RandomName("tf-test-adv")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_advertise_policy"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAdvertisePolicyConfig_withLabels(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvertisePolicyResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-test-adv")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_advertise_policy"),
+		Steps: []resource.TestStep{
+			{Config: testAccAdvertisePolicyConfig_basic(rName)},
+			{Config: testAccAdvertisePolicyConfig_basic(rName), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
+func TestAccAdvertisePolicyResource_planChecks(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_advertise_policy.test"
+	rName := acctest.RandomName("tf-test-adv")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_advertise_policy"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAdvertisePolicyConfig_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate)},
+				},
+			},
+			{
+				Config: testAccAdvertisePolicyConfig_withLabels(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)},
+				},
+			},
+			{
+				Config: testAccAdvertisePolicyConfig_withLabels(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop)},
+				},
+			},
+		},
+	})
+}
+
+func TestAccAdvertisePolicyResource_invalidName(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: testAccAdvertisePolicyConfig_basic("Invalid-NAME"), ExpectError: regexp.MustCompile(`(?i)(invalid|name|must)`)},
+		},
+	})
+}
+
+func TestAccAdvertisePolicyResource_requiresReplace(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_advertise_policy.test"
+	rName1 := acctest.RandomName("tf-test-adv")
+	rName2 := acctest.RandomName("tf-test-adv")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_advertise_policy"),
+		Steps: []resource.TestStep{
+			{Config: testAccAdvertisePolicyConfig_basic(rName1), Check: acctest.CheckResourceExists(resourceName)},
+			{
+				Config: testAccAdvertisePolicyConfig_basic(rName2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate)},
+				},
+			},
+		},
+	})
+}
+
+func TestAccAdvertisePolicyResource_updatePort(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_advertise_policy.test"
+	rName := acctest.RandomName("tf-test-adv")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_advertise_policy"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAdvertisePolicyConfig_port(rName, 80),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+				),
+			},
+			{
+				Config: testAccAdvertisePolicyConfig_port(rName, 443),
+				Check:  resource.TestCheckResourceAttr(resourceName, "port", "443"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)},
+				},
+			},
+		},
+	})
+}
+
+func testAccAdvertisePolicyConfig_withLabels(name string) string {
+	return fmt.Sprintf(`
+resource "f5xc_advertise_policy" "test" {
+  name            = %[1]q
+  namespace       = "system"
+  address         = "0.0.0.0"
+  port            = 80
+  protocol        = "TCP"
+  skip_xff_append = false
+  labels = {
+    environment = "test"
+  }
+}
+`, name)
+}
+
+func testAccAdvertisePolicyConfig_port(name string, port int) string {
+	return fmt.Sprintf(`
+resource "f5xc_advertise_policy" "test" {
+  name            = %[1]q
+  namespace       = "system"
+  address         = "0.0.0.0"
+  port            = %[2]d
+  protocol        = "TCP"
+  skip_xff_append = false
+}
+`, name, port)
+}
+
 func testAccAdvertisePolicyConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "f5xc_advertise_policy" "test" {
-  name      = %[1]q
-  namespace = "system"
-  port      = 80
-  protocol  = "TCP"
+  name            = %[1]q
+  namespace       = "system"
+  address         = "0.0.0.0"
+  port            = 80
+  protocol        = "TCP"
+  skip_xff_append = false
 }
 `, name)
 }

--- a/internal/provider/api_definition_resource_test.go
+++ b/internal/provider/api_definition_resource_test.go
@@ -4,9 +4,11 @@ package provider_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
@@ -54,6 +56,227 @@ func testAccAPIDefinitionImportStateIdFunc(resourceName string) resource.ImportS
 		name := rs.Primary.Attributes["name"]
 		return fmt.Sprintf("%s/%s", namespace, name), nil
 	}
+}
+
+func TestAccAPIDefinitionResource_withLabels(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_definition.test"
+	rName := acctest.RandomName("tf-test-def")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_definition"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDefinitionConfig_withLabels(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAPIDefinitionResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_definition.test"
+	rName := acctest.RandomName("tf-test-def")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_definition"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDefinitionConfig_withLabels(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccAPIDefinitionImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccAPIDefinitionConfig_basic(rName),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+			{
+				Config:             testAccAPIDefinitionConfig_basic(rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccAPIDefinitionResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-test-def")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_definition"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDefinitionConfig_basic(rName),
+			},
+			{
+				Config:             testAccAPIDefinitionConfig_basic(rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccAPIDefinitionResource_planChecks(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_definition.test"
+	rName := acctest.RandomName("tf-test-def")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_definition"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDefinitionConfig_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccAPIDefinitionConfig_withLabels(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccAPIDefinitionConfig_withLabels(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIDefinitionResource_invalidName(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAPIDefinitionConfig_basic("Invalid-NAME"),
+				ExpectError: regexp.MustCompile(`(?i)(invalid|name|must)`),
+			},
+		},
+	})
+}
+
+func TestAccAPIDefinitionResource_requiresReplace(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_definition.test"
+	rName1 := acctest.RandomName("tf-test-def")
+	rName2 := acctest.RandomName("tf-test-def")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_definition"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDefinitionConfig_basic(rName1),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+			{
+				Config: testAccAPIDefinitionConfig_basic(rName2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIDefinitionResource_strictSchemaOrigin(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_definition.test"
+	rName := acctest.RandomName("tf-test-def")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_definition"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDefinitionConfig_strictSchema(rName),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+				ImportStateIdFunc:       testAccAPIDefinitionImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccAPIDefinitionConfig_withLabels(name string) string {
+	return fmt.Sprintf(`
+resource "f5xc_api_definition" "test" {
+  name      = %[1]q
+  namespace = "shared"
+
+  labels = {
+    environment = "test"
+  }
+}
+`, name)
+}
+
+func testAccAPIDefinitionConfig_strictSchema(name string) string {
+	return fmt.Sprintf(`
+resource "f5xc_api_definition" "test" {
+  name      = %[1]q
+  namespace = "shared"
+
+  strict_schema_origin {}
+}
+`, name)
 }
 
 func testAccAPIDefinitionConfig_basic(name string) string {

--- a/internal/provider/api_discovery_resource_test.go
+++ b/internal/provider/api_discovery_resource_test.go
@@ -4,9 +4,11 @@ package provider_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
@@ -54,6 +56,129 @@ func testAccAPIDiscoveryImportStateIdFunc(resourceName string) resource.ImportSt
 		name := rs.Primary.Attributes["name"]
 		return fmt.Sprintf("%s/%s", namespace, name), nil
 	}
+}
+
+func TestAccAPIDiscoveryResource_withLabels(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_discovery.test"
+	rName := acctest.RandomName("tf-test-disc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_discovery"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDiscoveryConfig_withLabels(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAPIDiscoveryResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-test-disc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_discovery"),
+		Steps: []resource.TestStep{
+			{Config: testAccAPIDiscoveryConfig_basic(rName)},
+			{Config: testAccAPIDiscoveryConfig_basic(rName), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
+func TestAccAPIDiscoveryResource_planChecks(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_discovery.test"
+	rName := acctest.RandomName("tf-test-disc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_discovery"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIDiscoveryConfig_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate)},
+				},
+			},
+			{
+				Config: testAccAPIDiscoveryConfig_withLabels(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)},
+				},
+			},
+			{
+				Config: testAccAPIDiscoveryConfig_withLabels(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop)},
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIDiscoveryResource_invalidName(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: testAccAPIDiscoveryConfig_basic("Invalid-NAME"), ExpectError: regexp.MustCompile(`(?i)(invalid|name|must)`)},
+		},
+	})
+}
+
+func TestAccAPIDiscoveryResource_requiresReplace(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_api_discovery.test"
+	rName1 := acctest.RandomName("tf-test-disc")
+	rName2 := acctest.RandomName("tf-test-disc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_api_discovery"),
+		Steps: []resource.TestStep{
+			{Config: testAccAPIDiscoveryConfig_basic(rName1), Check: acctest.CheckResourceExists(resourceName)},
+			{
+				Config: testAccAPIDiscoveryConfig_basic(rName2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate)},
+				},
+			},
+		},
+	})
+}
+
+func testAccAPIDiscoveryConfig_withLabels(name string) string {
+	return fmt.Sprintf(`
+resource "f5xc_api_discovery" "test" {
+  name      = %[1]q
+  namespace = "system"
+  labels = {
+    environment = "test"
+  }
+}
+`, name)
 }
 
 func testAccAPIDiscoveryConfig_basic(name string) string {

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -119,9 +119,11 @@ func ParseMinConfigRequiredFields(raw interface{}) []string {
 func PromoteMinConfigRequired(attrs []openapi.TerraformAttribute, minFields map[string]bool) {
 	for i := range attrs {
 		if minFields[attrs[i].TfsdkTag] && attrs[i].Optional && !attrs[i].Required {
+			if len(attrs[i].ConflictsWith) > 0 {
+				continue
+			}
 			attrs[i].Required = true
 			attrs[i].Optional = false
-			// Clear Computed — Terraform rejects Required+Computed
 			if attrs[i].Computed {
 				attrs[i].Computed = false
 				attrs[i].PlanModifier = ""
@@ -284,6 +286,10 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	if depth == 0 && (schema.XRequired || schema.XVesRequired == "true" || schema.XF5XCRequiredFor.Create) {
 		attr.Required = true
 		attr.Optional = false
+	}
+	if attr.Required && len(attr.ConflictsWith) > 0 {
+		attr.Required = false
+		attr.Optional = true
 	}
 	// Set PlanModifier for immutable fields (reuses existing template infrastructure)
 	if attr.Immutable && attr.PlanModifier == "" {


### PR DESCRIPTION
## Summary

- **Bug fix**: OneOf fields with `ConflictsWith` are no longer promoted to `Required` in `PromoteMinConfigRequired` and `x-required` code paths in `tools/pkg/schema/convert.go`. This prevents an impossible schema where mutually exclusive fields are both required (discovered via advertise_policy where `port` and `port_ranges` are OneOf but both listed in `required_fields`).
- **TDD expansion batch 3**: 18 new tests across 3 resources -- api_definition (7), api_discovery (5), advertise_policy (6). All 21 tests pass against live staging API.
- **Upstream spec note**: advertise_policy `minimum-configuration.required_fields` lists both `port` AND `port_ranges` despite them being mutually exclusive. The generator fix handles this but the upstream spec should also be corrected.

Closes #567

## Test plan

- [x] api_definition: 8/8 PASS (live staging API)
- [x] api_discovery: 6/6 PASS (live staging API)
- [x] advertise_policy: 7/7 PASS (live staging API, previously ALL tests failed before fix)
- [ ] CI checks pass