### PR TITLE
ci: add manual (workflow_dispatch) release trigger

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,30 @@
+---
+# Manual release entrypoint.
+#
+# on-merge.yml only tags/releases on a bot regeneration or a substantive
+# non-workflow merge. When content is already on main but no such merge is
+# pending (e.g. after a failed/OOM'd release, or when subsequent commits are
+# workflow/governance-only), there is otherwise no way to cut a release. This
+# workflow_dispatch invokes the same reusable tag+release pipeline (which builds
+# with --parallelism 1) to publish the next semver version from current main.
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      create-release:
+        description: 'Create a GitHub release after tagging'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/_tag-release.yml
+    with:
+      create-release: ${{ inputs.create-release }}
+    secrets:
+      gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+      gpg-passphrase: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
Adds `.github/workflows/release-manual.yml` — a `workflow_dispatch` entrypoint that invokes the existing reusable `_tag-release.yml` to cut the next semver tag + release from current `main` on demand (serial `--parallelism 1` build, so no OOM).

## Why
`on-merge` only tags/releases on a bot regeneration or a substantive non-workflow merge. The DNS resources merged to `main` via #975, but that release OOM'd (fixed since by #977) and every merge since is workflow/governance-only → no release. Regeneration is a no-op (main is already at the latest spec). This gives a way to publish already-merged content.

## Verification
After merge, dispatch **Manual Release** → cuts `v3.61.15` from `main` (contains the DNS resources) and publishes it.

Closes #982