### PR TITLE
fix: include AI metadata and llms-txt generators in on-merge regeneration

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -354,6 +354,8 @@ jobs:
           go run tools/generate-test-examples.go
           scripts/go-retry.sh 3 tfplugindocs generate
           go run tools/transform-docs.go
+          go run tools/generate-ai-metadata.go
+          go run tools/generate-llms-txt.go
 
       - name: Clean build artifacts
         run: |


### PR DESCRIPTION
## Summary

- Add `go run tools/generate-ai-metadata.go` and `go run tools/generate-llms-txt.go` to the "Regenerate documentation" step in `on-merge.yml`
- These two generator calls were present in `_generate-docs.yml` but missing from the on-merge workflow, causing auto-regeneration PRs to omit `docs/_llms-txt/` and `docs/resources/*.ai.json` files

Closes #670

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify the on-merge workflow YAML is valid
- [ ] After merge, confirm the next auto-regeneration PR includes AI metadata and llms-txt output