### PR TITLE
feat(generate): drive namespace attribute from the spec namespace-profile constraint

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -286,9 +286,19 @@ func processV2Resource(domainFile string, resource openapi.ExtractedResource, do
 	if domainInfo.Spec != nil {
 		var profileSpec *openapi.NamespaceProfileSpec
 
-		// 1. Check per-schema profile (components.schemas.<Resource>.x-f5xc-namespace-profile)
-		if schema, ok := domainInfo.Spec.Components.Schemas[resource.Name]; ok && schema.XF5XCNamespaceProfile != nil {
-			profileSpec = schema.XF5XCNamespaceProfile
+		// 1. Check the per-schema profile on the resource's spec schema. There is no
+		//    schema keyed by the bare resource name — the accurate per-resource profile
+		//    lives on its CreateSpecType/GetSpecType (mirror the extraction lookup).
+		for _, pat := range []string{
+			resource.Name + "CreateSpecType",
+			"schema" + resource.Name + "CreateSpecType",
+			resource.Name + "GetSpecType",
+			resource.Name,
+		} {
+			if schema, ok := domainInfo.Spec.Components.Schemas[pat]; ok && schema.XF5XCNamespaceProfile != nil {
+				profileSpec = schema.XF5XCNamespaceProfile
+				break
+			}
 		}
 
 		// 2. Fall back to info-level profile

--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -66,7 +66,7 @@ func main() {
 			failed++
 			continue
 		}
-		_, ns := namespace.ForResource(name)
+		ns := exampleNamespace(rt, name)
 		if err := codegen.WriteResourceExample(rt, name, "examples", ns); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ %s: %v\n", name, err)
 			failed++
@@ -97,6 +97,21 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println("✅ All examples generated (schema-driven, from committed provider)")
+}
+
+// exampleNamespace returns the namespace value to use in the generated example. It is
+// spec-driven: when the provider schema restricts namespace to a single value (a
+// stringvalidator.OneOf captured as EnumValues — e.g. system-only DNS resources), that
+// value is used so the example satisfies the constraint. Otherwise it falls back to the
+// resource's namespace classification (default "staging").
+func exampleNamespace(rt *openapi.ResourceTemplate, name string) string {
+	for _, a := range rt.Attributes {
+		if a.TfsdkTag == "namespace" && len(a.EnumValues) == 1 {
+			return a.EnumValues[0]
+		}
+	}
+	_, ns := namespace.ForResource(name)
+	return ns
 }
 
 // parseResourceSchema builds a ResourceTemplate carrying the resource's TOP-LEVEL attributes

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -33,6 +33,9 @@ import (
 {{- end}}
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+{{- if .HasStringDefaults}}
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+{{- end}}
 {{- if .HasBlocks}}
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 {{- end}}
@@ -107,6 +110,9 @@ func (r *{{.TitleCase}}Resource) Schema(ctx context.Context, req resource.Schema
 {{- if .Computed}}
 				Computed: true,
 {{- end}}
+{{- if ne .StringDefault ""}}
+				Default: stringdefault.StaticString("{{.StringDefault}}"),
+{{- end}}
 {{- if eq .Type "map"}}
 				ElementType: types.StringType,
 {{- end}}
@@ -133,6 +139,9 @@ func (r *{{.TitleCase}}Resource) Schema(ctx context.Context, req resource.Schema
 {{- else if eq .TfsdkTag "namespace"}}
 				Validators: []validator.String{
 					validators.NamespaceValidator(),
+{{- if gt (len .EnumValues) 0}}
+					stringvalidator.OneOf({{enumValuesLiteral .EnumValues}}),
+{{- end}}
 				},
 {{- else if and (eq .Type "string") (or (gt .MinLength 0) (gt .MaxLength 0) (ne .Pattern "") (gt (len .EnumValues) 0))}}
 				Validators: []validator.String{

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -39,7 +39,7 @@ type Schema struct {
 	Required             []string          `json:"required"`
 	AdditionalProperties interface{}       `json:"additionalProperties"`
 	// AllOf wraps $ref for OAS3 compliance (x-ves-* sibling preservation pattern)
-	AllOf                []Schema          `json:"allOf"`
+	AllOf []Schema `json:"allOf"`
 
 	// Original F5 vendor extensions (x-ves-*) - technical metadata from upstream
 	XDisplayName        string            `json:"x-displayname"`
@@ -48,18 +48,18 @@ type Schema struct {
 	XVesProtoMessage    string            `json:"x-ves-proto-message"`
 
 	// Enrichment extensions (x-f5xc-*) - added by api-specs-enriched repository
-	XF5XCCategory         string   `json:"x-f5xc-category"`
-	XF5XCRequiresTier     string   `json:"x-f5xc-requires-tier"`
-	XF5XCComplexity       string   `json:"x-f5xc-complexity"`
-	XF5XCExample          string   `json:"x-f5xc-example"`
-	XF5XCDescriptionShort string   `json:"x-f5xc-description-short"`
-	XF5XCDescriptionMed   string   `json:"x-f5xc-description-medium"`
-	XF5XCUseCases         []string `json:"x-f5xc-use-cases"`
-	XF5XCRelatedDomains   []string `json:"x-f5xc-related-domains"`
-	XF5XCIsPreview          bool                  `json:"x-f5xc-is-preview"`
-	XF5XCNamespaceProfile   *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
-	XF5XCIcon               string                `json:"x-f5xc-icon"`
-	XF5XCCLIDomain          string                `json:"x-f5xc-cli-domain"`
+	XF5XCCategory         string                `json:"x-f5xc-category"`
+	XF5XCRequiresTier     string                `json:"x-f5xc-requires-tier"`
+	XF5XCComplexity       string                `json:"x-f5xc-complexity"`
+	XF5XCExample          string                `json:"x-f5xc-example"`
+	XF5XCDescriptionShort string                `json:"x-f5xc-description-short"`
+	XF5XCDescriptionMed   string                `json:"x-f5xc-description-medium"`
+	XF5XCUseCases         []string              `json:"x-f5xc-use-cases"`
+	XF5XCRelatedDomains   []string              `json:"x-f5xc-related-domains"`
+	XF5XCIsPreview        bool                  `json:"x-f5xc-is-preview"`
+	XF5XCNamespaceProfile *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
+	XF5XCIcon             string                `json:"x-f5xc-icon"`
+	XF5XCCLIDomain        string                `json:"x-f5xc-cli-domain"`
 
 	// Additional upstream extensions
 	XVesDeprecated   string            `json:"x-ves-deprecated"`
@@ -88,17 +88,17 @@ type Schema struct {
 
 	// Deserialized from enriched specs for lossless round-tripping.
 	// No generation code consumes these yet.
-	XF5XCValidation      map[string]interface{} `json:"x-f5xc-validation"`
-	XF5XCDefaults        map[string]interface{} `json:"x-f5xc-defaults"`
-	XF5XCConditions      map[string]interface{} `json:"x-f5xc-conditions"`
-	XF5XCDeprecated      string                 `json:"x-f5xc-deprecated"`
-	XF5XCCompletion      map[string]interface{} `json:"x-f5xc-completion"`
-	XF5XCDisplayName     string                 `json:"x-f5xc-display-name"`
-	XF5XCDescription     string                 `json:"x-f5xc-description"`
-	XF5XCExamples        []interface{}          `json:"x-f5xc-examples"`
-	XF5XCRequiredForOps  map[string]interface{} `json:"x-f5xc-required-for-operations"`
-	XF5XCDisplayOrder    int                    `json:"x-f5xc-displayorder"`
-	XF5XCUniqueness      string                 `json:"x-f5xc-uniqueness"`
+	XF5XCValidation        map[string]interface{} `json:"x-f5xc-validation"`
+	XF5XCDefaults          map[string]interface{} `json:"x-f5xc-defaults"`
+	XF5XCConditions        map[string]interface{} `json:"x-f5xc-conditions"`
+	XF5XCDeprecated        string                 `json:"x-f5xc-deprecated"`
+	XF5XCCompletion        map[string]interface{} `json:"x-f5xc-completion"`
+	XF5XCDisplayName       string                 `json:"x-f5xc-display-name"`
+	XF5XCDescription       string                 `json:"x-f5xc-description"`
+	XF5XCExamples          []interface{}          `json:"x-f5xc-examples"`
+	XF5XCRequiredForOps    map[string]interface{} `json:"x-f5xc-required-for-operations"`
+	XF5XCDisplayOrder      int                    `json:"x-f5xc-displayorder"`
+	XF5XCUniqueness        string                 `json:"x-f5xc-uniqueness"`
 	XF5XCTerraformResource string                 `json:"x-f5xc-terraform-resource"`
 
 	// ---- SP-1 additions: operation-level extensions ----
@@ -133,24 +133,25 @@ type TerraformAttribute struct {
 	UseDomainValidator bool   // True if name field should use DomainValidator (for DNS resources)
 
 	// ---- SP-1 additions: enrichment-driven attribute metadata ----
-	ServerDefault        bool              // x-f5xc-server-default
-	Default              interface{}       // Resolved default value
-	MinimumConfigRequired bool             // Derived from x-f5xc-required-for.minimum_config
-	RecommendedValue     interface{}       // x-f5xc-recommended-value
-	ValidationRules      map[string]string // Merged x-ves-validation-rules + x-validation-rules
-	Complexity           string            // x-f5xc-complexity
-	UseCases             []string          // x-f5xc-use-cases
-	DeprecationMessage   string            // x-f5xc-deprecated or x-ves-deprecated
-	ConflictsWith        []string          // x-f5xc-conflicts-with
-	MaxLength            int               // From x-original-maxLength or validation rules
-	Immutable            bool              // x-field-mutability == "immutable"
-	EnumValues           []string          // Resolved from enum + x-ves-proto-enum
-	MinLength            int               // From validation rules
-	Pattern              string            // From validation rules
-	MinItems             int               // From x-f5xc-constraints.min_items
-	MaxItems             int               // From x-f5xc-constraints.max_items
-	Minimum  int
-	Maximum  int
+	ServerDefault         bool              // x-f5xc-server-default
+	Default               interface{}       // Resolved default value
+	MinimumConfigRequired bool              // Derived from x-f5xc-required-for.minimum_config
+	RecommendedValue      interface{}       // x-f5xc-recommended-value
+	ValidationRules       map[string]string // Merged x-ves-validation-rules + x-validation-rules
+	Complexity            string            // x-f5xc-complexity
+	UseCases              []string          // x-f5xc-use-cases
+	DeprecationMessage    string            // x-f5xc-deprecated or x-ves-deprecated
+	ConflictsWith         []string          // x-f5xc-conflicts-with
+	MaxLength             int               // From x-original-maxLength or validation rules
+	Immutable             bool              // x-field-mutability == "immutable"
+	EnumValues            []string          // Resolved from enum + x-ves-proto-enum
+	StringDefault         string            // Spec-driven static string default (e.g. namespace fixed to "system"); empty = none
+	MinLength             int               // From validation rules
+	Pattern               string            // From validation rules
+	MinItems              int               // From x-f5xc-constraints.min_items
+	MaxItems              int               // From x-f5xc-constraints.max_items
+	Minimum               int
+	Maximum               int
 }
 
 // ResourceTemplate contains data for generating a Terraform resource.
@@ -177,15 +178,16 @@ type ResourceTemplate struct {
 	UsesMapPlanModifier    bool   // True if any map attribute uses a plan modifier
 
 	// ---- SP-1 additions: generation control flags ----
-	HasBlocks              bool   // True if any attribute is a block
-	HasMaxLengthValidators bool   // True if any attribute has MaxLength > 0
-	HasEnumValidators      bool   // True if any attribute has EnumValues
-	HasPatternValidators   bool   // True if any attribute has Pattern
-	HasListSizeValidators  bool   // True if any attribute has MinItems or MaxItems
+	HasBlocks               bool // True if any attribute is a block
+	HasMaxLengthValidators  bool // True if any attribute has MaxLength > 0
+	HasEnumValidators       bool // True if any attribute has EnumValues
+	HasPatternValidators    bool // True if any attribute has Pattern
+	HasListSizeValidators   bool // True if any attribute has MinItems or MaxItems
 	HasInt64RangeValidators bool
-	HasConflicts           bool   // True if any attribute has ConflictsWith
-	ConflictCheckCode      string // Generated Go code for conflict checks
-	IsReadOnly             bool   // True if resource has GetSpecType only (data source, no resource)
+	HasStringDefaults       bool   // True if any attribute has a StringDefault (needs stringdefault import)
+	HasConflicts            bool   // True if any attribute has ConflictsWith
+	ConflictCheckCode       string // Generated Go code for conflict checks
+	IsReadOnly              bool   // True if resource has GetSpecType only (data source, no resource)
 }
 
 // GenerationResult tracks the result of generating a resource.
@@ -238,50 +240,50 @@ func (s *Schema) HasProperties() bool {
 // Index represents the index.json manifest file in v2 spec structure.
 // This file provides metadata about all domain specifications.
 type Index struct {
-	Version            string                 `json:"version"`
-	Timestamp          string                 `json:"timestamp"`
-	Specifications     []DomainMetadata       `json:"specifications"`
-	CriticalResources  []string               `json:"x-f5xc-critical-resources"`
-	ErrorResolution    map[string]interface{} `json:"x-f5xc-error-resolution"`
-	GuidedWorkflows    map[string]interface{} `json:"x-f5xc-guided-workflows"`
-	Acronyms           map[string]interface{} `json:"x-f5xc-acronyms"`
+	Version           string                 `json:"version"`
+	Timestamp         string                 `json:"timestamp"`
+	Specifications    []DomainMetadata       `json:"specifications"`
+	CriticalResources []string               `json:"x-f5xc-critical-resources"`
+	ErrorResolution   map[string]interface{} `json:"x-f5xc-error-resolution"`
+	GuidedWorkflows   map[string]interface{} `json:"x-f5xc-guided-workflows"`
+	Acronyms          map[string]interface{} `json:"x-f5xc-acronyms"`
 }
 
 // DomainMetadata represents metadata about a domain specification file.
 // Field names map to the x-f5xc-* extensions in index.json.
 type DomainMetadata struct {
-	Name              string                      `json:"domain"` // Domain name from "domain" field
-	File              string                      `json:"file"`
-	Category          string                      `json:"x-f5xc-category"`
-	Description       string                      `json:"description"`
-	DescriptionShort  string                      `json:"x-f5xc-description-short"`
-	DescriptionMedium string                      `json:"x-f5xc-description-medium"`
-	Icon              string                      `json:"x-f5xc-icon"`
-	RequiresTier      string                      `json:"x-f5xc-requires-tier"`
-	Complexity        string                      `json:"x-f5xc-complexity"`
-	IsPreview         bool                        `json:"x-f5xc-is-preview"`
-	CLIDomain         string                      `json:"x-f5xc-cli-domain"`
-	Title             string                      `json:"title"`
-	PathCount         int                         `json:"path_count"`
-	SchemaCount       int                         `json:"schema_count"`
-	RelatedDomains    []string                    `json:"x-f5xc-related-domains"`
-	UseCases          []string                    `json:"x-f5xc-use-cases"`
-	PrimaryResources  []PrimaryResourceMetadata   `json:"x-f5xc-primary-resources"`
+	Name              string                    `json:"domain"` // Domain name from "domain" field
+	File              string                    `json:"file"`
+	Category          string                    `json:"x-f5xc-category"`
+	Description       string                    `json:"description"`
+	DescriptionShort  string                    `json:"x-f5xc-description-short"`
+	DescriptionMedium string                    `json:"x-f5xc-description-medium"`
+	Icon              string                    `json:"x-f5xc-icon"`
+	RequiresTier      string                    `json:"x-f5xc-requires-tier"`
+	Complexity        string                    `json:"x-f5xc-complexity"`
+	IsPreview         bool                      `json:"x-f5xc-is-preview"`
+	CLIDomain         string                    `json:"x-f5xc-cli-domain"`
+	Title             string                    `json:"title"`
+	PathCount         int                       `json:"path_count"`
+	SchemaCount       int                       `json:"schema_count"`
+	RelatedDomains    []string                  `json:"x-f5xc-related-domains"`
+	UseCases          []string                  `json:"x-f5xc-use-cases"`
+	PrimaryResources  []PrimaryResourceMetadata `json:"x-f5xc-primary-resources"`
 }
 
 // PrimaryResourceMetadata represents resource-level metadata from x-f5xc-primary-resources in index.json.
 // This is extracted from index.json and provides per-resource tier and dependency info.
 type PrimaryResourceMetadata struct {
-	Name             string               `json:"name"`
-	Description      string               `json:"description"`
-	DescriptionShort string               `json:"description_short"`
-	Tier             string               `json:"tier"`
-	Icon             string               `json:"icon"`
-	Category         string               `json:"category"`
-	SupportsLogs     bool                 `json:"supports_logs"`
-	SupportsMetrics  bool                 `json:"supports_metrics"`
-	Dependencies     ResourceDependencies `json:"dependencies"`
-	RelationshipHints []string            `json:"relationship_hints"`
+	Name              string               `json:"name"`
+	Description       string               `json:"description"`
+	DescriptionShort  string               `json:"description_short"`
+	Tier              string               `json:"tier"`
+	Icon              string               `json:"icon"`
+	Category          string               `json:"category"`
+	SupportsLogs      bool                 `json:"supports_logs"`
+	SupportsMetrics   bool                 `json:"supports_metrics"`
+	Dependencies      ResourceDependencies `json:"dependencies"`
+	RelationshipHints []string             `json:"relationship_hints"`
 
 	// ---- SP-1 additions: schema and API path references ----
 	SchemaComponents []string `json:"schema_components"`
@@ -315,12 +317,12 @@ type DomainSpec struct {
 	Components Components             `json:"components"`
 
 	// Domain-level enrichment metadata
-	XF5XCCategory       string   `json:"x-f5xc-category"`
-	XF5XCRequiresTier   string   `json:"x-f5xc-requires-tier"`
-	XF5XCComplexity     string   `json:"x-f5xc-complexity"`
-	XF5XCIsPreview      bool     `json:"x-f5xc-is-preview"`
-	XF5XCRelatedDomains []string `json:"x-f5xc-related-domains"`
-	XF5XCUseCases       []string `json:"x-f5xc-use-cases"`
+	XF5XCCategory         string                `json:"x-f5xc-category"`
+	XF5XCRequiresTier     string                `json:"x-f5xc-requires-tier"`
+	XF5XCComplexity       string                `json:"x-f5xc-complexity"`
+	XF5XCIsPreview        bool                  `json:"x-f5xc-is-preview"`
+	XF5XCRelatedDomains   []string              `json:"x-f5xc-related-domains"`
+	XF5XCUseCases         []string              `json:"x-f5xc-use-cases"`
 	XF5XCNamespaceProfile *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
 
 	// ---- SP-1 additions: domain-level spec metadata ----
@@ -338,12 +340,12 @@ type DomainInfo struct {
 	Version     string `json:"version"`
 
 	// Enrichment extensions at info level
-	XF5XCDescriptionShort  string         `json:"x-f5xc-description-short"`
-	XF5XCDescriptionMedium string         `json:"x-f5xc-description-medium"`
-	XF5XCIcon              string         `json:"x-f5xc-icon"`
-	XF5XCLogoSVG           string         `json:"x-f5xc-logo-svg"`
-	XF5XCDescriptionLong   string         `json:"x-f5xc-description-long"`
-	XF5XCSummary           string         `json:"x-f5xc-summary"`
+	XF5XCDescriptionShort  string                `json:"x-f5xc-description-short"`
+	XF5XCDescriptionMedium string                `json:"x-f5xc-description-medium"`
+	XF5XCIcon              string                `json:"x-f5xc-icon"`
+	XF5XCLogoSVG           string                `json:"x-f5xc-logo-svg"`
+	XF5XCDescriptionLong   string                `json:"x-f5xc-description-long"`
+	XF5XCSummary           string                `json:"x-f5xc-summary"`
 	XF5XCBestPractices     *BestPractices        `json:"x-f5xc-best-practices"`
 	XF5XCNamespaceProfile  *NamespaceProfileSpec `json:"x-f5xc-namespace-profile"`
 

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/conflicts"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/description"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
@@ -149,8 +150,24 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 			Required:    true, PlanModifier: "RequiresReplace", UseDomainValidator: useDomainValidator},
 	}
 
-	// For resources without namespace in API path (like namespace itself), namespace is optional
-	if hasNamespace {
+	// Namespace emission is driven by the spec-declared namespace constraint
+	// (x-f5xc-namespace-profile). Precedence:
+	//   1. Profile restricts the resource to a single namespace (e.g. system-only DNS
+	//      objects) -> Optional+Computed, defaulted to that value + OneOf, so it may be
+	//      omitted and can't be set wrong.
+	//   2. Path has {namespace} but the resource allows multiple namespaces -> Required.
+	//   3. No namespace in the API path -> Optional+Computed (omit/empty).
+	if prof, ok := namespace.GetProfile(resourceName); ok && len(prof.Allowed) == 1 {
+		fixedNS := string(prof.Allowed[0])
+		idComponentAttrs = append(idComponentAttrs, openapi.TerraformAttribute{
+			Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string",
+			Description:   fmt.Sprintf("Namespace for the %s. The F5 XC API restricts this resource to the %s namespace; it defaults to that value and may be omitted.", naming.ToHumanReadableName(resourceName), fixedNS),
+			Optional:      true,
+			Computed:      true,
+			StringDefault: fixedNS,
+			EnumValues:    []string{fixedNS},
+			PlanModifier:  "RequiresReplace"})
+	} else if hasNamespace {
 		idComponentAttrs = append(idComponentAttrs, openapi.TerraformAttribute{
 			Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string",
 			Description: fmt.Sprintf("Namespace where the %s will be created.", naming.ToHumanReadableName(resourceName)),
@@ -268,30 +285,31 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	conflictCode := conflicts.GenerateChecks(conflictAttrs, goNameLookup)
 
 	return &openapi.ResourceTemplate{
-		Name:                   resourceName,
-		TitleCase:              naming.ToResourceTypeName(resourceName),
-		APIPath:                apiPath,
-		APIPathPlural:          resourceName + "s",
-		APIPathItem:            apiPathItem,
-		HasNamespaceInPath:     hasNamespace,
-		Description:            resourceDescription,
-		Attributes:             attributes,
-		OneOfGroups:            oneOfGroups, // Now properly preserving extracted OneOf groups
-		ExampleUsage:           exampleUsage,
-		APIDocsURL:             apiDocsURL,
-		UsesBoolPlanModifier:   usesBool,
-		UsesInt64PlanModifier:  usesInt64,
-		UsesStringPlanModifier: usesString,
-		UsesListPlanModifier:   usesList,
-		UsesMapPlanModifier:    usesMap,
-		HasBlocks:              hasBlocks,
-		HasMaxLengthValidators: hasMaxLengthValidators,
-		HasEnumValidators:      HasEnumValidatorsAny(attributes),
-		HasPatternValidators:   HasPatternValidatorsAny(attributes),
-		HasListSizeValidators:  HasListSizeValidatorsAny(attributes),
+		Name:                    resourceName,
+		TitleCase:               naming.ToResourceTypeName(resourceName),
+		APIPath:                 apiPath,
+		APIPathPlural:           resourceName + "s",
+		APIPathItem:             apiPathItem,
+		HasNamespaceInPath:      hasNamespace,
+		Description:             resourceDescription,
+		Attributes:              attributes,
+		OneOfGroups:             oneOfGroups, // Now properly preserving extracted OneOf groups
+		ExampleUsage:            exampleUsage,
+		APIDocsURL:              apiDocsURL,
+		UsesBoolPlanModifier:    usesBool,
+		UsesInt64PlanModifier:   usesInt64,
+		UsesStringPlanModifier:  usesString,
+		UsesListPlanModifier:    usesList,
+		UsesMapPlanModifier:     usesMap,
+		HasBlocks:               hasBlocks,
+		HasMaxLengthValidators:  hasMaxLengthValidators,
+		HasEnumValidators:       HasEnumValidatorsAny(attributes),
+		HasPatternValidators:    HasPatternValidatorsAny(attributes),
+		HasListSizeValidators:   HasListSizeValidatorsAny(attributes),
 		HasInt64RangeValidators: HasInt64RangeValidatorsAny(attributes),
-		HasConflicts:           conflictCode != "",
-		ConflictCheckCode:      conflictCode,
+		HasStringDefaults:       HasStringDefaultsAny(attributes),
+		HasConflicts:            conflictCode != "",
+		ConflictCheckCode:       conflictCode,
 	}, nil
 }
 

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -5,8 +5,116 @@ package schema
 import (
 	"testing"
 
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
+
+// findAttr returns the attribute with the given tfsdk tag, or nil.
+func findAttr(attrs []openapi.TerraformAttribute, tag string) *openapi.TerraformAttribute {
+	for i := range attrs {
+		if attrs[i].TfsdkTag == tag {
+			return &attrs[i]
+		}
+	}
+	return nil
+}
+
+// systemOnlySpec builds a minimal spec + namespaced path for a resource.
+func systemOnlySpec(resourceName string) (*openapi.Spec, func(*openapi.Spec, string) (string, string, bool)) {
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				resourceName + "CreateSpecType": {
+					Type:       "object",
+					Properties: map[string]openapi.Schema{"port": {Type: "integer"}},
+				},
+			},
+		},
+	}
+	extractAPIPath := func(_ *openapi.Spec, _ string) (string, string, bool) {
+		return "/api/config/dns/namespaces/%s/" + resourceName + "s", "/api/config/dns/namespaces/%s/" + resourceName + "s/%s", true
+	}
+	return spec, extractAPIPath
+}
+
+// A resource whose spec profile restricts it to a single namespace ("system")
+// must emit namespace as Optional+Computed with a static default and a OneOf
+// validator — not Required — so it can be omitted and cannot be set wrong.
+func TestExtractResourceSchema_SingleAllowedNamespaceIsDefaulted(t *testing.T) {
+	namespace.ClearProfiles()
+	namespace.SetProfile("sys_res", namespace.Profile{Allowed: []namespace.NamespaceType{namespace.System}, Enforced: true})
+	defer namespace.ClearProfiles()
+
+	spec, extractAPIPath := systemOnlySpec("sys_res")
+	result, err := ExtractResourceSchema(spec, "sys_res", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns := findAttr(result.Attributes, "namespace")
+	if ns == nil {
+		t.Fatal("namespace attribute missing")
+	}
+	if ns.Required {
+		t.Error("namespace must not be Required for a single-allowed-namespace resource")
+	}
+	if !ns.Optional || !ns.Computed {
+		t.Errorf("namespace should be Optional+Computed, got Optional=%v Computed=%v", ns.Optional, ns.Computed)
+	}
+	if ns.StringDefault != "system" {
+		t.Errorf("StringDefault = %q, want %q", ns.StringDefault, "system")
+	}
+	if len(ns.EnumValues) != 1 || ns.EnumValues[0] != "system" {
+		t.Errorf("EnumValues = %v, want [system]", ns.EnumValues)
+	}
+	if !result.HasStringDefaults {
+		t.Error("ResourceTemplate.HasStringDefaults should be true")
+	}
+}
+
+// A resource whose spec profile allows multiple namespaces keeps namespace
+// Required with no default — the user must choose.
+func TestExtractResourceSchema_MultiAllowedNamespaceStaysRequired(t *testing.T) {
+	namespace.ClearProfiles()
+	namespace.SetProfile("app_res", namespace.Profile{Allowed: []namespace.NamespaceType{namespace.Custom, namespace.Default, namespace.Shared}})
+	defer namespace.ClearProfiles()
+
+	spec, extractAPIPath := systemOnlySpec("app_res")
+	result, err := ExtractResourceSchema(spec, "app_res", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns := findAttr(result.Attributes, "namespace")
+	if ns == nil {
+		t.Fatal("namespace attribute missing")
+	}
+	if !ns.Required {
+		t.Error("namespace must stay Required for a multi-allowed-namespace resource")
+	}
+	if ns.StringDefault != "" {
+		t.Errorf("StringDefault = %q, want empty", ns.StringDefault)
+	}
+	if len(ns.EnumValues) != 0 {
+		t.Errorf("EnumValues = %v, want empty", ns.EnumValues)
+	}
+}
+
+// With no registered profile, namespace behaviour is unchanged (Required when the
+// API path is namespaced).
+func TestExtractResourceSchema_NoProfileStaysRequired(t *testing.T) {
+	namespace.ClearProfiles()
+	spec, extractAPIPath := systemOnlySpec("unprofiled_res")
+	result, err := ExtractResourceSchema(spec, "unprofiled_res", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns := findAttr(result.Attributes, "namespace")
+	if ns == nil {
+		t.Fatal("namespace attribute missing")
+	}
+	if !ns.Required || ns.StringDefault != "" {
+		t.Errorf("unprofiled namespace should be Required with no default; got Required=%v StringDefault=%q", ns.Required, ns.StringDefault)
+	}
+}
 
 func TestExtractOneOfGroups_Empty(t *testing.T) {
 	spec := &openapi.Spec{}

--- a/tools/pkg/schema/scan.go
+++ b/tools/pkg/schema/scan.go
@@ -54,6 +54,20 @@ func HasEnumValidatorsAny(attributes []openapi.TerraformAttribute) bool {
 	return false
 }
 
+// HasStringDefaultsAny recursively checks if any attribute (top-level or nested)
+// has a StringDefault. This determines whether stringdefault must be imported.
+func HasStringDefaultsAny(attributes []openapi.TerraformAttribute) bool {
+	for _, attr := range attributes {
+		if attr.StringDefault != "" {
+			return true
+		}
+		if HasStringDefaultsAny(attr.NestedAttributes) {
+			return true
+		}
+	}
+	return false
+}
+
 // HasPatternValidatorsAny recursively checks if any attribute (top-level or nested)
 // has a Pattern regex. This determines whether regexp must be imported.
 func HasPatternValidatorsAny(attributes []openapi.TerraformAttribute) bool {


### PR DESCRIPTION
Makes the generated `namespace` attribute spec-driven from `x-f5xc-namespace-profile.constraint.allowed` (already in the enriched specs). Resources the API restricts to a single namespace (e.g. system-only DNS objects) emit `namespace` as **Optional + Computed + `stringdefault.StaticString(<v>)` + `stringvalidator.OneOf(<v>)`** — omittable, correctly defaulted, and wrong values rejected at plan time. Multi-namespace resources keep `Required`.

Also fixes a latent bug: profile registration looked up `Schemas[resource.Name]` (never a key — profiles live on `<Resource>CreateSpecType`), so it silently fell back to the domain default, which made system-only **examples** use `namespace = "staging"`.

## Verified
- `make build` + `make test` (incl. 3 new unit tests) + `make validate-examples` (253/253) green.
- `dns_zone`/`dns_lb_pool`/`dns_lb_health_check` → namespace defaults to `system`; examples use `system`.
- `http_loadbalancer`/`geo_location_set` (multi-namespace) → namespace stays `Required`.

## Note
`dns_load_balancer` stays `Required` due to an upstream enriched-spec data bug (its `schema`-prefixed CreateSpecType keeps the domain-default profile) — tracked in **api-specs-enriched#931**. The generator will pick it up automatically once the spec is corrected.

Generated files (`internal/**`, `examples/**`) are intentionally not committed here — the auto-regenerate bot produces them on merge.

Closes #984