### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+🌐 English |
+[日本語](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/ja/) |
+[한국어](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/ko/) |
+[简体中文](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/zh-cn/) |
+[繁體中文](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/zh-tw/) |
+[Español](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/es/) |
+[Português](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/pt-br/) |
+[Français](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/fr/) |
+[Deutsch](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/de/) |
+[Italiano](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/it/) |
+[العربية](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/ar/) |
+[हिन्दी](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/hi/) |
+[ไทย](https://f5xc-salesdemos.github.io/terraform-provider-xcsh/th/)
+
 # Terraform Provider
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/terraform-provider-xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/terraform-provider-xcsh/actions/workflows/github-pages-deploy.yml)

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,15 @@
   },
   "overrides": [
     {
-      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "includes": [
+        "dist/**",
+        "build/**",
+        "release/**",
+        "vendor/**",
+        "docs/snapshots/**",
+        ".github/config/managed-files-manifest.json",
+        "**/*.svg"
+      ],
       "formatter": {
         "enabled": false
       },


### PR DESCRIPTION
Closes #904

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/translation-audit.yml
- .gitignore
- .pre-commit-config.yaml
- .github/workflows/auto-merge.yml
- biome.json
- .jscpd.json
- .codespellrc
- .claude/governance.json
- README.md