### PR TITLE
fix: update Go import paths to new org name

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/provider"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/provider"
 )
 
 var (

--- a/internal/acctest/check_destroy_registry.go
+++ b/internal/acctest/check_destroy_registry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 // ResourceVerifier is a function that verifies a resource no longer exists via API

--- a/internal/acctest/mock_helpers.go
+++ b/internal/acctest/mock_helpers.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/mocks"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/provider"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/mocks"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/provider"
 )
 
 var (

--- a/internal/acctest/sweep.go
+++ b/internal/acctest/sweep.go
@@ -51,7 +51,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 const (

--- a/internal/acctest/tracker.go
+++ b/internal/acctest/tracker.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 // TrackedResource represents a resource created during a test run

--- a/internal/blindfold/auth.go
+++ b/internal/blindfold/auth.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 // AuthConfig holds configuration for XCSH API authentication.

--- a/internal/blindfold/size_test.go
+++ b/internal/blindfold/size_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 func TestSizeAnalysis(t *testing.T) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,7 +18,7 @@ import (
 
 	"golang.org/x/crypto/pkcs12"
 
-	xcsherrors "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/errors"
+	xcsherrors "github.com/f5-sales-demo/terraform-provider-xcsh/internal/errors"
 )
 
 // Client configuration defaults

--- a/internal/functions/blindfold.go
+++ b/internal/functions/blindfold.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/function"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/blindfold"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/blindfold"
 )
 
 var _ function.Function = &BlindfoldFunction{}

--- a/internal/functions/blindfold_acc_test.go
+++ b/internal/functions/blindfold_acc_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/blindfold"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/blindfold"
 )
 
 // skipIfNotAccTest skips the test if TF_ACC is not set

--- a/internal/functions/blindfold_file.go
+++ b/internal/functions/blindfold_file.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/function"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/blindfold"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/blindfold"
 )
 
 var _ function.Function = &BlindfoldFileFunction{}

--- a/internal/functions/blindfold_file_test.go
+++ b/internal/functions/blindfold_file_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/blindfold"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/blindfold"
 )
 
 // mockF5XCServerForFile creates a test server that simulates the F5XC API for file tests

--- a/internal/functions/blindfold_mock_test.go
+++ b/internal/functions/blindfold_mock_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/blindfold"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/blindfold"
 )
 
 // mockServer creates a comprehensive mock F5XC server for CI/CD testing

--- a/internal/functions/blindfold_test.go
+++ b/internal/functions/blindfold_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/blindfold"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/blindfold"
 )
 
 // mockF5XCServer creates a test server that simulates the F5XC API

--- a/internal/provider/addon_service_activation_status_data_source.go
+++ b/internal/provider/addon_service_activation_status_data_source.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/addon_service_data_source.go
+++ b/internal/provider/addon_service_data_source.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/address_allocator_data_source.go
+++ b/internal/provider/address_allocator_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/address_allocator_resource.go
+++ b/internal/provider/address_allocator_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/address_allocator_resource_test.go
+++ b/internal/provider/address_allocator_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAddressAllocatorResource_basic(t *testing.T) {

--- a/internal/provider/advertise_policy_data_source.go
+++ b/internal/provider/advertise_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/advertise_policy_data_source_test.go
+++ b/internal/provider/advertise_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAdvertisePolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/advertise_policy_resource.go
+++ b/internal/provider/advertise_policy_resource.go
@@ -25,9 +25,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/advertise_policy_resource_test.go
+++ b/internal/provider/advertise_policy_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAdvertisePolicyResource_basic(t *testing.T) {

--- a/internal/provider/alert_policy_data_source.go
+++ b/internal/provider/alert_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/alert_policy_data_source_test.go
+++ b/internal/provider/alert_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAlertPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/alert_policy_resource_test.go
+++ b/internal/provider/alert_policy_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/alert_receiver_data_source.go
+++ b/internal/provider/alert_receiver_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/alert_receiver_data_source_test.go
+++ b/internal/provider/alert_receiver_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAlertReceiverDataSource_basic(t *testing.T) {

--- a/internal/provider/alert_receiver_resource.go
+++ b/internal/provider/alert_receiver_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/alert_receiver_resource_test.go
+++ b/internal/provider/alert_receiver_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // NOTE: alert_receiver tests use system namespace to avoid namespace propagation delays

--- a/internal/provider/api_crawler_data_source.go
+++ b/internal/provider/api_crawler_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/api_crawler_data_source_test.go
+++ b/internal/provider/api_crawler_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccApiCrawlerDataSource_basic(t *testing.T) {

--- a/internal/provider/api_crawler_resource.go
+++ b/internal/provider/api_crawler_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/api_crawler_resource_test.go
+++ b/internal/provider/api_crawler_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAPICrawlerResource_basic(t *testing.T) {

--- a/internal/provider/api_definition_data_source.go
+++ b/internal/provider/api_definition_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/api_definition_data_source_test.go
+++ b/internal/provider/api_definition_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccApiDefinitionDataSource_basic(t *testing.T) {

--- a/internal/provider/api_definition_resource.go
+++ b/internal/provider/api_definition_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/api_definition_resource_test.go
+++ b/internal/provider/api_definition_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAPIDefinitionResource_basic(t *testing.T) {

--- a/internal/provider/api_discovery_data_source.go
+++ b/internal/provider/api_discovery_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/api_discovery_data_source_test.go
+++ b/internal/provider/api_discovery_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccApiDiscoveryDataSource_basic(t *testing.T) {

--- a/internal/provider/api_discovery_resource.go
+++ b/internal/provider/api_discovery_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/api_discovery_resource_test.go
+++ b/internal/provider/api_discovery_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAPIDiscoveryResource_basic(t *testing.T) {

--- a/internal/provider/api_testing_data_source.go
+++ b/internal/provider/api_testing_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/api_testing_data_source_test.go
+++ b/internal/provider/api_testing_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccApiTestingDataSource_basic(t *testing.T) {

--- a/internal/provider/api_testing_resource.go
+++ b/internal/provider/api_testing_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/api_testing_resource_test.go
+++ b/internal/provider/api_testing_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAPITestingResource_basic(t *testing.T) {

--- a/internal/provider/apm_data_source.go
+++ b/internal/provider/apm_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/apm_resource.go
+++ b/internal/provider/apm_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/apm_resource_test.go
+++ b/internal/provider/apm_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAPMResource_basic(t *testing.T) {

--- a/internal/provider/app_api_group_data_source.go
+++ b/internal/provider/app_api_group_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/app_api_group_data_source_test.go
+++ b/internal/provider/app_api_group_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppApiGroupDataSource_basic(t *testing.T) {

--- a/internal/provider/app_api_group_resource.go
+++ b/internal/provider/app_api_group_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/app_api_group_resource_test.go
+++ b/internal/provider/app_api_group_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppAPIGroupResource_basic(t *testing.T) {

--- a/internal/provider/app_firewall_data_source.go
+++ b/internal/provider/app_firewall_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/app_firewall_data_source_test.go
+++ b/internal/provider/app_firewall_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppFirewallDataSource_basic(t *testing.T) {

--- a/internal/provider/app_firewall_resource.go
+++ b/internal/provider/app_firewall_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/app_firewall_resource_test.go
+++ b/internal/provider/app_firewall_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/app_setting_data_source.go
+++ b/internal/provider/app_setting_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/app_setting_data_source_test.go
+++ b/internal/provider/app_setting_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppSettingDataSource_basic(t *testing.T) {

--- a/internal/provider/app_setting_resource.go
+++ b/internal/provider/app_setting_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/app_setting_resource_test.go
+++ b/internal/provider/app_setting_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppSettingResource_basic(t *testing.T) {

--- a/internal/provider/app_type_data_source.go
+++ b/internal/provider/app_type_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/app_type_data_source_test.go
+++ b/internal/provider/app_type_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppTypeDataSource_basic(t *testing.T) {

--- a/internal/provider/app_type_resource.go
+++ b/internal/provider/app_type_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/app_type_resource_test.go
+++ b/internal/provider/app_type_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAppTypeResource_basic(t *testing.T) {

--- a/internal/provider/application_profiles_data_source.go
+++ b/internal/provider/application_profiles_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/application_profiles_resource.go
+++ b/internal/provider/application_profiles_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/authentication_data_source.go
+++ b/internal/provider/authentication_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/authentication_data_source_test.go
+++ b/internal/provider/authentication_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAuthenticationDataSource_basic(t *testing.T) {

--- a/internal/provider/authentication_resource.go
+++ b/internal/provider/authentication_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/authentication_resource_test.go
+++ b/internal/provider/authentication_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAuthenticationResource_basic(t *testing.T) {

--- a/internal/provider/authorization_server_data_source.go
+++ b/internal/provider/authorization_server_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/authorization_server_resource.go
+++ b/internal/provider/authorization_server_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/aws_tgw_site_data_source.go
+++ b/internal/provider/aws_tgw_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/aws_tgw_site_data_source_test.go
+++ b/internal/provider/aws_tgw_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAwsTgwSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/aws_tgw_site_resource.go
+++ b/internal/provider/aws_tgw_site_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/aws_tgw_site_resource_test.go
+++ b/internal/provider/aws_tgw_site_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // TestAccAWSTGWSiteResource_basic validates basic AWS TGW Site resource operations

--- a/internal/provider/aws_vpc_site_data_source.go
+++ b/internal/provider/aws_vpc_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/aws_vpc_site_data_source_test.go
+++ b/internal/provider/aws_vpc_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAwsVpcSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/aws_vpc_site_resource.go
+++ b/internal/provider/aws_vpc_site_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/aws_vpc_site_resource_mock_test.go
+++ b/internal/provider/aws_vpc_site_resource_mock_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/mocks"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/mocks"
 )
 
 // =============================================================================

--- a/internal/provider/aws_vpc_site_resource_test.go
+++ b/internal/provider/aws_vpc_site_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // TestAccAWSVPCSiteResource_basic validates basic AWS VPC Site resource operations

--- a/internal/provider/azure_vnet_site_data_source.go
+++ b/internal/provider/azure_vnet_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/azure_vnet_site_data_source_test.go
+++ b/internal/provider/azure_vnet_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAzureVnetSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/azure_vnet_site_resource.go
+++ b/internal/provider/azure_vnet_site_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/azure_vnet_site_resource_test.go
+++ b/internal/provider/azure_vnet_site_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccAzureVNETSiteResource_basic(t *testing.T) {

--- a/internal/provider/bgp_asn_set_data_source.go
+++ b/internal/provider/bgp_asn_set_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/bgp_asn_set_data_source_test.go
+++ b/internal/provider/bgp_asn_set_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccBgpAsnSetDataSource_basic(t *testing.T) {

--- a/internal/provider/bgp_asn_set_resource.go
+++ b/internal/provider/bgp_asn_set_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/bgp_asn_set_resource_test.go
+++ b/internal/provider/bgp_asn_set_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/bgp_data_source.go
+++ b/internal/provider/bgp_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/bgp_data_source_test.go
+++ b/internal/provider/bgp_data_source_test.go
@@ -5,7 +5,7 @@ package provider_test
 import (
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccBgpDataSource_basic(t *testing.T) {

--- a/internal/provider/bgp_resource.go
+++ b/internal/provider/bgp_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/bgp_resource_test.go
+++ b/internal/provider/bgp_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccBGPResource_basic(t *testing.T) {

--- a/internal/provider/bgp_routing_policy_data_source.go
+++ b/internal/provider/bgp_routing_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/bgp_routing_policy_data_source_test.go
+++ b/internal/provider/bgp_routing_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccBgpRoutingPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/bgp_routing_policy_resource.go
+++ b/internal/provider/bgp_routing_policy_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/bgp_routing_policy_resource_test.go
+++ b/internal/provider/bgp_routing_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccBGPRoutingPolicyResource_basic(t *testing.T) {

--- a/internal/provider/bigip_http_proxy_data_source.go
+++ b/internal/provider/bigip_http_proxy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/bigip_http_proxy_resource.go
+++ b/internal/provider/bigip_http_proxy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/bigip_virtual_server_data_source.go
+++ b/internal/provider/bigip_virtual_server_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/bot_defense_app_infrastructure_data_source.go
+++ b/internal/provider/bot_defense_app_infrastructure_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/bot_defense_app_infrastructure_resource.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/bot_defense_app_infrastructure_resource_test.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccBotDefenseAppInfrastructureResource_basic(t *testing.T) {

--- a/internal/provider/cdn_cache_rule_data_source.go
+++ b/internal/provider/cdn_cache_rule_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cdn_cache_rule_data_source_test.go
+++ b/internal/provider/cdn_cache_rule_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCdnCacheRuleDataSource_basic(t *testing.T) {

--- a/internal/provider/cdn_cache_rule_resource.go
+++ b/internal/provider/cdn_cache_rule_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cdn_cache_rule_resource_test.go
+++ b/internal/provider/cdn_cache_rule_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCDNCacheRuleResource_basic(t *testing.T) {

--- a/internal/provider/cdn_loadbalancer_data_source.go
+++ b/internal/provider/cdn_loadbalancer_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cdn_loadbalancer_data_source_test.go
+++ b/internal/provider/cdn_loadbalancer_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCdnLoadbalancerDataSource_basic(t *testing.T) {

--- a/internal/provider/cdn_loadbalancer_resource.go
+++ b/internal/provider/cdn_loadbalancer_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cdn_loadbalancer_resource_test.go
+++ b/internal/provider/cdn_loadbalancer_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCDNLoadBalancerResource_basic(t *testing.T) {

--- a/internal/provider/cdn_purge_command_data_source.go
+++ b/internal/provider/cdn_purge_command_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cdn_purge_command_resource.go
+++ b/internal/provider/cdn_purge_command_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/certificate_blindfold_matrix_test.go
+++ b/internal/provider/certificate_blindfold_matrix_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/certificate_chain_data_source.go
+++ b/internal/provider/certificate_chain_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/certificate_chain_data_source_test.go
+++ b/internal/provider/certificate_chain_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCertificateChainDataSource_basic(t *testing.T) {

--- a/internal/provider/certificate_chain_resource.go
+++ b/internal/provider/certificate_chain_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/certificate_chain_resource_test.go
+++ b/internal/provider/certificate_chain_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCertificateChainResource_basic(t *testing.T) {

--- a/internal/provider/certificate_data_source.go
+++ b/internal/provider/certificate_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/certificate_data_source_test.go
+++ b/internal/provider/certificate_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCertificateDataSource_basic(t *testing.T) {

--- a/internal/provider/certificate_resource.go
+++ b/internal/provider/certificate_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/certificate_resource_test.go
+++ b/internal/provider/certificate_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCertificateResource_basic(t *testing.T) {

--- a/internal/provider/certified_hardware_data_source.go
+++ b/internal/provider/certified_hardware_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cloud_connect_data_source.go
+++ b/internal/provider/cloud_connect_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cloud_connect_data_source_test.go
+++ b/internal/provider/cloud_connect_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCloudConnectDataSource_basic(t *testing.T) {

--- a/internal/provider/cloud_connect_resource.go
+++ b/internal/provider/cloud_connect_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cloud_connect_resource_test.go
+++ b/internal/provider/cloud_connect_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCloudConnectResource_basic(t *testing.T) {

--- a/internal/provider/cloud_credentials_data_source.go
+++ b/internal/provider/cloud_credentials_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cloud_credentials_resource.go
+++ b/internal/provider/cloud_credentials_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cloud_credentials_resource_test.go
+++ b/internal/provider/cloud_credentials_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // TestAccCloudCredentialsResource_basic tests the basic creation and deletion of a cloud_credentials resource

--- a/internal/provider/cloud_elastic_ip_data_source.go
+++ b/internal/provider/cloud_elastic_ip_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cloud_elastic_ip_data_source_test.go
+++ b/internal/provider/cloud_elastic_ip_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCloudElasticIpDataSource_basic(t *testing.T) {

--- a/internal/provider/cloud_elastic_ip_resource.go
+++ b/internal/provider/cloud_elastic_ip_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cloud_elastic_ip_resource_test.go
+++ b/internal/provider/cloud_elastic_ip_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCloudElasticIPResource_basic(t *testing.T) {

--- a/internal/provider/cloud_link_data_source.go
+++ b/internal/provider/cloud_link_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cloud_link_data_source_test.go
+++ b/internal/provider/cloud_link_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCloudLinkDataSource_basic(t *testing.T) {

--- a/internal/provider/cloud_link_resource.go
+++ b/internal/provider/cloud_link_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cloud_link_resource_test.go
+++ b/internal/provider/cloud_link_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCloudLinkResource_basic(t *testing.T) {

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cluster_data_source_test.go
+++ b/internal/provider/cluster_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccClusterDataSource_basic(t *testing.T) {

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccClusterResource_basic(t *testing.T) {

--- a/internal/provider/cminstance_data_source.go
+++ b/internal/provider/cminstance_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/cminstance_resource.go
+++ b/internal/provider/cminstance_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/cminstance_resource_test.go
+++ b/internal/provider/cminstance_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCminstanceResource_basic(t *testing.T) {

--- a/internal/provider/code_base_integration_data_source.go
+++ b/internal/provider/code_base_integration_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/code_base_integration_data_source_test.go
+++ b/internal/provider/code_base_integration_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCodeBaseIntegrationDataSource_basic(t *testing.T) {

--- a/internal/provider/code_base_integration_resource.go
+++ b/internal/provider/code_base_integration_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/code_base_integration_resource_test.go
+++ b/internal/provider/code_base_integration_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCodeBaseIntegrationResource_basic(t *testing.T) {

--- a/internal/provider/container_registry_data_source.go
+++ b/internal/provider/container_registry_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/container_registry_data_source_test.go
+++ b/internal/provider/container_registry_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccContainerRegistryDataSource_basic(t *testing.T) {

--- a/internal/provider/container_registry_resource.go
+++ b/internal/provider/container_registry_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/container_registry_resource_test.go
+++ b/internal/provider/container_registry_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccContainerRegistryResource_basic(t *testing.T) {

--- a/internal/provider/crl_data_source.go
+++ b/internal/provider/crl_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/crl_data_source_test.go
+++ b/internal/provider/crl_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCrlDataSource_basic(t *testing.T) {

--- a/internal/provider/crl_resource.go
+++ b/internal/provider/crl_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/crl_resource_test.go
+++ b/internal/provider/crl_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccCRLResource_basic(t *testing.T) {

--- a/internal/provider/data_group_data_source.go
+++ b/internal/provider/data_group_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/data_group_data_source_test.go
+++ b/internal/provider/data_group_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDataGroupDataSource_basic(t *testing.T) {

--- a/internal/provider/data_group_resource.go
+++ b/internal/provider/data_group_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/data_group_resource_test.go
+++ b/internal/provider/data_group_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/data_type_data_source.go
+++ b/internal/provider/data_type_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/data_type_data_source_test.go
+++ b/internal/provider/data_type_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDataTypeDataSource_basic(t *testing.T) {

--- a/internal/provider/data_type_resource.go
+++ b/internal/provider/data_type_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/data_type_resource_test.go
+++ b/internal/provider/data_type_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/dc_cluster_group_data_source.go
+++ b/internal/provider/dc_cluster_group_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/dc_cluster_group_data_source_test.go
+++ b/internal/provider/dc_cluster_group_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDcClusterGroupDataSource_basic(t *testing.T) {

--- a/internal/provider/dc_cluster_group_resource.go
+++ b/internal/provider/dc_cluster_group_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/dc_cluster_group_resource_test.go
+++ b/internal/provider/dc_cluster_group_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDcClusterGroupResource_basic(t *testing.T) {

--- a/internal/provider/discovery_data_source.go
+++ b/internal/provider/discovery_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/discovery_data_source_test.go
+++ b/internal/provider/discovery_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDiscoveryDataSource_basic(t *testing.T) {

--- a/internal/provider/discovery_resource.go
+++ b/internal/provider/discovery_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/discovery_resource_test.go
+++ b/internal/provider/discovery_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDiscoveryResource_basic(t *testing.T) {

--- a/internal/provider/dns_compliance_checks_data_source.go
+++ b/internal/provider/dns_compliance_checks_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/dns_compliance_checks_data_source_test.go
+++ b/internal/provider/dns_compliance_checks_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDnsComplianceChecksDataSource_basic(t *testing.T) {

--- a/internal/provider/dns_compliance_checks_resource.go
+++ b/internal/provider/dns_compliance_checks_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/dns_compliance_checks_resource_test.go
+++ b/internal/provider/dns_compliance_checks_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDNSComplianceChecksResource_basic(t *testing.T) {

--- a/internal/provider/dns_domain_data_source.go
+++ b/internal/provider/dns_domain_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/dns_domain_data_source_test.go
+++ b/internal/provider/dns_domain_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccDnsDomainDataSource_basic(t *testing.T) {

--- a/internal/provider/dns_domain_resource.go
+++ b/internal/provider/dns_domain_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/dns_domain_resource_test.go
+++ b/internal/provider/dns_domain_resource_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/dns_proxy_data_source.go
+++ b/internal/provider/dns_proxy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/dns_proxy_resource.go
+++ b/internal/provider/dns_proxy_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/endpoint_data_source.go
+++ b/internal/provider/endpoint_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/endpoint_data_source_test.go
+++ b/internal/provider/endpoint_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccEndpointDataSource_basic(t *testing.T) {

--- a/internal/provider/endpoint_resource.go
+++ b/internal/provider/endpoint_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/endpoint_resource_test.go
+++ b/internal/provider/endpoint_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccEndpointResource_basic(t *testing.T) {

--- a/internal/provider/enhanced_firewall_policy_data_source.go
+++ b/internal/provider/enhanced_firewall_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/enhanced_firewall_policy_data_source_test.go
+++ b/internal/provider/enhanced_firewall_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccEnhancedFirewallPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/enhanced_firewall_policy_resource.go
+++ b/internal/provider/enhanced_firewall_policy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/enhanced_firewall_policy_resource_test.go
+++ b/internal/provider/enhanced_firewall_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccEnhancedFirewallPolicyResource_basic(t *testing.T) {

--- a/internal/provider/external_connector_data_source.go
+++ b/internal/provider/external_connector_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/external_connector_data_source_test.go
+++ b/internal/provider/external_connector_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccExternalConnectorDataSource_basic(t *testing.T) {

--- a/internal/provider/external_connector_resource.go
+++ b/internal/provider/external_connector_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/external_connector_resource_test.go
+++ b/internal/provider/external_connector_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccExternalConnectorResource_basic(t *testing.T) {

--- a/internal/provider/fast_acl_data_source.go
+++ b/internal/provider/fast_acl_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/fast_acl_data_source_test.go
+++ b/internal/provider/fast_acl_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFastAclDataSource_basic(t *testing.T) {

--- a/internal/provider/fast_acl_resource.go
+++ b/internal/provider/fast_acl_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/fast_acl_resource_test.go
+++ b/internal/provider/fast_acl_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFastACLResource_basic(t *testing.T) {

--- a/internal/provider/fast_acl_rule_data_source.go
+++ b/internal/provider/fast_acl_rule_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/fast_acl_rule_data_source_test.go
+++ b/internal/provider/fast_acl_rule_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFastAclRuleDataSource_basic(t *testing.T) {

--- a/internal/provider/fast_acl_rule_resource.go
+++ b/internal/provider/fast_acl_rule_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/fast_acl_rule_resource_test.go
+++ b/internal/provider/fast_acl_rule_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFastACLRuleResource_basic(t *testing.T) {

--- a/internal/provider/filter_set_data_source.go
+++ b/internal/provider/filter_set_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/filter_set_data_source_test.go
+++ b/internal/provider/filter_set_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFilterSetDataSource_basic(t *testing.T) {

--- a/internal/provider/filter_set_resource.go
+++ b/internal/provider/filter_set_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/filter_set_resource_test.go
+++ b/internal/provider/filter_set_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/fleet_data_source.go
+++ b/internal/provider/fleet_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/fleet_data_source_test.go
+++ b/internal/provider/fleet_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFleetDataSource_basic(t *testing.T) {

--- a/internal/provider/fleet_resource.go
+++ b/internal/provider/fleet_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/fleet_resource_test.go
+++ b/internal/provider/fleet_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccFleetResource_basic(t *testing.T) {

--- a/internal/provider/flow_anomaly_data_source.go
+++ b/internal/provider/flow_anomaly_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/forward_proxy_policy_data_source.go
+++ b/internal/provider/forward_proxy_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/forward_proxy_policy_data_source_test.go
+++ b/internal/provider/forward_proxy_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccForwardProxyPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/forward_proxy_policy_resource.go
+++ b/internal/provider/forward_proxy_policy_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/forward_proxy_policy_resource_test.go
+++ b/internal/provider/forward_proxy_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccForwardProxyPolicyResource_basic(t *testing.T) {

--- a/internal/provider/forwarding_class_data_source.go
+++ b/internal/provider/forwarding_class_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/forwarding_class_resource.go
+++ b/internal/provider/forwarding_class_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/forwarding_class_resource_test.go
+++ b/internal/provider/forwarding_class_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/functions_registration.go
+++ b/internal/provider/functions_registration.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/functions"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/functions"
 )
 
 // Ensure XCSHProvider satisfies the provider.ProviderWithFunctions interface.

--- a/internal/provider/gcp_vpc_site_data_source.go
+++ b/internal/provider/gcp_vpc_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/gcp_vpc_site_data_source_test.go
+++ b/internal/provider/gcp_vpc_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccGcpVpcSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/gcp_vpc_site_resource.go
+++ b/internal/provider/gcp_vpc_site_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/gcp_vpc_site_resource_test.go
+++ b/internal/provider/gcp_vpc_site_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccGCPVPCSiteResource_basic(t *testing.T) {

--- a/internal/provider/global_log_receiver_data_source.go
+++ b/internal/provider/global_log_receiver_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/global_log_receiver_data_source_test.go
+++ b/internal/provider/global_log_receiver_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccGlobalLogReceiverDataSource_basic(t *testing.T) {

--- a/internal/provider/global_log_receiver_resource.go
+++ b/internal/provider/global_log_receiver_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/global_log_receiver_resource_test.go
+++ b/internal/provider/global_log_receiver_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccGlobalLogReceiverResource_basic(t *testing.T) {

--- a/internal/provider/healthcheck_data_source.go
+++ b/internal/provider/healthcheck_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/healthcheck_data_source_test.go
+++ b/internal/provider/healthcheck_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccHealthcheckDataSource_basic(t *testing.T) {

--- a/internal/provider/healthcheck_origin_pool_matrix_test.go
+++ b/internal/provider/healthcheck_origin_pool_matrix_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/healthcheck_resource.go
+++ b/internal/provider/healthcheck_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/healthcheck_resource_test.go
+++ b/internal/provider/healthcheck_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/http_loadbalancer_data_source.go
+++ b/internal/provider/http_loadbalancer_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/http_loadbalancer_data_source_test.go
+++ b/internal/provider/http_loadbalancer_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccHttpLoadbalancerDataSource_basic(t *testing.T) {

--- a/internal/provider/http_loadbalancer_resource.go
+++ b/internal/provider/http_loadbalancer_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/http_loadbalancer_resource_test.go
+++ b/internal/provider/http_loadbalancer_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/ike1_data_source.go
+++ b/internal/provider/ike1_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/ike1_resource.go
+++ b/internal/provider/ike1_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/ike2_data_source.go
+++ b/internal/provider/ike2_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/ike2_resource.go
+++ b/internal/provider/ike2_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/ike_phase1_profile_data_source.go
+++ b/internal/provider/ike_phase1_profile_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/ike_phase1_profile_resource.go
+++ b/internal/provider/ike_phase1_profile_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/ike_phase2_profile_data_source.go
+++ b/internal/provider/ike_phase2_profile_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/ike_phase2_profile_resource.go
+++ b/internal/provider/ike_phase2_profile_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/ip_prefix_set_data_source.go
+++ b/internal/provider/ip_prefix_set_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/ip_prefix_set_data_source_test.go
+++ b/internal/provider/ip_prefix_set_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccIpPrefixSetDataSource_basic(t *testing.T) {

--- a/internal/provider/ip_prefix_set_resource.go
+++ b/internal/provider/ip_prefix_set_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/ip_prefix_set_resource_test.go
+++ b/internal/provider/ip_prefix_set_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/irule_data_source.go
+++ b/internal/provider/irule_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/irule_data_source_test.go
+++ b/internal/provider/irule_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccIruleDataSource_basic(t *testing.T) {

--- a/internal/provider/irule_resource.go
+++ b/internal/provider/irule_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/irule_resource_test.go
+++ b/internal/provider/irule_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccIruleResource_basic(t *testing.T) {

--- a/internal/provider/k8s_cluster_data_source.go
+++ b/internal/provider/k8s_cluster_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/k8s_cluster_resource.go
+++ b/internal/provider/k8s_cluster_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/k8s_cluster_role_binding_data_source.go
+++ b/internal/provider/k8s_cluster_role_binding_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/k8s_cluster_role_binding_resource.go
+++ b/internal/provider/k8s_cluster_role_binding_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/k8s_cluster_role_data_source.go
+++ b/internal/provider/k8s_cluster_role_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/k8s_cluster_role_resource.go
+++ b/internal/provider/k8s_cluster_role_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/k8s_pod_security_admission_data_source.go
+++ b/internal/provider/k8s_pod_security_admission_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/k8s_pod_security_admission_resource.go
+++ b/internal/provider/k8s_pod_security_admission_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/k8s_pod_security_policy_data_source.go
+++ b/internal/provider/k8s_pod_security_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/k8s_pod_security_policy_resource.go
+++ b/internal/provider/k8s_pod_security_policy_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/lma_region_data_source.go
+++ b/internal/provider/lma_region_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/log_receiver_data_source.go
+++ b/internal/provider/log_receiver_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/log_receiver_data_source_test.go
+++ b/internal/provider/log_receiver_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccLogReceiverDataSource_basic(t *testing.T) {

--- a/internal/provider/log_receiver_resource.go
+++ b/internal/provider/log_receiver_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/log_receiver_resource_test.go
+++ b/internal/provider/log_receiver_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccLogReceiverResource_basic(t *testing.T) {

--- a/internal/provider/malicious_user_mitigation_data_source.go
+++ b/internal/provider/malicious_user_mitigation_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/malicious_user_mitigation_data_source_test.go
+++ b/internal/provider/malicious_user_mitigation_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccMaliciousUserMitigationDataSource_basic(t *testing.T) {

--- a/internal/provider/malicious_user_mitigation_resource.go
+++ b/internal/provider/malicious_user_mitigation_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/malicious_user_mitigation_resource_test.go
+++ b/internal/provider/malicious_user_mitigation_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // testAccMaliciousUserMitigationImportStateIdFunc returns a function that generates the import ID

--- a/internal/provider/namespace_data_source.go
+++ b/internal/provider/namespace_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/namespace_data_source_test.go
+++ b/internal/provider/namespace_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNamespaceDataSource_basic(t *testing.T) {

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -18,9 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/nat_policy_data_source.go
+++ b/internal/provider/nat_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/nat_policy_data_source_test.go
+++ b/internal/provider/nat_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNatPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/nat_policy_resource.go
+++ b/internal/provider/nat_policy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/nat_policy_resource_test.go
+++ b/internal/provider/nat_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNatPolicyResource_basic(t *testing.T) {

--- a/internal/provider/network_connector_data_source.go
+++ b/internal/provider/network_connector_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_connector_data_source_test.go
+++ b/internal/provider/network_connector_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkConnectorDataSource_basic(t *testing.T) {

--- a/internal/provider/network_connector_resource.go
+++ b/internal/provider/network_connector_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/network_connector_resource_test.go
+++ b/internal/provider/network_connector_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // TestAccNetworkConnectorResource_basic tests the basic creation and deletion of a network_connector resource

--- a/internal/provider/network_firewall_data_source.go
+++ b/internal/provider/network_firewall_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_firewall_data_source_test.go
+++ b/internal/provider/network_firewall_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkFirewallDataSource_basic(t *testing.T) {

--- a/internal/provider/network_firewall_resource.go
+++ b/internal/provider/network_firewall_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/network_firewall_resource_test.go
+++ b/internal/provider/network_firewall_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkFirewallResource_basic(t *testing.T) {

--- a/internal/provider/network_interface_data_source.go
+++ b/internal/provider/network_interface_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_interface_data_source_test.go
+++ b/internal/provider/network_interface_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkInterfaceDataSource_basic(t *testing.T) {

--- a/internal/provider/network_interface_resource.go
+++ b/internal/provider/network_interface_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/network_interface_resource_test.go
+++ b/internal/provider/network_interface_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkInterfaceResource_basic(t *testing.T) {

--- a/internal/provider/network_policy_data_source.go
+++ b/internal/provider/network_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_policy_data_source_test.go
+++ b/internal/provider/network_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/network_policy_resource.go
+++ b/internal/provider/network_policy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/network_policy_resource_test.go
+++ b/internal/provider/network_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkPolicyResource_basic(t *testing.T) {

--- a/internal/provider/network_policy_rule_data_source.go
+++ b/internal/provider/network_policy_rule_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_policy_rule_data_source_test.go
+++ b/internal/provider/network_policy_rule_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkPolicyRuleDataSource_basic(t *testing.T) {

--- a/internal/provider/network_policy_rule_resource.go
+++ b/internal/provider/network_policy_rule_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/network_policy_rule_resource_test.go
+++ b/internal/provider/network_policy_rule_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkPolicyRuleResource_basic(t *testing.T) {

--- a/internal/provider/network_policy_set_data_source.go
+++ b/internal/provider/network_policy_set_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_policy_view_data_source.go
+++ b/internal/provider/network_policy_view_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/network_policy_view_data_source_test.go
+++ b/internal/provider/network_policy_view_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkPolicyViewDataSource_basic(t *testing.T) {

--- a/internal/provider/network_policy_view_resource.go
+++ b/internal/provider/network_policy_view_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/network_policy_view_resource_test.go
+++ b/internal/provider/network_policy_view_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNetworkPolicyViewResource_basic(t *testing.T) {

--- a/internal/provider/nfv_service_data_source.go
+++ b/internal/provider/nfv_service_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/nfv_service_data_source_test.go
+++ b/internal/provider/nfv_service_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNfvServiceDataSource_basic(t *testing.T) {

--- a/internal/provider/nfv_service_resource.go
+++ b/internal/provider/nfv_service_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/nfv_service_resource_test.go
+++ b/internal/provider/nfv_service_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccNFVServiceResource_basic(t *testing.T) {

--- a/internal/provider/nginx_csg_data_source.go
+++ b/internal/provider/nginx_csg_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/nginx_instance_data_source.go
+++ b/internal/provider/nginx_instance_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/nginx_server_data_source.go
+++ b/internal/provider/nginx_server_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/nginx_service_discovery_data_source.go
+++ b/internal/provider/nginx_service_discovery_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/nginx_service_discovery_resource.go
+++ b/internal/provider/nginx_service_discovery_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/origin_pool_data_source.go
+++ b/internal/provider/origin_pool_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/origin_pool_data_source_test.go
+++ b/internal/provider/origin_pool_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccOriginPoolDataSource_basic(t *testing.T) {

--- a/internal/provider/origin_pool_resource.go
+++ b/internal/provider/origin_pool_resource.go
@@ -25,9 +25,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/origin_pool_resource_test.go
+++ b/internal/provider/origin_pool_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/policer_data_source.go
+++ b/internal/provider/policer_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/policer_data_source_test.go
+++ b/internal/provider/policer_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccPolicerDataSource_basic(t *testing.T) {

--- a/internal/provider/policer_resource.go
+++ b/internal/provider/policer_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/policer_resource_test.go
+++ b/internal/provider/policer_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/policy_based_routing_data_source.go
+++ b/internal/provider/policy_based_routing_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/policy_based_routing_data_source_test.go
+++ b/internal/provider/policy_based_routing_data_source_test.go
@@ -5,7 +5,7 @@ package provider_test
 import (
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccPolicyBasedRoutingDataSource_basic(t *testing.T) {

--- a/internal/provider/policy_based_routing_resource.go
+++ b/internal/provider/policy_based_routing_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/policy_based_routing_resource_test.go
+++ b/internal/provider/policy_based_routing_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccPolicyBasedRoutingResource_basic(t *testing.T) {

--- a/internal/provider/protocol_inspection_data_source.go
+++ b/internal/provider/protocol_inspection_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/protocol_inspection_resource.go
+++ b/internal/provider/protocol_inspection_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/protocol_inspection_resource_test.go
+++ b/internal/provider/protocol_inspection_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccProtocolInspectionResource_basic(t *testing.T) {

--- a/internal/provider/protocol_policer_data_source.go
+++ b/internal/provider/protocol_policer_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/protocol_policer_resource.go
+++ b/internal/provider/protocol_policer_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/protocol_policer_resource_test.go
+++ b/internal/provider/protocol_policer_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccProtocolPolicerResource_basic(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 // Ensure XCSHProvider satisfies various provider interfaces.

--- a/internal/provider/proxy_data_source.go
+++ b/internal/provider/proxy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/proxy_data_source_test.go
+++ b/internal/provider/proxy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccProxyDataSource_basic(t *testing.T) {

--- a/internal/provider/proxy_resource.go
+++ b/internal/provider/proxy_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/proxy_resource_test.go
+++ b/internal/provider/proxy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccProxyResource_basic(t *testing.T) {

--- a/internal/provider/rate_limiter_data_source.go
+++ b/internal/provider/rate_limiter_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/rate_limiter_data_source_test.go
+++ b/internal/provider/rate_limiter_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccRateLimiterDataSource_basic(t *testing.T) {

--- a/internal/provider/rate_limiter_policy_data_source.go
+++ b/internal/provider/rate_limiter_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/rate_limiter_policy_data_source_test.go
+++ b/internal/provider/rate_limiter_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccRateLimiterPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/rate_limiter_policy_resource.go
+++ b/internal/provider/rate_limiter_policy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/rate_limiter_policy_resource_test.go
+++ b/internal/provider/rate_limiter_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccRateLimiterPolicyResource_basic(t *testing.T) {

--- a/internal/provider/rate_limiter_resource.go
+++ b/internal/provider/rate_limiter_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/rate_limiter_resource_test.go
+++ b/internal/provider/rate_limiter_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/resource_base.go
+++ b/internal/provider/resource_base.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
 )
 
 // ResourceType categorizes resources for timeout configuration

--- a/internal/provider/route_data_source.go
+++ b/internal/provider/route_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/route_resource_test.go
+++ b/internal/provider/route_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccRouteResource_basic(t *testing.T) {

--- a/internal/provider/secret_management_access_data_source.go
+++ b/internal/provider/secret_management_access_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/secret_management_access_resource.go
+++ b/internal/provider/secret_management_access_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/securemesh_site_data_source.go
+++ b/internal/provider/securemesh_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/securemesh_site_data_source_test.go
+++ b/internal/provider/securemesh_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccSecuremeshSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/securemesh_site_resource.go
+++ b/internal/provider/securemesh_site_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/securemesh_site_resource_test.go
+++ b/internal/provider/securemesh_site_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/securemesh_site_v2_data_source.go
+++ b/internal/provider/securemesh_site_v2_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/securemesh_site_v2_resource.go
+++ b/internal/provider/securemesh_site_v2_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/segment_data_source.go
+++ b/internal/provider/segment_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/segment_data_source_test.go
+++ b/internal/provider/segment_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccSegmentDataSource_basic(t *testing.T) {

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -18,9 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/segment_resource_test.go
+++ b/internal/provider/segment_resource_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )

--- a/internal/provider/sensitive_data_policy_data_source.go
+++ b/internal/provider/sensitive_data_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/sensitive_data_policy_data_source_test.go
+++ b/internal/provider/sensitive_data_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccSensitiveDataPolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/sensitive_data_policy_resource.go
+++ b/internal/provider/sensitive_data_policy_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/sensitive_data_policy_resource_test.go
+++ b/internal/provider/sensitive_data_policy_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/service_policy_data_source.go
+++ b/internal/provider/service_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/service_policy_data_source_test.go
+++ b/internal/provider/service_policy_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccServicePolicyDataSource_basic(t *testing.T) {

--- a/internal/provider/service_policy_resource.go
+++ b/internal/provider/service_policy_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/service_policy_resource_test.go
+++ b/internal/provider/service_policy_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/service_policy_rule_data_source.go
+++ b/internal/provider/service_policy_rule_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/service_policy_rule_data_source_test.go
+++ b/internal/provider/service_policy_rule_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/service_policy_rule_resource.go
+++ b/internal/provider/service_policy_rule_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/service_policy_rule_resource_test.go
+++ b/internal/provider/service_policy_rule_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/service_policy_set_data_source.go
+++ b/internal/provider/service_policy_set_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/shape_bot_defense_instance_data_source.go
+++ b/internal/provider/shape_bot_defense_instance_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/site_data_source.go
+++ b/internal/provider/site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/site_mesh_group_data_source.go
+++ b/internal/provider/site_mesh_group_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/site_mesh_group_resource.go
+++ b/internal/provider/site_mesh_group_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/site_mesh_group_resource_test.go
+++ b/internal/provider/site_mesh_group_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/srv6_network_slice_data_source.go
+++ b/internal/provider/srv6_network_slice_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/srv6_network_slice_resource.go
+++ b/internal/provider/srv6_network_slice_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/subnet_data_source.go
+++ b/internal/provider/subnet_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/subnet_data_source_test.go
+++ b/internal/provider/subnet_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccSubnetDataSource_basic(t *testing.T) {

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/subnet_resource_test.go
+++ b/internal/provider/subnet_resource_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )

--- a/internal/provider/tcp_loadbalancer_data_source.go
+++ b/internal/provider/tcp_loadbalancer_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/tcp_loadbalancer_data_source_test.go
+++ b/internal/provider/tcp_loadbalancer_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccTcpLoadbalancerDataSource_basic(t *testing.T) {

--- a/internal/provider/tcp_loadbalancer_resource.go
+++ b/internal/provider/tcp_loadbalancer_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/tcp_loadbalancer_resource_test.go
+++ b/internal/provider/tcp_loadbalancer_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/tenant_configuration_data_source.go
+++ b/internal/provider/tenant_configuration_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/tenant_configuration_resource.go
+++ b/internal/provider/tenant_configuration_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/tenant_configuration_resource_mock_test.go
+++ b/internal/provider/tenant_configuration_resource_mock_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/mocks"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/mocks"
 )
 
 // =============================================================================

--- a/internal/provider/tenant_configuration_resource_test.go
+++ b/internal/provider/tenant_configuration_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/third_party_application_data_source.go
+++ b/internal/provider/third_party_application_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/trusted_ca_list_data_source.go
+++ b/internal/provider/trusted_ca_list_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/trusted_ca_list_data_source_test.go
+++ b/internal/provider/trusted_ca_list_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccTrustedCaListDataSource_basic(t *testing.T) {

--- a/internal/provider/trusted_ca_list_resource.go
+++ b/internal/provider/trusted_ca_list_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/trusted_ca_list_resource_test.go
+++ b/internal/provider/trusted_ca_list_resource_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/tunnel_data_source.go
+++ b/internal/provider/tunnel_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/tunnel_data_source_test.go
+++ b/internal/provider/tunnel_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccTunnelDataSource_basic(t *testing.T) {

--- a/internal/provider/tunnel_resource.go
+++ b/internal/provider/tunnel_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/tunnel_resource_test.go
+++ b/internal/provider/tunnel_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/udp_loadbalancer_data_source.go
+++ b/internal/provider/udp_loadbalancer_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/udp_loadbalancer_resource.go
+++ b/internal/provider/udp_loadbalancer_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/udp_loadbalancer_resource_test.go
+++ b/internal/provider/udp_loadbalancer_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/usb_policy_data_source.go
+++ b/internal/provider/usb_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/usb_policy_resource.go
+++ b/internal/provider/usb_policy_resource.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/usb_policy_resource_test.go
+++ b/internal/provider/usb_policy_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/user_identification_data_source.go
+++ b/internal/provider/user_identification_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/user_identification_data_source_test.go
+++ b/internal/provider/user_identification_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccUserIdentificationDataSource_basic(t *testing.T) {

--- a/internal/provider/user_identification_resource.go
+++ b/internal/provider/user_identification_resource.go
@@ -20,9 +20,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/user_identification_resource_test.go
+++ b/internal/provider/user_identification_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/virtual_host_data_source.go
+++ b/internal/provider/virtual_host_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/virtual_host_data_source_test.go
+++ b/internal/provider/virtual_host_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccVirtualHostDataSource_basic(t *testing.T) {

--- a/internal/provider/virtual_host_resource.go
+++ b/internal/provider/virtual_host_resource.go
@@ -24,9 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/virtual_host_resource_test.go
+++ b/internal/provider/virtual_host_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/virtual_k8s_data_source.go
+++ b/internal/provider/virtual_k8s_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/virtual_k8s_resource.go
+++ b/internal/provider/virtual_k8s_resource.go
@@ -22,9 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/virtual_network_data_source.go
+++ b/internal/provider/virtual_network_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/virtual_network_data_source_test.go
+++ b/internal/provider/virtual_network_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccVirtualNetworkDataSource_basic(t *testing.T) {

--- a/internal/provider/virtual_network_resource.go
+++ b/internal/provider/virtual_network_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/virtual_network_resource_test.go
+++ b/internal/provider/virtual_network_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // testAccVirtualNetworkImportStateIdFunc returns a function that generates the import ID

--- a/internal/provider/virtual_site_data_source.go
+++ b/internal/provider/virtual_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/virtual_site_data_source_test.go
+++ b/internal/provider/virtual_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccVirtualSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/virtual_site_resource.go
+++ b/internal/provider/virtual_site_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/virtual_site_resource_test.go
+++ b/internal/provider/virtual_site_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/voltstack_site_data_source.go
+++ b/internal/provider/voltstack_site_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/voltstack_site_data_source_test.go
+++ b/internal/provider/voltstack_site_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccVoltstackSiteDataSource_basic(t *testing.T) {

--- a/internal/provider/voltstack_site_resource.go
+++ b/internal/provider/voltstack_site_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/voltstack_site_resource_test.go
+++ b/internal/provider/voltstack_site_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/waf_exclusion_policy_data_source.go
+++ b/internal/provider/waf_exclusion_policy_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/waf_exclusion_policy_resource.go
+++ b/internal/provider/waf_exclusion_policy_resource.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/waf_exclusion_policy_resource_test.go
+++ b/internal/provider/waf_exclusion_policy_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/workload_data_source.go
+++ b/internal/provider/workload_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/workload_data_source_test.go
+++ b/internal/provider/workload_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccWorkloadDataSource_basic(t *testing.T) {

--- a/internal/provider/workload_flavor_data_source.go
+++ b/internal/provider/workload_flavor_data_source.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/internal/provider/workload_flavor_data_source_test.go
+++ b/internal/provider/workload_flavor_data_source_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func TestAccWorkloadFlavorDataSource_basic(t *testing.T) {

--- a/internal/provider/workload_flavor_resource.go
+++ b/internal/provider/workload_flavor_resource.go
@@ -18,9 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/workload_flavor_resource_test.go
+++ b/internal/provider/workload_flavor_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/internal/provider/workload_resource.go
+++ b/internal/provider/workload_resource.go
@@ -23,9 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/workload_resource_test.go
+++ b/internal/provider/workload_resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 // =============================================================================

--- a/main.go
+++ b/main.go
@@ -1,15 +1,15 @@
 // Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 // terraform-provider-xcsh provides Terraform resources for managing F5 Distributed Cloud services.
-// For documentation, see https://registry.terraform.io/providers/f5xc-salesdemos/xcsh/latest/docs
+// For documentation, see https://registry.terraform.io/providers/f5-sales-demo/xcsh/latest/docs
 //
 // Documentation features OneOf property grouping for mutually exclusive arguments,
 // improving clarity by grouping related properties with a single explanatory note.
 //
 // Version tagging and releases are automated via CI/CD using semantic versioning.
 // Release workflow uses forked action with updated dependencies for improved cache performance.
-// MCP server documentation is available at https://github.com/f5xc-salesdemos/terraform-provider-xcsh/tree/main/mcp-server
-// Rebranded from f5xc to xcsh. The GitHub org f5xc-salesdemos is unchanged.
+// MCP server documentation is available at https://github.com/f5-sales-demo/terraform-provider-xcsh/tree/main/mcp-server
+// Rebranded from f5xc to xcsh. The GitHub org f5-sales-demo is unchanged.
 
 package main
 
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/provider"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -49,7 +49,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/f5xc-salesdemos/xcsh",
+		Address: "registry.terraform.io/f5-sales-demo/xcsh",
 		Debug:   debug,
 	}
 

--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -32,8 +32,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/resource"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/resource"
 )
 
 // ============================================================================

--- a/tools/fix-client-types.go
+++ b/tools/fix-client-types.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
 )
 
 func main() {

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -29,12 +29,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/codegen"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/namespace"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/registration"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/schema"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/codegen"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/registration"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/schema"
 )
 
 // Configuration

--- a/tools/generate-datasource-examples.go
+++ b/tools/generate-datasource-examples.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/namespace"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
 )
 
 func main() {
@@ -63,7 +63,7 @@ func generateDataSourceExample(dataSourceName string) string {
 	sb.WriteString("  required_version = \">= 1.0\"\n\n")
 	sb.WriteString("  required_providers {\n")
 	sb.WriteString("    xcsh = {\n")
-	sb.WriteString("      source  = \"f5xc-salesdemos/f5xc\"\n")
+	sb.WriteString("      source  = \"f5-sales-demo/f5xc\"\n")
 	sb.WriteString("      version = \">= 0.1.0\"\n")
 	sb.WriteString("    }\n")
 	sb.WriteString("  }\n")

--- a/tools/generate-datasource-tests.go
+++ b/tools/generate-datasource-tests.go
@@ -731,7 +731,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/acctest"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/acctest"
 )
 
 func {{.TestFuncName}}(t *testing.T) {

--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -18,10 +18,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/defaults"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/namespace"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/defaults"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 // Global defaults store for API-discovered default values
@@ -323,7 +323,7 @@ func generateExample(resourceName string, schema *SchemaInfo) string {
 	sb.WriteString("  required_version = \">= 1.0\"\n\n")
 	sb.WriteString("  required_providers {\n")
 	sb.WriteString("    xcsh = {\n")
-	sb.WriteString("      source  = \"f5xc-salesdemos/f5xc\"\n")
+	sb.WriteString("      source  = \"f5-sales-demo/f5xc\"\n")
 	sb.WriteString("      version = \">= 0.1.0\"\n")
 	sb.WriteString("    }\n")
 	sb.WriteString("  }\n")

--- a/tools/generate-llms-txt.go
+++ b/tools/generate-llms-txt.go
@@ -25,7 +25,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/resource"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/resource"
 )
 
 // LLMsConfig represents the llms-config.json structure.
@@ -958,7 +958,7 @@ func generateL0(config *LLMsConfig, categories []CategoryInfo) error {
 	sb.WriteString("    terraform {\n")
 	sb.WriteString("      required_providers {\n")
 	sb.WriteString("        xcsh = {\n")
-	sb.WriteString("          source = \"f5xc-salesdemos/xcsh\"\n")
+	sb.WriteString("          source = \"f5-sales-demo/xcsh\"\n")
 	sb.WriteString("        }\n")
 	sb.WriteString("      }\n")
 	sb.WriteString("    }\n\n")
@@ -1165,7 +1165,7 @@ func generateJSONIndex(config *LLMsConfig, categories []CategoryInfo, reverseDep
 			RequiredBlock: `terraform {
   required_providers {
     xcsh = {
-      source = "f5xc-salesdemos/xcsh"
+      source = "f5-sales-demo/xcsh"
     }
   }
 }`,

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 func TestEscapeGoString(t *testing.T) {

--- a/tools/pkg/codegen/generate.go
+++ b/tools/pkg/codegen/generate.go
@@ -15,8 +15,8 @@ import (
 
 	"golang.org/x/tools/imports"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/schema"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/schema"
 )
 
 // GenerateResourceFile generates the Terraform resource Go file for a single resource.

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/schema"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/schema"
 )
 
 // NestedModelInfo holds information needed to generate a nested model type

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -52,9 +52,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
-	inttimeouts "github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/timeouts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/validators"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+	inttimeouts "github.com/f5-sales-demo/terraform-provider-xcsh/internal/timeouts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -655,7 +655,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (
@@ -795,7 +795,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 var (

--- a/tools/pkg/description/description.go
+++ b/tools/pkg/description/description.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
 )
 
 // Clean removes example annotations, validation rules, internal vendor extensions,

--- a/tools/pkg/registration/registration.go
+++ b/tools/pkg/registration/registration.go
@@ -13,8 +13,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 // CoreResources are resources that must always be registered in the provider,
@@ -163,7 +163,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/internal/client"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 )
 
 // Ensure XCSHProvider satisfies various provider interfaces.

--- a/tools/pkg/registration/registration_test.go
+++ b/tools/pkg/registration/registration_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 func TestCleanOrphanGeneratedFiles(t *testing.T) {

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/constraints"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/description"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/constraints"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/description"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 // MaxNestedDepth is the maximum recursion depth for nested schemas to prevent infinite loops.

--- a/tools/pkg/schema/convert_test.go
+++ b/tools/pkg/schema/convert_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 func TestMapSchemaType(t *testing.T) {

--- a/tools/pkg/schema/examples.go
+++ b/tools/pkg/schema/examples.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/namespace"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 // GenerateExampleUsage creates a sample HCL configuration for the resource.

--- a/tools/pkg/schema/examples_test.go
+++ b/tools/pkg/schema/examples_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 func TestGenerateExampleUsage_Basic(t *testing.T) {

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -7,10 +7,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/conflicts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/description"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/conflicts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/description"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 // ExtractConfig holds resource metadata maps that extractResourceSchema needs

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -5,7 +5,7 @@ package schema
 import (
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 func TestExtractOneOfGroups_Empty(t *testing.T) {

--- a/tools/pkg/schema/scan.go
+++ b/tools/pkg/schema/scan.go
@@ -3,8 +3,8 @@
 package schema
 
 import (
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/conflicts"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/conflicts"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 // HasNestedModelsWithAttrTypes checks recursively if any nested blocks would generate AttrTypes.

--- a/tools/pkg/schema/scan_test.go
+++ b/tools/pkg/schema/scan_test.go
@@ -5,7 +5,7 @@ package schema
 import (
 	"testing"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
 func TestHasNestedModelsWithAttrTypes(t *testing.T) {

--- a/tools/pkg/schema/terraform_schema_test.go
+++ b/tools/pkg/schema/terraform_schema_test.go
@@ -21,7 +21,7 @@ func TestParseTerraformSchema_DistinguishesBlocksFromAttributes(t *testing.T) {
 	input := `{
 		"format_version": "1.0",
 		"provider_schemas": {
-			"registry.terraform.io/f5xc-salesdemos/f5xc": {
+			"registry.terraform.io/f5-sales-demo/f5xc": {
 				"resource_schemas": {
 					"xcsh_http_loadbalancer": {
 						"version": 0,

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -20,10 +20,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/defaults"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/naming"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/openapi"
-	"github.com/f5xc-salesdemos/terraform-provider-xcsh/tools/pkg/resource"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/defaults"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/resource"
 )
 
 // Global defaults store for API-discovered default values
@@ -666,7 +666,7 @@ func buildResourceAPIPathMap() {
 // Returns empty string if no mapping exists
 func getResourceAPIDocURL(resourceName string) string {
 	if urlPath, ok := resourceAPIPathMap[resourceName]; ok {
-		return fmt.Sprintf("https://f5xc-salesdemos.github.io/api-specs-enriched/api-reference/%s/", urlPath)
+		return fmt.Sprintf("https://f5-sales-demo.github.io/api-specs-enriched/api-reference/%s/", urlPath)
 	}
 	return ""
 }


### PR DESCRIPTION
Closes #910

Updated 469 Go files with old f5xc-salesdemos import paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)