### PR TITLE
chore: trigger regeneration for api-specs-enriched v2.1.129

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -5,6 +5,7 @@
 
 // generate-all-schemas.go - Batch generator for all F5 XC Terraform resources
 // This tool processes all OpenAPI spec files and generates comprehensive Terraform schemas.
+// Last synced: api-specs-enriched v2.1.129 (lables→labels property rename in fleetFlashBladeEndpoint)
 //
 // CI/CD Integration:
 //   Changes to this file trigger the generate.yml workflow which regenerates all


### PR DESCRIPTION
Closes #777

## Summary

- Adds spec version comment to `tools/generate-all-schemas.go` to trigger `on-merge.yml` CI regeneration
- When merged, `on-merge.yml` downloads latest api-specs-enriched v2.1.129 and regenerates all provider files

## Breaking Change in v2.1.129

`fleetFlashBladeEndpoint.lables` renamed to `labels` — affects:
- `internal/provider/fleet_resource.go`: `Lables` struct field → `Labels`, `tfsdk:"lables"` → `tfsdk:"labels"`
- `internal/provider/voltstack_site_resource.go`: same rename

Generated files are NOT committed directly per CLAUDE.md Rule 1 — CI/CD handles regeneration via `on-merge.yml`.

## Test Plan
- [ ] Merge triggers `on-merge.yml`
- [ ] `on-merge.yml` downloads v2.1.129 specs and regenerates provider
- [ ] Generated PR contains `lables` → `labels` rename in fleet/voltstack resources