### PR TITLE
fix: resolve markdown lint errors in llms-txt generator

### DIFF
--- a/tools/generate-llms-txt.go
+++ b/tools/generate-llms-txt.go
@@ -806,7 +806,7 @@ func generateL0(config *LLMsConfig, categories []CategoryInfo) error {
 
 	// Header
 	sb.WriteString("# F5 Distributed Cloud Terraform Provider\n\n")
-	sb.WriteString(fmt.Sprintf("> Provider: %s | Registry: %s\n\n",
+	sb.WriteString(fmt.Sprintf("> Provider: %s | Registry: <%s>\n\n",
 		config.Deprecation.Canonical.Provider,
 		config.Deprecation.Canonical.Registry))
 	sb.WriteString(fmt.Sprintf("DEPRECATED — do not use: %s\n\n",
@@ -885,14 +885,12 @@ func generateL1(cat CategoryInfo) error {
 		sb.WriteString(fmt.Sprintf("- [%s](_llms-txt/resources/%s.txt) : %s\n",
 			res.Name, res.Name, desc))
 	}
-	sb.WriteString("\n")
 
-	// Dependency chain (simplified)
+	// Dependency chain (only if there are known dependencies)
 	if len(cat.Resources) > 0 {
-		sb.WriteString("## Dependency Chain\n\n")
-		// Build a simple chain for key resources
 		deps := buildCategoryDependencyChain(cat.Resources)
 		if deps != "" {
+			sb.WriteString("\n## Dependency Chain\n\n")
 			sb.WriteString(deps + "\n")
 		}
 	}
@@ -990,8 +988,12 @@ func generateL2(res ResourceInfo, reverseDeps map[string][]string) error {
 	// Minimal Valid Config
 	if res.MinimalConfig != "" {
 		sb.WriteString("## Minimal Valid Config\n\n")
+		sb.WriteString("```terraform\n")
 		sb.WriteString(res.MinimalConfig)
-		sb.WriteString("\n\n")
+		if !strings.HasSuffix(res.MinimalConfig, "\n") {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("```\n\n")
 	}
 
 	// Dependencies


### PR DESCRIPTION
## Summary

- Fix MD012 (double blank lines) in L1 category files by moving the trailing blank line into the dependency chain conditional so it only emits when the section is written
- Fix MD034 (bare URL) in L0 file by wrapping the registry URL in angle brackets
- Fix missing code fences in L2 resource files by adding triple-backtick terraform fencing around minimal valid config blocks

Closes #676

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Regenerated `docs/llms.txt` and `docs/_llms-txt/` files pass markdownlint
- [ ] L0, L1, and L2 output files render correctly