### PR TITLE
fix(ci): accept either spec asset name (xcsh/f5xc) + trigger provider regeneration

### DIFF
--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -41,7 +41,7 @@ jobs:
             echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
             mkdir -p "${{ inputs.spec-dir }}"
             ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
-              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs"))] | .[0].id')
+              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
             if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
               gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
                 -H "Accept: application/octet-stream" > /tmp/specs.zip

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -283,7 +283,7 @@ jobs:
             echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
             mkdir -p "$SPEC_DIR"
             ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
-              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs"))] | .[0].id')
+              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
             if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
               gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
                 -H "Accept: application/octet-stream" > /tmp/specs.zip

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -131,7 +131,7 @@ jobs:
             # V2: Download via gh api (supports private repos)
             echo "Downloading v2 specs via gh api..."
             ASSET_ID=$(gh api "repos/${{ env.ENRICHED_REPO }}/releases" --jq \
-              '[.[0].assets[] | select(.name | startswith("f5xc-api-specs"))] | .[0].id')
+              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
             gh api "repos/${{ env.ENRICHED_REPO }}/releases/assets/${ASSET_ID}" \
               -H "Accept: application/octet-stream" > openapi.zip
             echo "Download successful"

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ download-specs:
 	@LATEST=$$(gh api repos/$(ENRICHED_REPO)/releases --jq '.[0].tag_name'); \
 	echo "Version: $$LATEST"; \
 	ASSET_ID=$$(gh api repos/$(ENRICHED_REPO)/releases --jq \
-		'[.[0].assets[] | select(.name | startswith("f5xc-api-specs"))] | .[0].id'); \
+		'[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id'); \
 	gh api repos/$(ENRICHED_REPO)/releases/assets/$$ASSET_ID \
 		-H "Accept: application/octet-stream" > /tmp/specs.zip; \
 	rm -rf $(SPEC_DIR)/*; \

--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -8,7 +8,7 @@
 // It is also the single source of truth for generated Terraform examples (resource +
 // data-source), rendered schema-driven from the TerraformAttribute tree so they cannot
 // drift from the schema; orphan example dirs are pruned each run.
-// Last synced: api-specs-enriched v2.1.167
+// Last synced: api-specs-enriched v2.1.168 (spec asset renamed f5xc-api-specs -> xcsh-api-specs; downloads accept either during transition)
 //
 // CI/CD Integration:
 //   Changes to this file trigger the generate.yml workflow which regenerates all


### PR DESCRIPTION
Closes #968

## Problem
`main`'s provider code is still stale — no DNS resources, and generated code predates the types.List fix (#961) — because CI's provider-regeneration jobs (`on-merge`, `_generate-provider.yml`) look only for the `xcsh-api-specs` release asset. The published asset is still `f5xc-api-specs-v2.1.168` (the `api-specs-enriched` rename is mid-transition), so those jobs download nothing and skip provider regeneration. #972 could therefore only refresh docs/examples (fixing the `f5xc` QA blocker), not the provider.

## Fix
All spec downloads now accept **either** asset name (`xcsh-api-specs` **or** `f5xc-api-specs`) — works today via `f5xc-api-specs` and after the asset is republished as `xcsh-api-specs`, with no version pinning. Applied to `Makefile`, `sync-openapi.yml`, `_generate-provider.yml`, `on-merge.yml`.

The generator-header bump (synced `v2.1.168`) is a `tools/` change so `detect-changes` requests a regeneration. On merge, the now-working spec download lets `on-merge` regenerate the **provider** (DNS resources + types.List fix) and open a `chore: auto-regenerate` PR that brings `main` fully current.

Verified: latest release `v2.1.168` `f5xc-api-specs` asset contains the `dns` domain (38 domains), so `dns_zone`/`dns_lb_*` will generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)