### PR TITLE
fix(service_policy): add allow_all_requests and deny_all_requests to OneOf comment

### DIFF
--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -527,7 +527,7 @@ func addResourceSpecificConfig(sb *strings.Builder, resourceName string, schema 
 
 	case "service_policy":
 		sb.WriteString("\n  # Service Policy configuration\n")
-		sb.WriteString("  // One of the arguments from this list \"allow_list deny_list rule_list\" must be set\n\n")
+		sb.WriteString("  // One of the arguments from this list \"allow_all_requests allow_list deny_all_requests deny_list rule_list\" must be set\n\n")
 		sb.WriteString("  rule_list {\n")
 		sb.WriteString("    rules {\n")
 		sb.WriteString("      metadata {\n")


### PR DESCRIPTION
## Summary

- Fixes `tools/generate-examples.go` hardcoded OneOf comment for `service_policy` — was missing `allow_all_requests` and `deny_all_requests` from the 5-option group
- CI will regenerate `examples/resources/f5xc_service_policy/resource.tf`, `docs/resources/service_policy.md`, and `docs/terraform-llms-index.json` with the correct full oneOf list

## Root cause

Line 530 of `generate-examples.go` had:
```go
"allow_list deny_list rule_list"  // only 3 of 5 options
```

The provider schema (`service_policy_resource.go`) already documents all 5 correctly:
```
[OneOf: allow_all_requests, allow_list, deny_all_requests, deny_list, rule_list]
```

## Impact

`terraform-llms-index.json` was missing `allow_all_requests` and `deny_all_requests`, causing xcsh to not reliably use `allow_all_requests {}` for "allow all traffic" service policies — leading to intermittent CRUD benchmark failures.

## Test plan

- [ ] CI passes and regenerates affected files
- [ ] `docs/terraform-llms-index.json` shows all 5 options in service_policy oneOf group
- [ ] CRUD benchmark service_policy phrases pass consistently

Closes #724