### PR TITLE
fix(codegen): allow digits in resource names in OpenAPI path regex

### DIFF
--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -318,10 +318,11 @@ func extractResourcePathsFromPaths(paths map[string]interface{}) []resourcePath 
 	seen := make(map[string]bool)
 
 	// Primary pattern: /api/config/namespaces/{namespace}/{resource_plural}
-	configPathRegex := regexp.MustCompile(`^/api/config/namespaces/\{namespace\}/([a-z_]+s)$`)
+	// Include digits (e.g., securemesh_site_v2s has a digit in the name)
+	configPathRegex := regexp.MustCompile(`^/api/config/namespaces/\{namespace\}/([a-z_0-9]+s)$`)
 
 	// Secondary pattern: /api/web/{resource_plural} (for system-level resources like namespace)
-	webPathRegex := regexp.MustCompile(`^/api/web/([a-z_]+s)$`)
+	webPathRegex := regexp.MustCompile(`^/api/web/([a-z_0-9]+s)$`)
 
 	for path := range paths {
 		var resourcePlural string


### PR DESCRIPTION
The configPathRegex `[a-z_]+s` did not match `securemesh_site_v2s` because it contains a digit. Changed to `[a-z_0-9]+s`. CI will auto-regenerate f5xc_securemesh_site_v2 and all other resources.

Closes #762