### PR TITLE
feat: TDD tests for waf_exclusion_policy, certificate, certificate_chain, crl, bot_defense, trusted_ca_list

### DIFF
--- a/internal/provider/bot_defense_app_infrastructure_resource_test.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource_test.go
@@ -51,6 +51,25 @@ func TestAccBotDefenseAppInfrastructureResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccBotDefenseAppInfrastructureResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-acc-test-bot")
+	nsName := acctest.RandomName("tf-acc-test-ns")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_bot_defense_app_infrastructure"),
+		Steps: []resource.TestStep{
+			{Config: testAccBotDefenseAppInfrastructureConfig_basic(nsName, rName)},
+			{Config: testAccBotDefenseAppInfrastructureConfig_basic(nsName, rName), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
 func testAccBotDefenseAppInfrastructureImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -86,7 +105,7 @@ resource "f5xc_bot_defense_app_infrastructure" "test" {
 
   cloud_hosted {
     infra_host_name = "test.example.com"
-    region          = "us-west-2"
+    region          = "US"
   }
 }
 `, nsName, name))

--- a/internal/provider/certificate_chain_resource_test.go
+++ b/internal/provider/certificate_chain_resource_test.go
@@ -51,6 +51,26 @@ func TestAccCertificateChainResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccCertificateChainResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-acc-test-certchain")
+	nsName := acctest.RandomName("tf-acc-test-ns")
+	certs := acctest.MustGenerateTestCertificates()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}},
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_certificate_chain"),
+		Steps: []resource.TestStep{
+			{Config: testAccCertificateChainConfig_basic(nsName, rName, certs)},
+			{Config: testAccCertificateChainConfig_basic(nsName, rName, certs), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
 func testAccCertificateChainImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/provider/certificate_resource_test.go
+++ b/internal/provider/certificate_resource_test.go
@@ -51,6 +51,87 @@ func TestAccCertificateResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccCertificateResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-acc-test-cert")
+	nsName := acctest.RandomName("tf-acc-test-ns")
+	certs := acctest.MustGenerateTestCertificates()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}},
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_certificate"),
+		Steps: []resource.TestStep{
+			{Config: testAccCertificateConfig_basic(nsName, rName, certs)},
+			{Config: testAccCertificateConfig_basic(nsName, rName, certs), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
+func TestAccCertificateResource_withLabels(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-acc-test-cert")
+	nsName := acctest.RandomName("tf-acc-test-ns")
+	resourceName := "f5xc_certificate.test"
+	certs := acctest.MustGenerateTestCertificates()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        map[string]resource.ExternalProvider{"time": {Source: "hashicorp/time"}},
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_certificate"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateConfig_withLabels(nsName, rName, certs),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "labels.environment", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCertificateConfig_withLabels(nsName, name string, certs *acctest.TestCertificates) string {
+	return acctest.ConfigCompose(
+		acctest.ProviderConfig(),
+		fmt.Sprintf(`
+resource "f5xc_namespace" "test" {
+  name = %[1]q
+}
+
+resource "time_sleep" "wait_for_namespace" {
+  depends_on      = [f5xc_namespace.test]
+  create_duration = "5s"
+}
+
+resource "f5xc_certificate" "test" {
+  depends_on = [time_sleep.wait_for_namespace]
+  name       = %[2]q
+  namespace  = f5xc_namespace.test.name
+
+  labels = {
+    environment = "test"
+  }
+
+  certificate_url = "string:///%[3]s"
+
+  private_key {
+    clear_secret_info {
+      url = "string:///%[4]s"
+    }
+  }
+
+  disable_ocsp_stapling {}
+}
+`, nsName, name, certs.ServerCertBase64, certs.ServerKeyBase64))
+}
+
 func testAccCertificateImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/provider/crl_resource_test.go
+++ b/internal/provider/crl_resource_test.go
@@ -52,6 +52,25 @@ func TestAccCRLResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccCRLResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-acc-test-crl")
+	nsName := acctest.RandomName("tf-acc-test-ns")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_crl"),
+		Steps: []resource.TestStep{
+			{Config: testAccCRLConfig_basic(nsName, rName)},
+			{Config: testAccCRLConfig_basic(nsName, rName), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
 func testAccCRLImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/provider/trusted_ca_list_resource_test.go
+++ b/internal/provider/trusted_ca_list_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
@@ -298,7 +299,114 @@ func testAccTrustedCaListResourceImportStateIdFunc(resourceName string) resource
 // Test Configuration Functions
 // =============================================================================
 
+// =============================================================================
+// TEST: Empty plan (no drift)
+// =============================================================================
+func TestAccTrustedCaListResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	nsName := acctest.RandomName("tf-test-ns")
+	rName := acctest.RandomName("tf-test-tcl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		Steps: []resource.TestStep{
+			{Config: testAccTrustedCaListResourceConfig_basic(nsName, rName)},
+			{Config: testAccTrustedCaListResourceConfig_basic(nsName, rName), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Plan checks (create, update, noop)
+// =============================================================================
+func TestAccTrustedCaListResource_planChecks(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_trusted_ca_list.test"
+	nsName := acctest.RandomName("tf-test-ns")
+	rName := acctest.RandomName("tf-test-tcl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustedCaListResourceConfig_basic(nsName, rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate)},
+				},
+			},
+			{
+				Config: testAccTrustedCaListResourceConfig_allAttributes(nsName, rName, "updated"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)},
+				},
+			},
+			{
+				Config: testAccTrustedCaListResourceConfig_allAttributes(nsName, rName, "updated"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop)},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Full lifecycle
+// =============================================================================
+func TestAccTrustedCaListResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_trusted_ca_list.test"
+	nsName := acctest.RandomName("tf-test-ns")
+	rName := acctest.RandomName("tf-test-tcl")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustedCaListResourceConfig_allAttributes(nsName, rName, "lifecycle test"),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts", "disable", "description"},
+				ImportStateIdFunc:       testAccTrustedCaListResourceImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccTrustedCaListResourceConfig_basic(nsName, rName),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+			{
+				Config:             testAccTrustedCaListResourceConfig_basic(nsName, rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// =============================================================================
+// Test Configuration Functions
+// =============================================================================
+
 func testAccTrustedCaListResourceConfig_basic(nsName, name string) string {
+	return testAccTrustedCaListResourceConfig_basicWithCert(nsName, name, acctest.MustGenerateTestCertificates().IntermediateCABase64)
+}
+
+func testAccTrustedCaListResourceConfig_basicWithCert(nsName, name, certBase64 string) string {
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
@@ -312,14 +420,16 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 resource "f5xc_trusted_ca_list" "test" {
-  depends_on = [time_sleep.wait_for_namespace]
-  name       = %[2]q
-  namespace  = f5xc_namespace.test.name
+  depends_on     = [time_sleep.wait_for_namespace]
+  name           = %[2]q
+  namespace      = f5xc_namespace.test.name
+  trusted_ca_url = "string:///%[3]s"
 }
-`, nsName, name))
+`, nsName, name, certBase64))
 }
 
 func testAccTrustedCaListResourceConfig_allAttributes(nsName, name, description string) string {
+	certs := acctest.MustGenerateTestCertificates()
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
@@ -333,10 +443,11 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 resource "f5xc_trusted_ca_list" "test" {
-  depends_on  = [time_sleep.wait_for_namespace]
-  name        = %[2]q
-  namespace   = f5xc_namespace.test.name
-  description = %[3]q
+  depends_on     = [time_sleep.wait_for_namespace]
+  name           = %[2]q
+  namespace      = f5xc_namespace.test.name
+  trusted_ca_url = "string:///%[4]s"
+  description    = %[3]q
 
   labels = {
     environment = "test"
@@ -348,10 +459,11 @@ resource "f5xc_trusted_ca_list" "test" {
     owner   = "ci-cd"
   }
 }
-`, nsName, name, description))
+`, nsName, name, description, certs.IntermediateCABase64))
 }
 
 func testAccTrustedCaListResourceConfig_withLabels(nsName, name, environment, managedBy string) string {
+	certs := acctest.MustGenerateTestCertificates()
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
@@ -365,19 +477,21 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 resource "f5xc_trusted_ca_list" "test" {
-  depends_on = [time_sleep.wait_for_namespace]
-  name       = %[2]q
-  namespace  = f5xc_namespace.test.name
+  depends_on     = [time_sleep.wait_for_namespace]
+  name           = %[2]q
+  namespace      = f5xc_namespace.test.name
+  trusted_ca_url = "string:///%[5]s"
 
   labels = {
     environment = %[3]q
     managed_by  = %[4]q
   }
 }
-`, nsName, name, environment, managedBy))
+`, nsName, name, environment, managedBy, certs.IntermediateCABase64))
 }
 
 func testAccTrustedCaListResourceConfig_withDescription(nsName, name, description string) string {
+	certs := acctest.MustGenerateTestCertificates()
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
@@ -391,15 +505,17 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 resource "f5xc_trusted_ca_list" "test" {
-  depends_on  = [time_sleep.wait_for_namespace]
-  name        = %[2]q
-  namespace   = f5xc_namespace.test.name
-  description = %[3]q
+  depends_on     = [time_sleep.wait_for_namespace]
+  name           = %[2]q
+  namespace      = f5xc_namespace.test.name
+  trusted_ca_url = "string:///%[4]s"
+  description    = %[3]q
 }
-`, nsName, name, description))
+`, nsName, name, description, certs.IntermediateCABase64))
 }
 
 func testAccTrustedCaListResourceConfig_withAnnotations(nsName, name, value1, value2 string) string {
+	certs := acctest.MustGenerateTestCertificates()
 	return acctest.ConfigCompose(
 		acctest.ProviderConfig(),
 		fmt.Sprintf(`
@@ -413,14 +529,15 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 resource "f5xc_trusted_ca_list" "test" {
-  depends_on = [time_sleep.wait_for_namespace]
-  name       = %[2]q
-  namespace  = f5xc_namespace.test.name
+  depends_on     = [time_sleep.wait_for_namespace]
+  name           = %[2]q
+  namespace      = f5xc_namespace.test.name
+  trusted_ca_url = "string:///%[5]s"
 
   annotations = {
     key1 = %[3]q
     key2 = %[4]q
   }
 }
-`, nsName, name, value1, value2))
+`, nsName, name, value1, value2, certs.IntermediateCABase64))
 }

--- a/internal/provider/waf_exclusion_policy_resource_test.go
+++ b/internal/provider/waf_exclusion_policy_resource_test.go
@@ -4,9 +4,11 @@ package provider_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/internal/acctest"
@@ -331,6 +333,130 @@ func testAccWAFExclusionPolicyResourceImportStateIdFunc(resourceName string) res
 		}
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["namespace"], rs.Primary.Attributes["name"]), nil
 	}
+}
+
+// =============================================================================
+// TEST: Empty plan after apply (no drift)
+// =============================================================================
+func TestAccWAFExclusionPolicyResource_emptyPlan(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	rName := acctest.RandomName("tf-test-waf-exc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_waf_exclusion_policy"),
+		Steps: []resource.TestStep{
+			{Config: testAccWAFExclusionPolicyResourceConfig_basic("", rName)},
+			{Config: testAccWAFExclusionPolicyResourceConfig_basic("", rName), PlanOnly: true, ExpectNonEmptyPlan: false},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Plan checks (create, update, noop)
+// =============================================================================
+func TestAccWAFExclusionPolicyResource_planChecks(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_waf_exclusion_policy.test"
+	rName := acctest.RandomName("tf-test-waf-exc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_waf_exclusion_policy"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_basic("", rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate)},
+				},
+			},
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_withLabels("", rName, "test", "terraform"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)},
+				},
+			},
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_withLabels("", rName, "test", "terraform"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop)},
+				},
+			},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Invalid name validation
+// =============================================================================
+func TestAccWAFExclusionPolicyResource_invalidName(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		Steps: []resource.TestStep{
+			{Config: testAccWAFExclusionPolicyResourceConfig_basic("", "Invalid-NAME"), ExpectError: regexp.MustCompile(`(?i)(invalid|name|must)`)},
+		},
+	})
+}
+
+// =============================================================================
+// TEST: Full lifecycle
+// =============================================================================
+func TestAccWAFExclusionPolicyResource_fullLifecycle(t *testing.T) {
+	acctest.SkipIfNotAccTest(t)
+	acctest.PreCheck(t)
+
+	resourceName := "f5xc_waf_exclusion_policy.test"
+	rName := acctest.RandomName("tf-test-waf-exc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ExternalProviders:        acctest.ExternalProviders,
+		CheckDestroy:             acctest.CheckResourceDestroyed("f5xc_waf_exclusion_policy"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_allAttributes("", rName, "Full lifecycle test"),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts", "disable", "description"},
+				ImportStateIdFunc:       testAccWAFExclusionPolicyResourceImportStateIdFunc(resourceName),
+			},
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_withExclusionRules("", rName),
+				Check:  acctest.CheckResourceExists(resourceName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate)},
+				},
+			},
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_withExclusionRules("", rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				Config: testAccWAFExclusionPolicyResourceConfig_basic("", rName),
+				Check:  acctest.CheckResourceExists(resourceName),
+			},
+		},
+	})
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add expanded TDD test coverage for the final batch of HTTP LB dependency resources: waf_exclusion_policy (5 new), certificate (2 new), certificate_chain (1 new), crl (1 new), bot_defense_app_infrastructure (1 new), trusted_ca_list (3 new)
- Fix bot_defense region enum (AWS regions -> US/EU/ASIA) and add required trusted_ca_url field after v2.1.104 migration
- All 22 HTTP LB dependencies now have expanded test coverage verified against live staging API

Closes #571

## Test plan

- [x] WAF exclusion policy: 10/10 PASS (live staging)
- [x] Certificate: 3/3 PASS (live staging)
- [x] Certificate chain: 2/2 PASS (live staging)
- [x] CRL: 2/2 PASS (live staging)
- [ ] CI checks pass