### PR TITLE
refactor: remove dead GetResourceAIMetadata with hardcoded namespace map, annotate parsed-not-consumed fields

### DIFF
--- a/tools/pkg/description/description.go
+++ b/tools/pkg/description/description.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/f5xc-salesdemos/terraform-provider-f5xc/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-f5xc/tools/pkg/resource"
 )
 
 // Clean removes example annotations, validation rules, internal vendor extensions,
@@ -198,40 +197,6 @@ func FormatEnum(desc string, enumValues []interface{}) string {
 		return fmt.Sprintf("%s %s", aiPrefix, humanSuffix)
 	}
 	return fmt.Sprintf("%s %s %s", aiPrefix, desc, humanSuffix)
-}
-
-// GetResourceAIMetadata generates AI-parseable metadata prefix for a resource.
-// Format: [Category: X] [Namespace: required|optional] [DependsOn: res1, res2]
-func GetResourceAIMetadata(resourceName string) string {
-	var parts []string
-
-	// Add category if known
-	if category, ok := resource.AICategories[resourceName]; ok {
-		parts = append(parts, fmt.Sprintf("[Category: %s]", category))
-	}
-
-	// Add namespace requirement
-	// Most F5 XC resources require a namespace except for system-level resources
-	systemResources := map[string]bool{
-		"namespace": true, "tenant": true, "role": true, "allowed_tenant": true,
-		"dns_zone": true, "dns_domain": true, "virtual_site": true,
-		"cloud_credentials": true, "certificate": true, "trusted_ca_list": true,
-	}
-	if systemResources[resourceName] {
-		parts = append(parts, "[Namespace: not_required]")
-	} else {
-		parts = append(parts, "[Namespace: required]")
-	}
-
-	// Add dependencies if known
-	if deps, ok := resource.Dependencies[resourceName]; ok && len(deps) > 0 {
-		parts = append(parts, fmt.Sprintf("[DependsOn: %s]", strings.Join(deps, ", ")))
-	}
-
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.Join(parts, " ")
 }
 
 // TransformResourceDescription converts technical API descriptions into user-friendly

--- a/tools/pkg/description/description_test.go
+++ b/tools/pkg/description/description_test.go
@@ -510,19 +510,6 @@ func TestExtractCapability(t *testing.T) {
 	}
 }
 
-func TestGetResourceAIMetadata(t *testing.T) {
-	// Basic smoke test — depends on resource.AICategories and resource.Dependencies
-	result := GetResourceAIMetadata("namespace")
-	if !strings.Contains(result, "[Namespace: not_required]") {
-		t.Errorf("GetResourceAIMetadata('namespace') = %q, want to contain '[Namespace: not_required]'", result)
-	}
-
-	result2 := GetResourceAIMetadata("http_loadbalancer")
-	if !strings.Contains(result2, "[Namespace: required]") {
-		t.Errorf("GetResourceAIMetadata('http_loadbalancer') = %q, want to contain '[Namespace: required]'", result2)
-	}
-}
-
 func TestTransformResourceDescription(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -86,7 +86,8 @@ type Schema struct {
 	XF5XCRecommendedValue     interface{} `json:"x-f5xc-recommended-value"`
 	XF5XCMinimumConfiguration interface{} `json:"x-f5xc-minimum-configuration"`
 
-	// ---- SP-1 additions: schema-level extensions ----
+	// Deserialized from enriched specs for lossless round-tripping.
+	// No generation code consumes these yet.
 	XF5XCValidation      map[string]interface{} `json:"x-f5xc-validation"`
 	XF5XCDefaults        map[string]interface{} `json:"x-f5xc-defaults"`
 	XF5XCConditions      map[string]interface{} `json:"x-f5xc-conditions"`


### PR DESCRIPTION
## Summary
- Delete dead `GetResourceAIMetadata()` function and its test — had hardcoded 9-resource `systemResources` map, was never called from production code
- Remove unused `resource` package import from description.go
- Annotate 5 parsed-not-consumed extension fields in types.go Schema struct (validation, defaults, conditions, completion, uniqueness) — preserved for lossless deserialization

## Test plan
- [ ] `go test ./tools/pkg/description/...` passes
- [ ] `go build ./tools/...` compiles clean

Closes #607