### PR TITLE
fix: generator produces valid HCL for map body placeholders in test examples

### DIFF
--- a/tools/generate-test-examples.go
+++ b/tools/generate-test-examples.go
@@ -208,6 +208,8 @@ func extractHCL(funcBody string) string {
 func cleanConfig(config string) string {
 	config = strings.TrimSpace(config)
 
+	config = regexp.MustCompile(`%\[\d+\]s(\s*)\}`).ReplaceAllString(config, "    example-key = \"example-value\"\n$1}")
+
 	config = regexp.MustCompile(`%\[1\]q`).ReplaceAllString(config, `"example"`)
 	config = regexp.MustCompile(`%\[1\]s`).ReplaceAllString(config, "example")
 	config = regexp.MustCompile(`%\[2\]q`).ReplaceAllString(config, `"example-value"`)


### PR DESCRIPTION
## Summary

- Added a map-body-aware regex in `cleanConfig()` that detects `%[N]s` placeholders followed by a closing brace and substitutes a valid `key = "value"` pair
- Fixes terraform fmt failures on auto-regenerate PRs where map body placeholders were replaced with bare strings instead of valid HCL

Closes #601

## Test plan

- [ ] CI checks pass
- [ ] On-merge auto-regeneration workflow produces valid HCL that passes `terraform fmt`

## Post-merge cleanup

After this merges and the on-merge auto-regeneration runs successfully, close these stale auto-regenerate issues:
- #525
- #529
- #533
- #597

Also close PR #598 (superseded by the new auto-regeneration).