### PR TITLE
fix(ci): bound GoReleaser build parallelism to avoid release OOM

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -160,6 +160,11 @@ jobs:
       gpg-private-key-passphrase: ${{ secrets.gpg-passphrase }}
     with:
       setup-go-version-file: 'go.mod'
+      # Build one target at a time. GoReleaser defaults to NumCPU concurrent builds;
+      # compiling the large generated provider (~121 resources) on that many at once
+      # OOM-kills the runner (exit 143). Serial builds match the proven single-build
+      # footprint and keep releases reliably green (raise to 2 only if runner RAM allows).
+      goreleaser-release-args: '--parallelism 1'
 
   upload-mcp-data:
     name: Upload MCP Data Artifact


### PR DESCRIPTION
Closes #976

## Problem
`Tag and Release / Create Release` (GoReleaser via `robinmordasiewicz/ghaction-terraform-provider-release@v6`) fails reproducibly — runner killed (exit 143) the instant GoReleaser starts building. It builds with default parallelism = NumCPU (4 concurrent); each build compiles the large generated provider (~121 resources, 400k+ lines). A single build succeeds (~9 min in Build and Test), but 4 concurrent compiles OOM the runner. Tag `v3.61.15` was created but its release never published. Started after the DNS resources grew the provider (#968).

## Fix
Pass `--parallelism 1` via the external workflow's supported `goreleaser-release-args` input, so targets build one at a time — same memory footprint as the proven single build. Reliability over speed for a large provider; can raise to 2 later if runner RAM allows.

Merging this cuts a new patch release that will exercise the fix (the dangling `v3.61.15` tag can be cleaned up separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)