### PR TITLE
Add provider config_block + auth_methods to LLM index

### DIFF
--- a/docs/terraform-llms-index.json
+++ b/docs/terraform-llms-index.json
@@ -4,6 +4,15 @@
     "source": "f5xc-salesdemos/f5xc",
     "registry": "https://registry.terraform.io/providers/f5xc-salesdemos/f5xc",
     "required_block": "terraform {\n  required_providers {\n    f5xc = {\n      source = \"f5xc-salesdemos/f5xc\"\n    }\n  }\n}",
+    "config_block": "provider \"f5xc\" {}",
+    "auth_methods": [
+      "REQUIRED: every .tf must contain a `provider \"f5xc\" {}` block. Without it Terraform errors: \"Provider requires explicit configuration. Add a provider block\".",
+      "Configure exactly ONE auth method, via environment variables (preferred) or explicit arguments in the provider block:",
+      "api_token (env F5XC_API_TOKEN) — API token authentication.",
+      "api_p12_file + p12_password (env F5XC_P12_FILE + F5XC_P12_PASSWORD) — PKCS#12 certificate authentication.",
+      "api_cert + api_key (env F5XC_CERT + F5XC_KEY) — PEM certificate authentication.",
+      "api_url (env F5XC_API_URL) — tenant base URL without /api suffix, e.g. https://your-tenant.console.ves.volterra.io."
+    ],
     "syntax_rules": [
       "OneOf selectors: use empty block `field {}`, never `field = true`",
       "Cross-resource refs: block with name + namespace attributes",

--- a/tools/generate-llms-txt.go
+++ b/tools/generate-llms-txt.go
@@ -93,6 +93,8 @@ type JSONProvider struct {
 	Source        string   `json:"source"`
 	Registry      string   `json:"registry"`
 	RequiredBlock string   `json:"required_block"`
+	ConfigBlock   string   `json:"config_block"`
+	AuthMethods   []string `json:"auth_methods"`
 	SyntaxRules   []string `json:"syntax_rules"`
 }
 
@@ -1103,6 +1105,15 @@ func generateJSONIndex(config *LLMsConfig, categories []CategoryInfo, reverseDep
     }
   }
 }`,
+			ConfigBlock: `provider "f5xc" {}`,
+			AuthMethods: []string{
+				"REQUIRED: every .tf must contain a `provider \"f5xc\" {}` block. Without it Terraform errors: \"Provider requires explicit configuration. Add a provider block\".",
+				"Configure exactly ONE auth method, via environment variables (preferred) or explicit arguments in the provider block:",
+				"api_token (env F5XC_API_TOKEN) — API token authentication.",
+				"api_p12_file + p12_password (env F5XC_P12_FILE + F5XC_P12_PASSWORD) — PKCS#12 certificate authentication.",
+				"api_cert + api_key (env F5XC_CERT + F5XC_KEY) — PEM certificate authentication.",
+				"api_url (env F5XC_API_URL) — tenant base URL without /api suffix, e.g. https://your-tenant.console.ves.volterra.io.",
+			},
 			SyntaxRules: []string{
 				"OneOf selectors: use empty block `field {}`, never `field = true`",
 				"Cross-resource refs: block with name + namespace attributes",


### PR DESCRIPTION
Closes #840

## Problem
`docs/terraform-llms-index.json` (consumed by xcsh for deterministic Terraform knowledge) exposed only `provider.required_block` (the `terraform { required_providers {} }` block). It had no field for the `provider "f5xc" {}` configuration block. Consumers therefore generated HCL with `required_providers` + resources but no provider block, so `terraform plan` failed:

```
Error: Invalid provider configuration
... requires explicit configuration. Add a provider block ...
```

## Change
- `tools/generate-llms-txt.go` — add `config_block` and `auth_methods` to `JSONProvider` (struct + literal). `config_block` is the canonical empty, env-driven `provider "f5xc" {}` block; `auth_methods` lists the three auth methods + `F5XC_*` env vars, mirroring `internal/provider/provider.go` and `docs/index.md`.
- `docs/terraform-llms-index.json` — regenerated provider keys (minimal 9-line delta; category ordering left as-is since the generator’s map iteration is nondeterministic).

## Verification
`make llms-txt` compiles and emits `provider.config_block` / `provider.auth_methods`; JSON validates; downstream xcsh renders the `provider "f5xc" {}` block in its Terraform knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)