### PR TITLE
fix(ci): run biome format on terraform-llms-index.json after regeneration

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -466,6 +466,10 @@ jobs:
                       open(ds_file, 'w').write(content.rstrip() + '\n' + output_block)
           "
 
+      - name: Format generated JSON with Biome
+        run: |
+          npx --yes @biomejs/biome format --write docs/terraform-llms-index.json || true
+
       - name: Check for changes
         id: check
         run: |


### PR DESCRIPTION
## Summary

Adds a `biome format --write` step to the on-merge workflow immediately after files are generated. The `generate-llms-txt.go` tool outputs JSON with multi-line pretty-print format, but Biome expects compact arrays — this causes the lint check on every auto-regenerate PR to fail.

## Test plan

- [ ] CI passes
- [ ] After merging, the next auto-regenerate PR passes lint without needing a manual fix

Closes #730