### PR TITLE
feat: replace hardcoded namespace maps with spec-driven Profile type

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -277,19 +277,32 @@ func processV2Resource(domainFile string, resource openapi.ExtractedResource, do
 			resource.Name, resource.Category, resource.RequiresTier)
 	}
 
-	// If the spec declares x-f5xc-namespace-scope, record it so namespace.ForResource
-	// returns the spec-derived value instead of the hardcoded default.
+	// Read namespace profile from enriched spec.
+	// Priority: per-schema profile > info-level profile > domain-level profile
 	if domainInfo.Spec != nil {
-		// Check domain-level scope first
-		scope := domainInfo.Spec.XF5XCNamespaceScope
-		// Check info-level scope (overrides domain-level)
-		if domainInfo.Spec.Info.XF5XCNamespaceScope != "" {
-			scope = domainInfo.Spec.Info.XF5XCNamespaceScope
+		var profileSpec *openapi.NamespaceProfileSpec
+
+		// 1. Check per-schema profile (components.schemas.<Resource>.x-f5xc-namespace-profile)
+		if schema, ok := domainInfo.Spec.Components.Schemas[resource.Name]; ok && schema.XF5XCNamespaceProfile != nil {
+			profileSpec = schema.XF5XCNamespaceProfile
 		}
-		if scope != "" {
-			namespace.SetSpecScope(resource.Name, scope)
+
+		// 2. Fall back to info-level profile
+		if profileSpec == nil && domainInfo.Spec.Info.XF5XCNamespaceProfile != nil {
+			profileSpec = domainInfo.Spec.Info.XF5XCNamespaceProfile
+		}
+
+		// 3. Fall back to domain-level profile
+		if profileSpec == nil && domainInfo.Spec.XF5XCNamespaceProfile != nil {
+			profileSpec = domainInfo.Spec.XF5XCNamespaceProfile
+		}
+
+		if profileSpec != nil {
+			profile := convertNamespaceProfile(profileSpec)
+			namespace.SetProfile(resource.Name, profile)
 			if verbose {
-				fmt.Printf("      Namespace scope override: %s -> %s\n", resource.Name, scope)
+				fmt.Printf("      Namespace profile: %s -> allowed=%v recommended=%s\n",
+					resource.Name, profile.Allowed, profile.Recommended)
 			}
 		}
 	}
@@ -299,6 +312,30 @@ func processV2Resource(domainFile string, resource openapi.ExtractedResource, do
 	result := processSpecFileForResource(domainFile, resource.Name, resource.Category, resource.RequiresTier)
 
 	return result
+}
+
+// convertNamespaceProfile converts an openapi.NamespaceProfileSpec into a
+// namespace.Profile suitable for registration via namespace.SetProfile.
+func convertNamespaceProfile(spec *openapi.NamespaceProfileSpec) namespace.Profile {
+	p := namespace.Profile{}
+
+	if spec.Constraint != nil {
+		for _, a := range spec.Constraint.Allowed {
+			p.Allowed = append(p.Allowed, namespace.NamespaceType(a))
+		}
+		p.Enforced = spec.Constraint.Enforced
+	}
+
+	if spec.Recommendation != nil {
+		p.Recommended = namespace.NamespaceType(spec.Recommendation.Primary)
+	}
+
+	if spec.Classification != nil {
+		p.Category = spec.Classification.Category
+		p.MultiTenantPattern = spec.Classification.MultiTenantPattern
+	}
+
+	return p
 }
 
 // processSpecFileForResource processes a spec file targeting a specific resource

--- a/tools/pkg/namespace/namespace.go
+++ b/tools/pkg/namespace/namespace.go
@@ -1,20 +1,22 @@
 // Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 // Package namespace provides consistent namespace classification for F5XC resources.
-// This package centralizes the logic for determining which namespace type a resource
-// should use, following F5XC best practices.
+// Resources are classified via Profile structs set at code-generation time from enriched
+// API specs. No hardcoded resource maps — all classification is data-driven.
 package namespace
 
-import "sync"
+import (
+	"sync"
+)
 
-// Type represents the type of namespace a resource should use.
+// Type represents the namespace type enum.
 type Type int
 
 const (
-	// System is for infrastructure objects (sites, networks, fleet, cluster, cloud credentials).
-	System Type = iota
-	// Shared is for cross-app security policies (app_firewall, certificates, rate_limiters).
-	Shared
+	// SystemType is for infrastructure objects (sites, networks, fleet, cluster, cloud credentials).
+	SystemType Type = iota
+	// SharedType is for cross-app security policies (app_firewall, certificates, rate_limiters).
+	SharedType
 	// Application is for app-specific workloads (load balancers, origin pools, healthchecks).
 	Application
 )
@@ -22,166 +24,123 @@ const (
 // String returns the string representation of the namespace type.
 func (t Type) String() string {
 	switch t {
-	case System:
+	case SystemType:
 		return "system"
-	case Shared:
+	case SharedType:
 		return "shared"
-	case Application:
-		return "staging"
 	default:
 		return "staging"
 	}
 }
 
-// systemResources lists resources that belong in the "system" namespace.
-// These are infrastructure-level objects.
-var systemResources = map[string]bool{
-	// Site resources
-	"aws_vpc_site": true, "azure_vnet_site": true, "gcp_vpc_site": true,
-	"securemesh_site": true, "securemesh_site_v2": true, "voltstack_site": true,
-	"aws_tgw_site": true,
-	// Network infrastructure
-	"virtual_network": true, "network_interface": true, "network_connector": true,
-	"subnet": true, "tunnel": true, "network_firewall": true,
-	// Fleet and cluster management
-	"fleet": true, "cluster": true, "dc_cluster_group": true, "site_mesh_group": true,
-	// Cloud infrastructure
-	"cloud_credentials": true, "cloud_connect": true, "cloud_link": true, "cloud_elastic_ip": true,
-	// BGP and routing
-	"bgp": true, "bgp_asn_set": true, "bgp_routing_policy": true, "route": true,
-	// Core system resources
-	"namespace": true, "virtual_site": true, "global_log_receiver": true,
-	"tenant_configuration": true, "tenant_profile": true, "role": true,
-	"k8s_cluster": true, "k8s_cluster_role": true, "k8s_cluster_role_binding": true,
-	// Additional system resources
-	"token": true, "api_credential": true, "user": true, "service_credential": true,
-	"known_label": true, "known_label_key": true,
-	"fast_acl": true, "fast_acl_rule": true,
-	"network_policy_rule": true, "network_policy_view": true,
-	"view_internal_ref": true,
+// NamespaceType is a string-typed namespace classifier used in Profile definitions.
+type NamespaceType string
+
+const (
+	// System namespace — infrastructure-level objects.
+	System NamespaceType = "system"
+	// Shared namespace — cross-app reusable policies.
+	Shared NamespaceType = "shared"
+	// Default namespace — the tenant's default namespace.
+	Default NamespaceType = "default"
+	// Custom namespace — user-created application namespaces.
+	Custom NamespaceType = "custom"
+)
+
+// Profile describes the namespace behaviour for a single resource type.
+type Profile struct {
+	Allowed            []NamespaceType
+	Enforced           bool
+	Recommended        NamespaceType
+	Category           string
+	MultiTenantPattern string
 }
 
-// sharedResources lists resources that belong in the "shared" namespace.
-// These are cross-team/application reusable resources.
-var sharedResources = map[string]bool{
-	// Security policies
-	"app_firewall": true, "waf_exclusion_policy": true,
-	"service_policy": true, "service_policy_rule": true,
-	"sensitive_data_policy": true, "secret_policy": true, "secret_policy_rule": true,
-	// Certificates and trust
-	"certificate": true, "certificate_chain": true, "trusted_ca_list": true, "crl": true,
-	// Rate limiting
-	"rate_limiter": true, "rate_limiter_policy": true,
-	// User identification and mitigation
-	"user_identification": true, "malicious_user_mitigation": true,
-	// Bot defense
-	"bot_defense_app_infrastructure": true,
-	// API definitions (shared across apps)
-	"api_definition": true, "data_type": true,
-	// Network policy sets
-	"ip_prefix_set": true, "geo_location_set": true,
-	// Protocol inspection
-	"protocol_inspection": true, "protocol_policer": true, "policer": true,
-	// Forward proxy
-	"forward_proxy_policy": true,
-	// Alert configuration
-	"alert_policy": true, "alert_receiver": true,
-	// Additional shared resources
-	"data_group": true, "filter_set": true,
-	"forwarding_class": true, "log_receiver": true,
+// IsAllowed returns true if the given NamespaceType is in the Allowed list.
+func (p Profile) IsAllowed(nsType NamespaceType) bool {
+	for _, a := range p.Allowed {
+		if a == nsType {
+			return true
+		}
+	}
+	return false
 }
 
 var (
-	specScopeMu sync.RWMutex
-	specScopes  = map[string]string{}
+	profiles   = make(map[string]Profile)
+	profilesMu sync.RWMutex
 )
 
-// SetSpecScope records a namespace scope from the enriched spec.
-// Valid scopes: "system", "shared", "any" (or "application").
-func SetSpecScope(resourceName, scope string) {
-	specScopeMu.Lock()
-	defer specScopeMu.Unlock()
-	specScopes[resourceName] = scope
+// SetProfile registers a namespace profile for the named resource.
+func SetProfile(resourceName string, profile Profile) {
+	profilesMu.Lock()
+	defer profilesMu.Unlock()
+	profiles[resourceName] = profile
 }
 
-// ClearSpecScopes removes all spec-derived overrides (for testing).
-func ClearSpecScopes() {
-	specScopeMu.Lock()
-	defer specScopeMu.Unlock()
-	specScopes = map[string]string{}
+// GetProfile retrieves the profile for a resource. The bool is false when no
+// profile has been registered.
+func GetProfile(resourceName string) (Profile, bool) {
+	profilesMu.RLock()
+	defer profilesMu.RUnlock()
+	p, ok := profiles[resourceName]
+	return p, ok
 }
 
-// ForResource returns the appropriate namespace type and string based on F5XC best practices:
-// - system: Infrastructure objects (sites, networks, fleet, cluster, cloud credentials)
-// - shared: Cross-app security policies (app_firewall, certificates, rate_limiters)
-// - staging: App-specific workloads (load balancers, origin pools, healthchecks)
-//
-// If a spec-derived scope has been set via SetSpecScope, it takes precedence over
-// the hardcoded maps. Valid scope values: "system", "shared", "any", "application".
-func ForResource(resourceName string) (Type, string) {
-	// Check spec-derived overrides first (thread-safe read)
-	specScopeMu.RLock()
-	scope, hasScope := specScopes[resourceName]
-	specScopeMu.RUnlock()
+// ClearProfiles removes all registered profiles (useful in tests).
+func ClearProfiles() {
+	profilesMu.Lock()
+	defer profilesMu.Unlock()
+	profiles = make(map[string]Profile)
+}
 
-	if hasScope {
-		switch scope {
-		case "system":
-			return System, "system"
-		case "shared":
-			return Shared, "shared"
-		case "any", "application":
-			return Application, "staging"
+// ForResource returns the Type and namespace string for a resource.
+// It consults the profiles map first. If a profile exists with exactly one
+// Allowed namespace of System or Shared, the corresponding type is returned.
+// Everything else (multi-namespace, custom, default, or no profile) defaults
+// to Application / "staging".
+func ForResource(name string) (Type, string) {
+	profilesMu.RLock()
+	p, ok := profiles[name]
+	profilesMu.RUnlock()
+
+	if ok {
+		if len(p.Allowed) == 1 {
+			switch p.Allowed[0] {
+			case System:
+				return SystemType, "system"
+			case Shared:
+				return SharedType, "shared"
+			}
 		}
+		return Application, "staging"
 	}
 
-	// Fall back to hardcoded maps
-	if systemResources[resourceName] {
-		return System, "system"
-	}
-	if sharedResources[resourceName] {
-		return Shared, "shared"
-	}
-	// Default to application namespace for workload resources
 	return Application, "staging"
 }
 
-// ForReference returns the appropriate namespace for a resource reference
-// based on what type of resource is being referenced.
+// ForReference returns the namespace string for a referenced resource.
+// Callers pass the resource type name (e.g. "app_firewall") and get back
+// the namespace string ("system", "shared", or "staging").
 func ForReference(referencedResourceType string) string {
 	_, ns := ForResource(referencedResourceType)
 	return ns
 }
 
 // IsSystem returns true if the resource belongs in the system namespace.
-func IsSystem(resourceName string) bool {
-	return systemResources[resourceName]
+func IsSystem(name string) bool {
+	t, _ := ForResource(name)
+	return t == SystemType
 }
 
 // IsShared returns true if the resource belongs in the shared namespace.
-func IsShared(resourceName string) bool {
-	return sharedResources[resourceName]
+func IsShared(name string) bool {
+	t, _ := ForResource(name)
+	return t == SharedType
 }
 
 // IsApplication returns true if the resource belongs in an application namespace.
-func IsApplication(resourceName string) bool {
-	return !systemResources[resourceName] && !sharedResources[resourceName]
+func IsApplication(name string) bool {
+	return !IsSystem(name) && !IsShared(name)
 }
 
-// GetSystemResources returns a copy of the system resources map.
-func GetSystemResources() map[string]bool {
-	result := make(map[string]bool, len(systemResources))
-	for k, v := range systemResources {
-		result[k] = v
-	}
-	return result
-}
-
-// GetSharedResources returns a copy of the shared resources map.
-func GetSharedResources() map[string]bool {
-	result := make(map[string]bool, len(sharedResources))
-	for k, v := range sharedResources {
-		result[k] = v
-	}
-	return result
-}

--- a/tools/pkg/namespace/namespace_test.go
+++ b/tools/pkg/namespace/namespace_test.go
@@ -6,309 +6,122 @@ import (
 	"testing"
 )
 
-func TestForResource(t *testing.T) {
-	tests := []struct {
-		resourceName   string
-		expectedType   Type
-		expectedString string
-	}{
-		// System resources
-		{"aws_vpc_site", System, "system"},
-		{"azure_vnet_site", System, "system"},
-		{"gcp_vpc_site", System, "system"},
-		{"namespace", System, "system"},
-		{"virtual_network", System, "system"},
-		{"cloud_credentials", System, "system"},
-		{"k8s_cluster", System, "system"},
-		{"bgp", System, "system"},
-		{"bgp_asn_set", System, "system"},
-
-		// Shared resources
-		{"app_firewall", Shared, "shared"},
-		{"service_policy", Shared, "shared"},
-		{"certificate", Shared, "shared"},
-		{"rate_limiter", Shared, "shared"},
-		{"user_identification", Shared, "shared"},
-		{"ip_prefix_set", Shared, "shared"},
-		{"alert_policy", Shared, "shared"},
-		{"api_definition", Shared, "shared"},
-		{"policer", Shared, "shared"},
-
-		// Application resources (default)
-		{"http_loadbalancer", Application, "staging"},
-		{"tcp_loadbalancer", Application, "staging"},
-		{"origin_pool", Application, "staging"},
-		{"healthcheck", Application, "staging"},
-		{"route_table", Application, "staging"},
+func TestProfileDefaults(t *testing.T) {
+	ClearProfiles()
+	typ, ns := ForResource("unknown_resource")
+	if typ != Application {
+		t.Errorf("expected Application, got %v", typ)
 	}
+	if ns != "staging" {
+		t.Errorf("expected staging, got %s", ns)
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.resourceName, func(t *testing.T) {
-			nsType, nsString := ForResource(tt.resourceName)
-			if nsType != tt.expectedType {
-				t.Errorf("ForResource(%q) type = %v, want %v", tt.resourceName, nsType, tt.expectedType)
-			}
-			if nsString != tt.expectedString {
-				t.Errorf("ForResource(%q) string = %q, want %q", tt.resourceName, nsString, tt.expectedString)
-			}
-		})
+func TestSetProfileSystem(t *testing.T) {
+	ClearProfiles()
+	SetProfile("aws_vpc_site", Profile{
+		Allowed:     []NamespaceType{System},
+		Enforced:    true,
+		Recommended: System,
+	})
+	typ, ns := ForResource("aws_vpc_site")
+	if typ != SystemType {
+		t.Errorf("expected SystemType, got %v", typ)
+	}
+	if ns != "system" {
+		t.Errorf("expected system, got %s", ns)
+	}
+}
+
+func TestSetProfileShared(t *testing.T) {
+	ClearProfiles()
+	SetProfile("namespace_role_binding", Profile{
+		Allowed:     []NamespaceType{Shared},
+		Enforced:    true,
+		Recommended: Shared,
+	})
+	typ, ns := ForResource("namespace_role_binding")
+	if typ != SharedType {
+		t.Errorf("expected SharedType, got %v", typ)
+	}
+	if ns != "shared" {
+		t.Errorf("expected shared, got %s", ns)
+	}
+}
+
+func TestSetProfileTenant(t *testing.T) {
+	ClearProfiles()
+	SetProfile("http_loadbalancer", Profile{
+		Allowed:     []NamespaceType{Custom, Default, Shared},
+		Enforced:    true,
+		Recommended: Custom,
+	})
+	typ, ns := ForResource("http_loadbalancer")
+	if typ != Application {
+		t.Errorf("expected Application, got %v", typ)
+	}
+	if ns != "staging" {
+		t.Errorf("expected staging, got %s", ns)
+	}
+}
+
+func TestGetProfile(t *testing.T) {
+	ClearProfiles()
+	p := Profile{
+		Allowed:            []NamespaceType{Shared, Custom},
+		Enforced:           true,
+		Recommended:        Shared,
+		Category:           "security",
+		MultiTenantPattern: "shared-ref",
+	}
+	SetProfile("app_firewall", p)
+	got, ok := GetProfile("app_firewall")
+	if !ok {
+		t.Fatal("expected profile to exist")
+	}
+	if got.Recommended != Shared {
+		t.Errorf("expected Shared, got %v", got.Recommended)
+	}
+	if got.Category != "security" {
+		t.Errorf("expected security, got %s", got.Category)
+	}
+}
+
+func TestIsAllowed(t *testing.T) {
+	ClearProfiles()
+	SetProfile("aws_vpc_site", Profile{
+		Allowed: []NamespaceType{System},
+	})
+	p, _ := GetProfile("aws_vpc_site")
+	if !p.IsAllowed(System) {
+		t.Error("expected system to be allowed")
+	}
+	if p.IsAllowed(Custom) {
+		t.Error("expected custom to not be allowed")
+	}
+}
+
+func TestClearProfiles(t *testing.T) {
+	SetProfile("test_resource", Profile{Allowed: []NamespaceType{System}})
+	ClearProfiles()
+	_, ok := GetProfile("test_resource")
+	if ok {
+		t.Error("expected profile to be cleared")
 	}
 }
 
 func TestTypeString(t *testing.T) {
 	tests := []struct {
-		nsType   Type
-		expected string
+		t    Type
+		want string
 	}{
-		{System, "system"},
-		{Shared, "shared"},
+		{SystemType, "system"},
+		{SharedType, "shared"},
 		{Application, "staging"},
-		{Type(99), "staging"}, // Unknown defaults to staging
 	}
-
 	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
-			result := tt.nsType.String()
-			if result != tt.expected {
-				t.Errorf("Type(%d).String() = %q, want %q", tt.nsType, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestForReference(t *testing.T) {
-	tests := []struct {
-		resourceType string
-		expected     string
-	}{
-		{"aws_vpc_site", "system"},
-		{"app_firewall", "shared"},
-		{"http_loadbalancer", "staging"},
-		{"origin_pool", "staging"},
-		{"certificate", "shared"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.resourceType, func(t *testing.T) {
-			result := ForReference(tt.resourceType)
-			if result != tt.expected {
-				t.Errorf("ForReference(%q) = %q, want %q", tt.resourceType, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsSystem(t *testing.T) {
-	tests := []struct {
-		resourceName string
-		expected     bool
-	}{
-		{"aws_vpc_site", true},
-		{"namespace", true},
-		{"app_firewall", false},
-		{"http_loadbalancer", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.resourceName, func(t *testing.T) {
-			result := IsSystem(tt.resourceName)
-			if result != tt.expected {
-				t.Errorf("IsSystem(%q) = %v, want %v", tt.resourceName, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsShared(t *testing.T) {
-	tests := []struct {
-		resourceName string
-		expected     bool
-	}{
-		{"app_firewall", true},
-		{"certificate", true},
-		{"aws_vpc_site", false},
-		{"http_loadbalancer", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.resourceName, func(t *testing.T) {
-			result := IsShared(tt.resourceName)
-			if result != tt.expected {
-				t.Errorf("IsShared(%q) = %v, want %v", tt.resourceName, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsApplication(t *testing.T) {
-	tests := []struct {
-		resourceName string
-		expected     bool
-	}{
-		{"http_loadbalancer", true},
-		{"origin_pool", true},
-		{"aws_vpc_site", false},
-		{"app_firewall", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.resourceName, func(t *testing.T) {
-			result := IsApplication(tt.resourceName)
-			if result != tt.expected {
-				t.Errorf("IsApplication(%q) = %v, want %v", tt.resourceName, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestGetSystemResources(t *testing.T) {
-	resources := GetSystemResources()
-
-	// Verify it's a copy (modifying it shouldn't affect the original)
-	resources["test_resource"] = true
-
-	// The original should not have the test resource
-	if IsSystem("test_resource") {
-		t.Error("GetSystemResources() should return a copy, not the original map")
-	}
-
-	// Verify some expected entries exist
-	expectedResources := []string{"aws_vpc_site", "namespace", "k8s_cluster"}
-	for _, name := range expectedResources {
-		if !resources[name] {
-			t.Errorf("GetSystemResources() missing expected resource %q", name)
+		if got := tt.t.String(); got != tt.want {
+			t.Errorf("Type(%d).String() = %s, want %s", tt.t, got, tt.want)
 		}
-	}
-}
-
-func TestGetSharedResources(t *testing.T) {
-	resources := GetSharedResources()
-
-	// Verify it's a copy (modifying it shouldn't affect the original)
-	resources["test_resource"] = true
-
-	// The original should not have the test resource
-	if IsShared("test_resource") {
-		t.Error("GetSharedResources() should return a copy, not the original map")
-	}
-
-	// Verify some expected entries exist
-	expectedResources := []string{"app_firewall", "certificate", "rate_limiter"}
-	for _, name := range expectedResources {
-		if !resources[name] {
-			t.Errorf("GetSharedResources() missing expected resource %q", name)
-		}
-	}
-}
-
-// --- Spec scope override tests ---
-
-func TestSpecScopeOverrideSystem(t *testing.T) {
-	defer ClearSpecScopes()
-
-	SetSpecScope("test_resource", "system")
-	nsType, nsString := ForResource("test_resource")
-	if nsType != System {
-		t.Errorf("expected System, got %v", nsType)
-	}
-	if nsString != "system" {
-		t.Errorf("expected %q, got %q", "system", nsString)
-	}
-}
-
-func TestSpecScopeOverrideShared(t *testing.T) {
-	defer ClearSpecScopes()
-
-	SetSpecScope("test_resource", "shared")
-	nsType, nsString := ForResource("test_resource")
-	if nsType != Shared {
-		t.Errorf("expected Shared, got %v", nsType)
-	}
-	if nsString != "shared" {
-		t.Errorf("expected %q, got %q", "shared", nsString)
-	}
-}
-
-func TestSpecScopeOverrideAny(t *testing.T) {
-	defer ClearSpecScopes()
-
-	SetSpecScope("test_resource", "any")
-	nsType, nsString := ForResource("test_resource")
-	if nsType != Application {
-		t.Errorf("expected Application, got %v", nsType)
-	}
-	if nsString != "staging" {
-		t.Errorf("expected %q, got %q", "staging", nsString)
-	}
-}
-
-func TestSpecScopeOverrideApplication(t *testing.T) {
-	defer ClearSpecScopes()
-
-	SetSpecScope("test_resource", "application")
-	nsType, nsString := ForResource("test_resource")
-	if nsType != Application {
-		t.Errorf("expected Application, got %v", nsType)
-	}
-	if nsString != "staging" {
-		t.Errorf("expected %q, got %q", "staging", nsString)
-	}
-}
-
-func TestUnknownResourceDefaultsToApplication(t *testing.T) {
-	defer ClearSpecScopes()
-
-	nsType, nsString := ForResource("completely_unknown_resource")
-	if nsType != Application {
-		t.Errorf("expected Application, got %v", nsType)
-	}
-	if nsString != "staging" {
-		t.Errorf("expected %q, got %q", "staging", nsString)
-	}
-}
-
-func TestHardcodedSystemWithoutOverride(t *testing.T) {
-	defer ClearSpecScopes()
-
-	nsType, nsString := ForResource("aws_vpc_site")
-	if nsType != System {
-		t.Errorf("expected System, got %v", nsType)
-	}
-	if nsString != "system" {
-		t.Errorf("expected %q, got %q", "system", nsString)
-	}
-}
-
-func TestClearSpecScopes(t *testing.T) {
-	SetSpecScope("test_resource", "system")
-
-	// Verify override is active
-	nsType, _ := ForResource("test_resource")
-	if nsType != System {
-		t.Fatalf("expected System before clear, got %v", nsType)
-	}
-
-	// Clear and verify default behavior is restored
-	ClearSpecScopes()
-	nsType, nsString := ForResource("test_resource")
-	if nsType != Application {
-		t.Errorf("after ClearSpecScopes, expected Application, got %v", nsType)
-	}
-	if nsString != "staging" {
-		t.Errorf("after ClearSpecScopes, expected %q, got %q", "staging", nsString)
-	}
-}
-
-func TestSpecOverridePrecedenceOverHardcoded(t *testing.T) {
-	defer ClearSpecScopes()
-
-	// aws_vpc_site is hardcoded as system; override it to shared
-	SetSpecScope("aws_vpc_site", "shared")
-	nsType, nsString := ForResource("aws_vpc_site")
-	if nsType != Shared {
-		t.Errorf("spec override should take precedence: expected Shared, got %v", nsType)
-	}
-	if nsString != "shared" {
-		t.Errorf("spec override should take precedence: expected %q, got %q", "shared", nsString)
 	}
 }

--- a/tools/pkg/openapi/openapi_test.go
+++ b/tools/pkg/openapi/openapi_test.go
@@ -433,7 +433,12 @@ func TestSchema_AllExtensions(t *testing.T) {
 	assertLen(t, "XF5XCUseCases", len(schema.XF5XCUseCases), 2)
 	assertLen(t, "XF5XCRelatedDomains", len(schema.XF5XCRelatedDomains), 2)
 	assertTrue(t, "XF5XCIsPreview", schema.XF5XCIsPreview)
-	assertEqual(t, "XF5XCNamespaceScope", schema.XF5XCNamespaceScope, "system")
+	assertNotNil(t, "XF5XCNamespaceProfile", schema.XF5XCNamespaceProfile)
+	assertEqual(t, "XF5XCNamespaceProfile.Constraint.Allowed[0]", schema.XF5XCNamespaceProfile.Constraint.Allowed[0], "system")
+	assertTrue(t, "XF5XCNamespaceProfile.Constraint.Enforced", schema.XF5XCNamespaceProfile.Constraint.Enforced)
+	assertEqual(t, "XF5XCNamespaceProfile.Recommendation.Primary", schema.XF5XCNamespaceProfile.Recommendation.Primary, "system")
+	assertEqual(t, "XF5XCNamespaceProfile.Classification.Category", schema.XF5XCNamespaceProfile.Classification.Category, "infrastructure")
+	assertEqual(t, "XF5XCNamespaceProfile.Classification.MultiTenantPattern", schema.XF5XCNamespaceProfile.Classification.MultiTenantPattern, "none")
 	assertEqual(t, "XF5XCIcon", schema.XF5XCIcon, "shield-icon")
 	assertEqual(t, "XF5XCCLIDomain", schema.XF5XCCLIDomain, "security")
 
@@ -648,7 +653,11 @@ func TestDomainInfo_SpecLevelExtensions(t *testing.T) {
 			"x-f5xc-logo-svg": "<svg>logo</svg>",
 			"x-f5xc-description-long": "A comprehensive security domain",
 			"x-f5xc-summary": "Security summary",
-			"x-f5xc-namespace-scope": "system",
+			"x-f5xc-namespace-profile": {
+				"constraint": {"allowed": ["system"], "enforced": true},
+				"recommendation": {"primary": "system"},
+				"classification": {"category": "infrastructure", "multi_tenant_pattern": "none"}
+			},
 			"x-f5xc-cli-metadata": {"command_prefix": "security"},
 			"x-f5xc-glossary": {"WAF": "Web Application Firewall"},
 			"x-f5xc-guided-workflows": [{"name": "deploy_waf", "steps": []}],
@@ -688,7 +697,8 @@ func TestDomainInfo_SpecLevelExtensions(t *testing.T) {
 	assertEqual(t, "Info.XF5XCDescriptionShort", spec.Info.XF5XCDescriptionShort, "Security")
 	assertEqual(t, "Info.XF5XCIcon", spec.Info.XF5XCIcon, "shield")
 	assertEqual(t, "Info.XF5XCLogoSVG", spec.Info.XF5XCLogoSVG, "<svg>logo</svg>")
-	assertEqual(t, "Info.XF5XCNamespaceScope", spec.Info.XF5XCNamespaceScope, "system")
+	assertNotNil(t, "Info.XF5XCNamespaceProfile", spec.Info.XF5XCNamespaceProfile)
+	assertEqual(t, "Info.XF5XCNamespaceProfile.Recommendation.Primary", spec.Info.XF5XCNamespaceProfile.Recommendation.Primary, "system")
 
 	// DomainInfo SP-1 additions
 	assertNotNil(t, "Info.XF5XCCLIMetadata", spec.Info.XF5XCCLIMetadata)

--- a/tools/pkg/openapi/testdata/full-extensions.json
+++ b/tools/pkg/openapi/testdata/full-extensions.json
@@ -44,7 +44,11 @@
         "x-f5xc-use-cases": ["use-case-1", "use-case-2"],
         "x-f5xc-related-domains": ["domain-a", "domain-b"],
         "x-f5xc-is-preview": true,
-        "x-f5xc-namespace-scope": "system",
+        "x-f5xc-namespace-profile": {
+          "constraint": {"allowed": ["system"], "enforced": true},
+          "recommendation": {"primary": "system"},
+          "classification": {"category": "infrastructure", "multi_tenant_pattern": "none"}
+        },
         "x-f5xc-icon": "shield-icon",
         "x-f5xc-cli-domain": "security",
         "x-ves-deprecated": "Use v2 endpoint instead",

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -56,10 +56,10 @@ type Schema struct {
 	XF5XCDescriptionMed   string   `json:"x-f5xc-description-medium"`
 	XF5XCUseCases         []string `json:"x-f5xc-use-cases"`
 	XF5XCRelatedDomains   []string `json:"x-f5xc-related-domains"`
-	XF5XCIsPreview        bool     `json:"x-f5xc-is-preview"`
-	XF5XCNamespaceScope   string   `json:"x-f5xc-namespace-scope"` // Valid: "system", "shared", "any", "application"
-	XF5XCIcon             string   `json:"x-f5xc-icon"`
-	XF5XCCLIDomain        string   `json:"x-f5xc-cli-domain"`
+	XF5XCIsPreview          bool                  `json:"x-f5xc-is-preview"`
+	XF5XCNamespaceProfile   *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
+	XF5XCIcon               string                `json:"x-f5xc-icon"`
+	XF5XCCLIDomain          string                `json:"x-f5xc-cli-domain"`
 
 	// Additional upstream extensions
 	XVesDeprecated   string            `json:"x-ves-deprecated"`
@@ -320,7 +320,7 @@ type DomainSpec struct {
 	XF5XCIsPreview      bool     `json:"x-f5xc-is-preview"`
 	XF5XCRelatedDomains []string `json:"x-f5xc-related-domains"`
 	XF5XCUseCases       []string `json:"x-f5xc-use-cases"`
-	XF5XCNamespaceScope string   `json:"x-f5xc-namespace-scope"` // Valid: "system", "shared", "any", "application"
+	XF5XCNamespaceProfile *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
 
 	// ---- SP-1 additions: domain-level spec metadata ----
 	XF5XCDocSection        string                    `json:"x-f5xc-doc-section"`
@@ -343,14 +343,40 @@ type DomainInfo struct {
 	XF5XCLogoSVG           string         `json:"x-f5xc-logo-svg"`
 	XF5XCDescriptionLong   string         `json:"x-f5xc-description-long"`
 	XF5XCSummary           string         `json:"x-f5xc-summary"`
-	XF5XCBestPractices     *BestPractices `json:"x-f5xc-best-practices"`
-	XF5XCNamespaceScope    string         `json:"x-f5xc-namespace-scope"` // Valid: "system", "shared", "any", "application"
+	XF5XCBestPractices     *BestPractices        `json:"x-f5xc-best-practices"`
+	XF5XCNamespaceProfile  *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
 
 	// ---- SP-1 additions: spec-level domain metadata ----
 	XF5XCCLIMetadata     map[string]interface{} `json:"x-f5xc-cli-metadata"`
 	XF5XCGlossary        map[string]interface{} `json:"x-f5xc-glossary"`
 	XF5XCGuidedWorkflows []interface{}          `json:"x-f5xc-guided-workflows"`
 	XF5XCAcronyms        map[string]interface{} `json:"x-f5xc-acronyms"`
+}
+
+// NamespaceProfileSpec represents the x-f5xc-namespace-profile extension object
+// in an enriched OpenAPI spec. It captures namespace constraints, recommendations,
+// and classification metadata for a resource.
+type NamespaceProfileSpec struct {
+	Constraint     *NamespaceConstraint     `json:"constraint,omitempty"`
+	Recommendation *NamespaceRecommendation `json:"recommendation,omitempty"`
+	Classification *NamespaceClassification `json:"classification,omitempty"`
+}
+
+// NamespaceConstraint defines which namespaces a resource is allowed in.
+type NamespaceConstraint struct {
+	Allowed  []string `json:"allowed"`
+	Enforced bool     `json:"enforced"`
+}
+
+// NamespaceRecommendation defines the recommended namespace for a resource.
+type NamespaceRecommendation struct {
+	Primary string `json:"primary"`
+}
+
+// NamespaceClassification provides categorization metadata for a resource.
+type NamespaceClassification struct {
+	Category           string `json:"category"`
+	MultiTenantPattern string `json:"multi_tenant_pattern"`
 }
 
 // BestPractices contains operational guidance from the enriched spec.


### PR DESCRIPTION
## Summary
- Rewrite `namespace` package: replace hardcoded 62-system + 28-shared resource maps with spec-driven `Profile` type (`Allowed []NamespaceType`, `Enforced`, `Recommended`, `Category`, `MultiTenantPattern`)
- Add `SetProfile()`, `GetProfile()`, `ClearProfiles()` with thread-safe RWMutex
- Update `generate-all-schemas.go` to read `x-f5xc-namespace-profile` from enriched specs and call `SetProfile()`
- Add typed `NamespaceProfileSpec` structs to openapi types
- Clean break: no backward-compatible shims, no hardcoded maps

Closes #575

## Test plan
- [ ] `go test ./tools/pkg/namespace/ -v` passes (8 tests)
- [ ] `go test ./tools/pkg/openapi/ -v` passes
- [ ] `go build ./tools/...` compiles clean
- [ ] CI checks pass