### PR TITLE
fix(ci): install tfplugindocs@latest with GOTOOLCHAIN=auto

### DIFF
--- a/.github/workflows/_generate-docs.yml
+++ b/.github/workflows/_generate-docs.yml
@@ -45,7 +45,7 @@ jobs:
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "::group::Install tfplugindocs - Attempt $attempt of $max_attempts"
-            if go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; then
+            if GOTOOLCHAIN=auto go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; then
               echo "::endgroup::"
               break
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           attempt=1
           while [ "$attempt" -le "$max_attempts" ]; do
             echo "::group::Install tfplugindocs - Attempt $attempt of $max_attempts"
-            if go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; then
+            if GOTOOLCHAIN=auto go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; then
               echo "::endgroup::"
               break
             fi

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -316,7 +316,7 @@ jobs:
           attempt=1
           while [ "$attempt" -le "$max_attempts" ]; do
             echo "::group::Install tfplugindocs - Attempt $attempt of $max_attempts"
-            if go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; then
+            if GOTOOLCHAIN=auto go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; then
               echo "::endgroup::"
               break
             fi

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ docs:
 		tfplugindocs generate --provider-name xcsh; \
 	else \
 		echo "tfplugindocs not installed. Installing..."; \
-		$(GO) install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; \
+		GOTOOLCHAIN=auto $(GO) install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest; \
 		tfplugindocs generate --provider-name xcsh; \
 	fi
 	@echo "Transforming documentation to Volterra-style format..."


### PR DESCRIPTION
Closes #966

## Problem
`tfplugindocs@latest` is now **v0.25.0**, requiring **Go ≥ 1.25.8**. CI installs Go 1.25.0 (from `go.mod`) via `setup-go@v6` with the default `GOTOOLCHAIN=local`, so `go install tfplugindocs@latest` can't fetch the newer toolchain → install fails after retries. This broke `on-merge` **Regenerate Docs** and PR **Validate Docs Generation** (surfaced after unpinning tfplugindocs to `@latest` in #965).

## Fix
Prefix the `tfplugindocs@latest` install with `GOTOOLCHAIN=auto` so `go install` fetches whatever toolchain the latest release needs — self-healing for future bumps, no version pinning. Applied in `ci.yml`, `_generate-docs.yml`, `on-merge.yml`, and the Makefile `docs` target.

## Verification
- All 3 workflow YAMLs parse.
- `tfplugindocs@latest` installs cleanly locally (Go 1.26.4).
- Once merged, `on-merge` Regenerate Docs should complete and refresh `main`'s docs (which currently lag the provider/example regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)