### PR TITLE
docs(tools): add comment documenting terraform-llms-index.json output

### DIFF
--- a/tools/generate-llms-txt.go
+++ b/tools/generate-llms-txt.go
@@ -3,6 +3,9 @@
 //go:build ignore
 // +build ignore
 
+// Also outputs docs/terraform-llms-index.json — machine-readable resource index
+// with required fields, oneof_groups, server_defaults and minimal configs.
+//
 // This tool generates a three-level llms.txt hierarchy for AI consumption:
 //   - L0: docs/llms.txt — Provider entry point with category index
 //   - L1: docs/_llms-txt/<subcategory>.txt — Category indexes with resource lists


### PR DESCRIPTION
## Summary

Adds a clarifying comment to `generate-llms-txt.go` documenting that the tool also outputs the JSON index.

This PR also serves as the regeneration trigger — merging it will cause the on-merge workflow to re-run `generate-llms-txt.go` and create a new auto-regenerate PR that now includes:
- service_policy oneOf fix (#725): `allow_all_requests`/`deny_all_requests` in the index
- biome format fix (#731): JSON will be properly formatted and pass lint

## Test plan

- [ ] CI passes  
- [ ] After merging, watch for new auto-regenerate PR with passing lint

Closes #732