### PR TITLE
fix: unblock lint gate — biome manifest + Mermaid diagram + jscpd docs ignore

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,6 +1,8 @@
 {
   "threshold": 10,
-  "reporters": ["console"],
+  "reporters": [
+    "console"
+  ],
   "ignore": [
     "**/*.yaml",
     "**/*.yml",
@@ -16,8 +18,6 @@
     "**/internal/client/**",
     "**/internal/provider/**",
     "**/templates/**",
-    "**/docs/resources/**",
-    "**/docs/data-sources/**",
-    "**/docs/functions/**"
+    "**/docs/**"
   ]
 }

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,8 +1,6 @@
 {
   "threshold": 10,
-  "reporters": [
-    "console"
-  ],
+  "reporters": ["console"],
   "ignore": [
     "**/*.yaml",
     "**/*.yml",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,36 +107,15 @@ These files live in otherwise auto-generated directories but are hand-written:
 
 ## Workflow Architecture
 
-```
-Push to main (human commit)
-         |
-         v
-+------------------+
-| Detect Changes   | <-- What changed? (specs/code/tools)
-+--------+---------+
-         |
-         v
-+------------------+
-| Build & Test     | <-- Validate merged code
-+--------+---------+
-         |
-    +----+----+
-    v         v
-+-------+ +-------+
-| Regen | | Regen | <-- Regenerate if needed
-|Provider| | Docs  |
-+---+---+ +---+---+
-    +----+----+
-         v
-+------------------+
-| Create PR        | <-- Single consolidated PR
-| (if changes)     |   for all regeneration
-+--------+---------+
-         |
-         v
-+------------------+
-| Tag & Release    | <-- ONE version bump
-+------------------+
+```mermaid
+flowchart TD
+    push[Push to main<br/>human commit] --> detect[Detect Changes<br/>what changed? specs / code / tools]
+    detect --> build[Build &amp; Test<br/>validate merged code]
+    build --> regenProvider[Regenerate Provider<br/>if needed]
+    build --> regenDocs[Regenerate Docs<br/>if needed]
+    regenProvider --> pr[Create PR<br/>single consolidated PR for all regeneration]
+    regenDocs --> pr
+    pr --> release[Tag &amp; Release<br/>ONE version bump]
 ```
 
 Reusable workflows (`_build-test.yml`, `_generate-docs.yml`, `_generate-provider.yml`, `_tag-release.yml`) are called by the `on-merge.yml` orchestrator.

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,5 +1,6 @@
 {
-  "_gpg_key_updated": true, "version": 1,
+  "_gpg_key_updated": true,
+  "version": 1,
   "metadata": {
     "protocol_versions": ["6.0"]
   }


### PR DESCRIPTION
Resolves all `lint / Lint Code Base` failures blocking governance sync PR #953.

1. **`terraform-registry-manifest.json`** — biome format (two keys on one line → split; jq -S identical).
2. **`DEVELOPMENT.md`** — ASCII workflow diagram → Mermaid (removes JSCPD false-positive tokens; renders on GitHub).
3. **`.jscpd.json`** — ignore `**/docs/**` (mirrors docs-control #612). The narrow `**/docs/{resources,data-sources,functions}/**` patterns missed the i18n `docs/en/…` layout + generated guides, leaving ~224 generated docs tripping JSCPD (29.7%). JSCPD is a source-code copy-paste detector; generated/translated docs aren't source.

Verified locally: `biome ci` clean; `jscpd` 29.7% → 6.8% (exit 0), no Go/TS source clones suppressed. `.jscpd.json` is byte-identical to docs-control #612, so no managed-file drift once that lands.

Closes #954