### PR TITLE
chore(codegen): trigger catch-up regeneration of stale main output

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -5,7 +5,10 @@
 
 // generate-all-schemas.go - Batch generator for all F5 XC Terraform resources
 // This tool processes all OpenAPI spec files and generates comprehensive Terraform schemas.
-// Last synced: api-specs-enriched v2.1.129 (labels→labels property rename in fleetFlashBladeEndpoint)
+// It is also the single source of truth for generated Terraform examples (resource +
+// data-source), rendered schema-driven from the TerraformAttribute tree so they cannot
+// drift from the schema; orphan example dirs are pruned each run.
+// Last synced: api-specs-enriched v2.1.167
 //
 // CI/CD Integration:
 //   Changes to this file trigger the generate.yml workflow which regenerates all


### PR DESCRIPTION
Closes #968

`main`'s generated output has been stale since #893 — **491 files still reference `f5-sales-demo/f5xc`**, DNS resources are missing, and provider code predates the types.List fix (#961). The `on-merge` regeneration pipeline was blocked at the `tfplugindocs` install step (fixed in #967).

This makes a minimal, accurate generator-header change (synced spec version `v2.1.129`→`v2.1.167`; documents the schema-driven example generation added in #965) so `detect-changes` requests regeneration. On merge, the now-succeeding pipeline opens a `chore: auto-regenerate` PR that brings `main`'s provider/examples/docs current and eliminates the `f5xc` references — unblocking QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)