### PR TITLE
Fix remaining docs and config refs for xcsh rebrand

### DIFF
--- a/.claude/hooks/enforce-git-delegation.sh
+++ b/.claude/hooks/enforce-git-delegation.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# PreToolUse hook: enforces the docs-control delegation policy.
+# In docs-control itself: everything is allowed (source-of-truth).
+# In downstream repos:
+#   - main session and non-delegated subagents are blocked from running
+#     git commit / git push / gh pr create (must delegate to github-ops).
+#   - the xcsh-github-ops:github-ops subagent may run those operations,
+#     UNLESS the changeset touches a file listed in governance.json.
+# Distributed by docs-control via managed_files sync.
+# Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
+set -euo pipefail
+
+# ── Guard: exit if no stdin data (e.g., linter running script) ───────
+if ! read -t 0 2>/dev/null; then
+  exit 0
+fi
+
+INPUT=$(cat)
+
+# ── Self-exclusion: allow all git/GitHub operations in docs-control ─
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+if echo "$REMOTE_URL" | grep -q "docs-control"; then
+  exit 0
+fi
+
+# ── Extract the Bash command ────────────────────────────────────────
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# ── Detect operation type ───────────────────────────────────────────
+IS_COMMIT=0
+IS_PUSH=0
+IS_PR=0
+if [[ "$COMMAND" =~ (^|[^A-Za-z0-9_])git[[:space:]]+commit([^A-Za-z0-9_]|$) ]]; then
+  IS_COMMIT=1
+fi
+if [[ "$COMMAND" =~ (^|[^A-Za-z0-9_])git[[:space:]]+push([^A-Za-z0-9_]|$) ]]; then
+  IS_PUSH=1
+fi
+if [[ "$COMMAND" =~ (^|[^A-Za-z0-9_])gh[[:space:]]+pr[[:space:]]+create([^A-Za-z0-9_]|$) ]]; then
+  IS_PR=1
+fi
+
+# Not a delegated operation — no policy applies
+if [ "$IS_COMMIT" = 0 ] && [ "$IS_PUSH" = 0 ] && [ "$IS_PR" = 0 ]; then
+  exit 0
+fi
+
+# ── Delegation check: only github-ops may run delegated operations ──
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null || echo "")
+if [ "$AGENT_TYPE" != "xcsh-github-ops:github-ops" ]; then
+  cat >&2 <<EOF
+BLOCKED: "${COMMAND}" is a delegated git/GitHub operation.
+
+CLAUDE.md requires all git commit, git push, and gh pr create calls to
+go through the xcsh-github-ops:github-ops subagent. Dispatch that agent
+with a clear task description instead of running the command directly.
+EOF
+  exit 2
+fi
+
+# ── Content check: governed files cannot leave a downstream repo ────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GOVERNANCE_FILE="${SCRIPT_DIR}/../governance.json"
+if [ ! -f "$GOVERNANCE_FILE" ]; then
+  exit 0
+fi
+
+# Compute the set of file paths this operation would affect
+CHANGED=""
+if [ "$IS_COMMIT" = 1 ]; then
+  # Files staged for this commit
+  CHANGED=$(git diff --cached --name-only 2>/dev/null || echo "")
+  # -a / --all flag includes modified-but-unstaged tracked files
+  if [[ " $COMMAND " =~ [[:space:]]-[a-zA-Z]*a[a-zA-Z]*[[:space:]] ]] ||
+    [[ " $COMMAND " =~ [[:space:]]--all[[:space:]] ]]; then
+    CHANGED=$(printf '%s\n%s\n' "$CHANGED" "$(git diff --name-only 2>/dev/null || echo "")")
+  fi
+else
+  # push or pr create: files changed between upstream and HEAD
+  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+  if [ -z "$UPSTREAM" ]; then
+    UPSTREAM=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo "origin/main")
+  fi
+  CHANGED=$(git diff --name-only "${UPSTREAM}..HEAD" 2>/dev/null || echo "")
+fi
+
+CHANGED_SORTED=$(printf '%s\n' "$CHANGED" | awk 'NF' | sort -u)
+GOVERNED_SORTED=$(jq -r '.protected_files[]' "$GOVERNANCE_FILE" 2>/dev/null | awk 'NF' | sort -u)
+
+if [ -z "$CHANGED_SORTED" ] || [ -z "$GOVERNED_SORTED" ]; then
+  exit 0
+fi
+
+VIOLATIONS=$(comm -12 <(printf '%s' "$CHANGED_SORTED") <(printf '%s' "$GOVERNED_SORTED"))
+
+if [ -n "$VIOLATIONS" ]; then
+  SOURCE_REPO=$(jq -r '.source_repo' "$GOVERNANCE_FILE")
+  cat >&2 <<EOF
+BLOCKED: "${COMMAND}" would affect governed file(s) managed by ${SOURCE_REPO}:
+$(printf '%s\n' "$VIOLATIONS" | sed 's/^/  - /')
+
+Governed files cannot be committed, pushed, or PR-submitted from
+downstream repos. To change them, open an issue/PR in ${SOURCE_REPO} —
+changes sync automatically to downstream repos.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.github-runner-docker/.env.example
+++ b/.github-runner-docker/.env.example
@@ -11,7 +11,7 @@
 GITHUB_REPOSITORY=robinmordasiewicz/terraform-provider-xcsh
 
 # Required: GitHub Personal Access Token with 'repo' scope
-GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # pragma: allowlist secret
+GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # pragma: allowlist secret
 
 # Optional: Custom runner name (default: xcsh-container-runner)
 RUNNER_NAME=xcsh-container-runner

--- a/.github-runner-docker/.env.example
+++ b/.github-runner-docker/.env.example
@@ -8,19 +8,19 @@
 #   4. Copy the token
 
 # Required: Your repository (owner/repo format)
-GITHUB_REPOSITORY=robinmordasiewicz/terraform-provider-xcsh
+GITHUB_REPOSITORY="robinmordasiewicz/terraform-provider-xcsh"
 
 # Required: GitHub Personal Access Token with 'repo' scope
 GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # pragma: allowlist secret
 
 # Optional: Custom runner name (default: xcsh-container-runner)
-RUNNER_NAME=xcsh-container-runner
+RUNNER_NAME="xcsh-container-runner"
 
 # Optional: Runner labels (comma-separated)
-RUNNER_LABELS=self-hosted,Linux,X64,container
+RUNNER_LABELS="self-hosted,Linux,X64,container"
 
 # F5 XC API Credentials (for acceptance tests)
 # Get API token from F5 XC Console:
 #   Administration → Personal Management → Credentials → Add Credentials → API Token
-XCSH_API_URL=https://console.ves.volterra.io
-XCSH_API_TOKEN=your-api-token-here
+XCSH_API_URL="https://console.ves.volterra.io"
+XCSH_API_TOKEN="your-api-token-here"

--- a/.github-runner-docker/.env.example
+++ b/.github-runner-docker/.env.example
@@ -1,26 +1,17 @@
-# Self-Hosted GitHub Actions Runner Configuration
-# Copy this file to .env and fill in your values
-#
-# To get a GitHub Personal Access Token:
-#   1. Go to https://github.com/settings/tokens
-#   2. Generate new token (classic)
-#   3. Select scope: repo (Full control of private repositories)
-#   4. Copy the token
+# GitHub Runner Configuration
+# Copy this file to .env and fill in values
 
-# Required: Your repository (owner/repo format)
-GITHUB_REPOSITORY="robinmordasiewicz/terraform-provider-xcsh"
+# Required
+GITHUB_OWNER=f5xc-salesdemos
+GITHUB_REPOSITORY=robinmordasiewicz/terraform-provider-xcsh
 
-# Required: GitHub Personal Access Token with 'repo' scope
-GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # pragma: allowlist secret
+# Authentication (use fine-grained PAT with Administration: Read & Write)
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Optional: Custom runner name (default: xcsh-container-runner)
-RUNNER_NAME="xcsh-container-runner"
+# Runner Settings
+RUNNER_LABELS=self-hosted,Linux,X64,container
+RUNNER_NAME=xcsh-container-runner
 
-# Optional: Runner labels (comma-separated)
-RUNNER_LABELS="self-hosted,Linux,X64,container"
-
-# F5 XC API Credentials (for acceptance tests)
-# Get API token from F5 XC Console:
-#   Administration → Personal Management → Credentials → Add Credentials → API Token
-XCSH_API_URL="https://console.ves.volterra.io"
-XCSH_API_TOKEN="your-api-token-here"
+# API Credentials (for acceptance tests)
+XCSH_API_TOKEN=your-api-token-here
+XCSH_API_URL=https://console.ves.volterra.io

--- a/.github-runner-docker/.env.example
+++ b/.github-runner-docker/.env.example
@@ -8,13 +8,13 @@
 #   4. Copy the token
 
 # Required: Your repository (owner/repo format)
-GITHUB_REPOSITORY=robinmordasiewicz/terraform-provider-f5xc
+GITHUB_REPOSITORY=robinmordasiewicz/terraform-provider-xcsh
 
 # Required: GitHub Personal Access Token with 'repo' scope
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # pragma: allowlist secret
 
-# Optional: Custom runner name (default: f5xc-container-runner)
-RUNNER_NAME=f5xc-container-runner
+# Optional: Custom runner name (default: xcsh-container-runner)
+RUNNER_NAME=xcsh-container-runner
 
 # Optional: Runner labels (comma-separated)
 RUNNER_LABELS=self-hosted,Linux,X64,container
@@ -22,5 +22,5 @@ RUNNER_LABELS=self-hosted,Linux,X64,container
 # F5 XC API Credentials (for acceptance tests)
 # Get API token from F5 XC Console:
 #   Administration → Personal Management → Credentials → Add Credentials → API Token
-F5XC_API_URL=https://console.ves.volterra.io
-F5XC_API_TOKEN=your-api-token-here
+XCSH_API_URL=https://console.ves.volterra.io
+XCSH_API_TOKEN=your-api-token-here

--- a/.github-runner-docker/README.md
+++ b/.github-runner-docker/README.md
@@ -109,4 +109,4 @@ docker-compose -f docker-compose.yml --env-file runner1.env up -d
 
 ### Persistent Caching
 
-The work directory is persisted in a Docker volume (`f5xc-runner-work`) for caching Go modules and build artifacts between runs.
+The work directory is persisted in a Docker volume (`xcsh-runner-work`) for caching Go modules and build artifacts between runs.

--- a/.github-runner-docker/docker-compose.yml
+++ b/.github-runner-docker/docker-compose.yml
@@ -18,8 +18,8 @@ services:
         - RUNNER_VERSION=2.321.0
         - GO_VERSION=1.24.2
         - TERRAFORM_VERSION=1.9.8
-    image: f5xc-runner:latest
-    container_name: f5xc-github-runner
+    image: xcsh-runner:latest
+    container_name: xcsh-github-runner
     restart: unless-stopped
     environment:
       # Required: Repository in owner/repo format
@@ -27,7 +27,7 @@ services:
       # Required: Personal Access Token with repo scope
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       # Optional: Custom runner name (default: container hostname)
-      - RUNNER_NAME=${RUNNER_NAME:-f5xc-container-runner}
+      - RUNNER_NAME=${RUNNER_NAME:-xcsh-container-runner}
       # Optional: Additional labels
       - RUNNER_LABELS=${RUNNER_LABELS:-self-hosted,Linux,X64,container}
       # F5 XC API credentials (passed to workflow jobs)
@@ -50,4 +50,4 @@ services:
 
 volumes:
   runner-work:
-    name: f5xc-runner-work
+    name: xcsh-runner-work

--- a/.github-runner-docker/entrypoint.sh
+++ b/.github-runner-docker/entrypoint.sh
@@ -14,13 +14,13 @@ set -euo pipefail
 
 # Validate required environment variables
 if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
-    echo "ERROR: GITHUB_REPOSITORY is required (e.g., owner/repo)"
-    exit 1
+  echo "ERROR: GITHUB_REPOSITORY is required (e.g., owner/repo)"
+  exit 1
 fi
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-    echo "ERROR: GITHUB_TOKEN is required (Personal Access Token with repo scope)"
-    exit 1
+  echo "ERROR: GITHUB_TOKEN is required (Personal Access Token with repo scope)"
+  exit 1
 fi
 
 # Set defaults
@@ -41,54 +41,54 @@ echo "=============================================="
 # Get registration token from GitHub API
 echo "Getting registration token..."
 REGISTRATION_TOKEN=$(curl -sX POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/registration-token" \
-    | jq -r '.token')
+  -H "Authorization: token ${GITHUB_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/registration-token" |
+  jq -r '.token')
 
 if [[ -z "$REGISTRATION_TOKEN" || "$REGISTRATION_TOKEN" == "null" ]]; then
-    echo "ERROR: Failed to get registration token"
-    echo "Make sure GITHUB_TOKEN has 'repo' scope and you have admin access"
-    exit 1
+  echo "ERROR: Failed to get registration token"
+  echo "Make sure GITHUB_TOKEN has 'repo' scope and you have admin access"
+  exit 1
 fi
 
 echo "Registration token obtained"
 
 # Remove existing runner configuration if present
 if [[ -f ".runner" ]]; then
-    echo "Removing existing runner configuration..."
-    ./config.sh remove --token "$REGISTRATION_TOKEN" 2>/dev/null || true
+  echo "Removing existing runner configuration..."
+  ./config.sh remove --token "$REGISTRATION_TOKEN" 2>/dev/null || true
 fi
 
 # Configure the runner
 echo "Configuring runner..."
 ./config.sh \
-    --url "https://github.com/${GITHUB_REPOSITORY}" \
-    --token "$REGISTRATION_TOKEN" \
-    --name "$RUNNER_NAME" \
-    --labels "$RUNNER_LABELS" \
-    --work "$RUNNER_WORKDIR" \
-    --unattended \
-    --replace
+  --url "https://github.com/${GITHUB_REPOSITORY}" \
+  --token "$REGISTRATION_TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "$RUNNER_LABELS" \
+  --work "$RUNNER_WORKDIR" \
+  --unattended \
+  --replace
 
 # Cleanup function for graceful shutdown
 cleanup() {
-    echo ""
-    echo "Received shutdown signal, removing runner..."
+  echo ""
+  echo "Received shutdown signal, removing runner..."
 
-    # Get removal token
-    REMOVAL_TOKEN=$(curl -sX POST \
-        -H "Authorization: token ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/remove-token" \
-        | jq -r '.token')
+  # Get removal token
+  REMOVAL_TOKEN=$(curl -sX POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners/remove-token" |
+    jq -r '.token')
 
-    if [[ -n "$REMOVAL_TOKEN" && "$REMOVAL_TOKEN" != "null" ]]; then
-        ./config.sh remove --token "$REMOVAL_TOKEN" 2>/dev/null || true
-        echo "Runner removed from repository"
-    fi
+  if [[ -n "$REMOVAL_TOKEN" && "$REMOVAL_TOKEN" != "null" ]]; then
+    ./config.sh remove --token "$REMOVAL_TOKEN" 2>/dev/null || true
+    echo "Runner removed from repository"
+  fi
 
-    exit 0
+  exit 0
 }
 
 # Trap signals for graceful shutdown

--- a/.github-runner-docker/entrypoint.sh
+++ b/.github-runner-docker/entrypoint.sh
@@ -2,7 +2,7 @@
 # Entrypoint for GitHub Actions Runner Container
 #
 # Required environment variables:
-#   GITHUB_REPOSITORY  - owner/repo (e.g., robinmordasiewicz/terraform-provider-f5xc)
+#   GITHUB_REPOSITORY  - owner/repo (e.g., robinmordasiewicz/terraform-provider-xcsh)
 #   GITHUB_TOKEN       - Personal Access Token with repo scope
 #
 # Optional environment variables:

--- a/internal/mocks/README.md
+++ b/internal/mocks/README.md
@@ -32,8 +32,8 @@ import (
     "testing"
 
     "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-    "github.com/f5xc/terraform-provider-xcsh/internal/acctest"
-    "github.com/f5xc/terraform-provider-xcsh/internal/mocks"
+    "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+    "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/mocks"
 )
 
 func TestMockMyResource_basic(t *testing.T) {

--- a/tools/add-client-types.sh
+++ b/tools/add-client-types.sh
@@ -25,16 +25,16 @@ TEMP_FILE=$(mktemp)
 LINE_NUM=$(grep -n "^}$" $CLIENT_FILE | tail -1 | cut -d: -f1)
 
 # Insert before the last line
-head -n $((LINE_NUM - 1)) $CLIENT_FILE > $TEMP_FILE
+head -n $((LINE_NUM - 1)) $CLIENT_FILE >$TEMP_FILE
 
 # Add each resource's client types
 for resource in $RESOURCES; do
-    # Convert to TitleCase
-    title_case=$(echo $resource | sed -r 's/(^|_)([a-z])/\U\2/g' | sed 's/_//g')
+  # Convert to TitleCase
+  title_case=$(echo $resource | sed -r 's/(^|_)([a-z])/\U\2/g' | sed 's/_//g')
 
-    echo "Adding types for: $resource ($title_case)"
+  echo "Adding types for: $resource ($title_case)"
 
-    cat >> $TEMP_FILE << EOF
+  cat >>$TEMP_FILE <<EOF
 
 // $title_case represents an XCSH $title_case
 type $title_case struct {
@@ -80,7 +80,7 @@ EOF
 done
 
 # Close the file
-echo "}" >> $TEMP_FILE
+echo "}" >>$TEMP_FILE
 
 # Replace original file
 mv $TEMP_FILE $CLIENT_FILE

--- a/tools/add-client-types.sh
+++ b/tools/add-client-types.sh
@@ -7,8 +7,8 @@
 
 set -e
 
-CLIENT_FILE="/tmp/terraform-provider-f5xc/internal/client/client.go"
-PROVIDER_DIR="/tmp/terraform-provider-f5xc/internal/provider"
+CLIENT_FILE="/tmp/terraform-provider-xcsh/internal/client/client.go"
+PROVIDER_DIR="/tmp/terraform-provider-xcsh/internal/provider"
 
 # Extract resource names from generated files
 # Using find instead of ls | grep to avoid SC2010
@@ -36,7 +36,7 @@ for resource in $RESOURCES; do
 
     cat >> $TEMP_FILE << EOF
 
-// $title_case represents a F5XC $title_case
+// $title_case represents an XCSH $title_case
 type $title_case struct {
 	Metadata Metadata        \`json:"metadata"\`
 	Spec     ${title_case}Spec \`json:"spec"\`

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -163,7 +163,7 @@ func main() {
 	fmt.Println("\n🎉 Batch generation complete!")
 }
 
-// processV2Specs processes v2 format specs (domain-organized files from f5xc-api-enriched)
+// processV2Specs processes v2 format specs (domain-organized files from api-specs-enriched)
 func processV2Specs(specDir string) ([]GenerationResult, int, int) {
 	// Parse the index.json to get domain information
 	index, err := openapi.ParseIndexFromDir(specDir)

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -47,7 +47,7 @@ type Schema struct {
 	XVesValidationRules map[string]string `json:"x-ves-validation-rules"`
 	XVesProtoMessage    string            `json:"x-ves-proto-message"`
 
-	// Enrichment extensions (x-f5xc-*) - added by f5xc-api-enriched repository
+	// Enrichment extensions (x-f5xc-*) - added by api-specs-enriched repository
 	XF5XCCategory         string   `json:"x-f5xc-category"`
 	XF5XCRequiresTier     string   `json:"x-f5xc-requires-tier"`
 	XF5XCComplexity       string   `json:"x-f5xc-complexity"`
@@ -232,7 +232,7 @@ func (s *Schema) HasProperties() bool {
 }
 
 // =============================================================================
-// V2 Spec Types - For parsing enriched API specifications from f5xc-api-enriched
+// V2 Spec Types - For parsing enriched API specifications from api-specs-enriched
 // =============================================================================
 
 // Index represents the index.json manifest file in v2 spec structure.


### PR DESCRIPTION
## Summary
mocks README, docker-compose, .env.example, hooks, and tool comments

Final pass (iteration 3) of xcsh ecosystem rebrand.

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)