### PR TITLE
feat: add repository_dispatch trigger for enriched-specs-updated events

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -8,6 +8,8 @@
 name: Sync OpenAPI Specs
 
 on:
+  repository_dispatch:
+    types: [enriched-specs-updated]
   schedule:
     # 7am Atlantic Time (11:00 UTC during AST, 10:00 UTC during ADT)
     - cron: '0 11 * * *'


### PR DESCRIPTION
## Summary

- Add `repository_dispatch` trigger with `enriched-specs-updated` event type to the sync-openapi workflow
- Enables automatic spec synchronization when the api-specs-enriched repo dispatches update events
- Complements existing schedule and manual triggers for near-real-time sync

Closes #629

## Test plan

- [ ] CI checks pass
- [ ] Verify workflow YAML is valid and triggers are correctly defined
- [ ] Confirm repository_dispatch event type matches the upstream dispatch event name