### PR TITLE
fix: truncate descriptions at word boundaries in llms-txt generator

### DIFF
--- a/tools/generate-llms-txt.go
+++ b/tools/generate-llms-txt.go
@@ -779,6 +779,17 @@ func groupByCategory(resources []ResourceInfo) []CategoryInfo {
 	return categories
 }
 
+func truncateAtWord(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	cut := strings.LastIndex(s[:maxLen-3], " ")
+	if cut <= 0 {
+		cut = maxLen - 3
+	}
+	return s[:cut] + "..."
+}
+
 func categorySlug(name string) string {
 	slug := strings.ToLower(name)
 	slug = strings.ReplaceAll(slug, " ", "-")
@@ -878,10 +889,7 @@ func generateL1(cat CategoryInfo) error {
 	// Resources
 	sb.WriteString("## Resources\n\n")
 	for _, res := range cat.Resources {
-		desc := res.Description
-		if len(desc) > 80 {
-			desc = desc[:77] + "..."
-		}
+		desc := truncateAtWord(res.Description, 80)
 		sb.WriteString(fmt.Sprintf("- [%s](_llms-txt/resources/%s.txt) : %s\n",
 			res.Name, res.Name, desc))
 	}


### PR DESCRIPTION
## Summary

- Add `truncateAtWord()` function to `tools/generate-llms-txt.go` that finds the last space before the character limit and appends `"..."` instead of cutting mid-word
- Replace the fixed-position truncation in `generateL1()` with the new word-boundary-aware function
- Fixes codespell CI failures on auto-regeneration PRs caused by truncated word fragments (e.g., "healt", "exis")

Closes #684

## Test plan

- [ ] CI checks pass (lint, codespell)
- [ ] Auto-regenerated L1 category files no longer contain truncated word fragments