### PR TITLE
docs: add AI-consumable documentation section to provider index template

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -150,4 +150,12 @@ resource "f5xc_http_loadbalancer" "example" {
 
 Browse the documentation sidebar for the complete list of resources and data sources organized by category.
 
-<!-- Template version: 1.1.0 - Remove deprecated MCP configuration -->
+## AI-Consumable Documentation
+
+For AI assistants and tools, this provider publishes machine-readable documentation:
+
+- **[llms.txt](llms.txt)** — Entry point with provider identity, syntax rules, and category index
+- **Per-resource files** — Self-contained text files at `_llms-txt/resources/<name>.txt` with required fields, OneOf groups, minimal valid configs, and dependency chains
+- **AI JSON metadata** — Machine-readable schemas at `resources/<name>.ai.json`
+
+<!-- Template version: 1.2.0 - Add AI-consumable documentation section -->


### PR DESCRIPTION
## Summary

- Add "AI-Consumable Documentation" section to `templates/index.md.tmpl` documenting the llms.txt hierarchy, per-resource text files, and AI JSON metadata
- Bump template version from 1.1.0 to 1.2.0
- This template change will trigger doc regeneration which publishes the new `_llms-txt/` hierarchy

Closes #672

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify the template renders correctly during doc regeneration