### PR TITLE
fix: add version constraint to time provider required_providers block

### DIFF
--- a/tools/generate-test-examples.go
+++ b/tools/generate-test-examples.go
@@ -77,7 +77,7 @@ func main() {
 			}
 
 			if strings.Contains(cleaned, "time_sleep") {
-				cleaned = "terraform {\n  required_providers {\n    time = {\n      source = \"hashicorp/time\"\n    }\n  }\n}\n\n" + cleaned
+				cleaned = "terraform {\n  required_providers {\n    time = {\n      source  = \"hashicorp/time\"\n      version = \">= 0.9.0\"\n    }\n  }\n}\n\n" + cleaned
 			}
 
 			if err := os.WriteFile(outPath, []byte(header+cleaned), 0644); err != nil {


### PR DESCRIPTION
## Summary

- Add `version = ">= 0.9.0"` to the `hashicorp/time` required_providers block in `tools/generate-test-examples.go`
- The previous fix added the `source` field but omitted the `version` constraint, which the tflint `terraform_required_providers` rule requires
- Verified locally with tflint 0.62.1 — all example directories pass clean

Closes #617

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] On-merge auto-regeneration produces example files with both `source` and `version` fields
- [ ] tflint passes on all regenerated example directories

## Post-merge cleanup

After this merges and on-merge auto-regeneration succeeds with clean CI, close these stale auto-regenerate issues and PRs: #525, #529, #533, #597, #598, #604, #610, #616