### PR TITLE
fix: collapse short JSON arrays in ai-metadata generator for biome compliance

### DIFF
--- a/tools/generate-ai-metadata.go
+++ b/tools/generate-ai-metadata.go
@@ -120,12 +120,64 @@ func processFile(mdPath string) error {
 		return fmt.Errorf("marshal %s: %w", name, err)
 	}
 
+	// Collapse short string arrays onto one line to satisfy biome formatting.
+	formatted := collapseShortArrays(out, 120)
+
 	outPath := filepath.Join("docs/resources", name+".ai.json")
-	if err := os.WriteFile(outPath, append(out, '\n'), 0644); err != nil {
+	if err := os.WriteFile(outPath, append(formatted, '\n'), 0644); err != nil {
 		return fmt.Errorf("write %s: %w", outPath, err)
 	}
 	fmt.Printf("Generated: %s\n", outPath)
 	return nil
+}
+
+// collapseShortArrays rewrites multi-line JSON arrays of strings onto a single
+// line when the collapsed form fits within maxWidth. This produces biome-
+// compatible output without changing semantics.
+func collapseShortArrays(src []byte, maxWidth int) []byte {
+	lines := strings.Split(string(src), "\n")
+	var result []string
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasSuffix(trimmed, "[") && !strings.Contains(trimmed, "]") {
+			var elements []string
+			allStrings := true
+			j := i + 1
+			for j < len(lines) {
+				elemTrimmed := strings.TrimSpace(lines[j])
+				if elemTrimmed == "]" || elemTrimmed == "]," {
+					break
+				}
+				clean := strings.TrimSuffix(elemTrimmed, ",")
+				if !strings.HasPrefix(clean, "\"") || !strings.HasSuffix(clean, "\"") {
+					allStrings = false
+					break
+				}
+				elements = append(elements, clean)
+				j++
+			}
+			if allStrings && j < len(lines) {
+				closer := strings.TrimSpace(lines[j])
+				trailingComma := strings.HasSuffix(closer, ",")
+				prefix := strings.TrimSuffix(line, "[")
+				collapsed := prefix + "[" + strings.Join(elements, ", ") + "]"
+				if trailingComma {
+					collapsed += ","
+				}
+				if len(collapsed) <= maxWidth {
+					result = append(result, collapsed)
+					i = j + 1
+					continue
+				}
+			}
+		}
+		result = append(result, line)
+		i++
+	}
+	return []byte(strings.Join(result, "\n"))
 }
 
 // buildMetadata constructs the AIMetadata for one resource.


### PR DESCRIPTION
## Summary

- Added `collapseShortArrays()` post-processing function to `tools/generate-ai-metadata.go` that rewrites multi-line JSON string arrays onto a single line when they fit within the 120-char line width
- This fixes 105 biome formatting errors that were blocking the auto-regeneration PR, since `json.MarshalIndent` produces multi-line arrays that biome expects to be collapsed

Closes #680

## Test plan

- [ ] CI checks pass (biome no longer reports formatting errors on generated `.ai.json` files)
- [ ] Generated `.ai.json` files are semantically identical (valid JSON with same data)
- [ ] Auto-regeneration workflow produces biome-compliant JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)