### PR TITLE
fix(lint): exclude 'linux' from terminology checker in textlintrc

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -51,7 +51,8 @@
         "OS X",
         "Sdk",
         "Client Side",
-        "Code Base"
+        "Code Base",
+        "linux"
       ]
     }
   }


### PR DESCRIPTION
Fixes pre-existing linter failure blocking auto-regenerate PR.

Closes #766