### PR TITLE
fix(ci): stop golangci-lint OOM on the generated tree (unblocks regeneration/release)

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -94,5 +94,6 @@ jobs:
           # concurrency — exit 143 — which was skipping the on-merge regeneration
           # cascade. Excluding them as targets, plus GOGC=20 and serial
           # concurrency, keeps peak memory bounded.
-          pkgs=$(go list ./internal/... . | grep -vE '/internal/(provider|client)$')
+          # Use directories ({{.Dir}}), not import paths — golangci-lint expects paths.
+          pkgs=$(go list -f '{{.Dir}}' ./internal/... . | grep -vE '/internal/(provider|client)$')
           golangci-lint run --timeout=15m --concurrency=1 $pkgs

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -85,4 +85,14 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m ./internal/... .
+        env:
+          GOGC: "20"
+        run: |
+          # Lint hand-written code only. The generated internal/provider and
+          # internal/client packages (// Code generated ... DO NOT EDIT, ~400k
+          # lines) OOM the whole-program linters (unused/staticcheck) at default
+          # concurrency — exit 143 — which was skipping the on-merge regeneration
+          # cascade. Excluding them as targets, plus GOGC=20 and serial
+          # concurrency, keeps peak memory bounded.
+          pkgs=$(go list ./internal/... . | grep -vE '/internal/(provider|client)$')
+          golangci-lint run --timeout=15m --concurrency=1 $pkgs

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -95,5 +95,6 @@ jobs:
           # cascade. Excluding them as targets, plus GOGC=20 and serial
           # concurrency, keeps peak memory bounded.
           # Use directories ({{.Dir}}), not import paths — golangci-lint expects paths.
-          pkgs=$(go list -f '{{.Dir}}' ./internal/... . | grep -vE '/internal/(provider|client)$')
-          golangci-lint run --timeout=15m --concurrency=1 $pkgs
+          # Read into an array so each dir is a separate quoted arg (shellcheck-clean).
+          mapfile -t pkgs < <(go list -f '{{.Dir}}' ./internal/... . | grep -vE '/internal/(provider|client)$')
+          golangci-lint run --timeout=15m --concurrency=1 "${pkgs[@]}"

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -469,6 +469,31 @@ func TestResourceTemplate_ClearsImportMarkerAfterImport(t *testing.T) {
 	}
 }
 
+// The resource template must (a) emit a guarded static string default for attributes
+// carrying a StringDefault, and (b) let the namespace attribute carry a OneOf validator
+// (for spec-driven fixed-namespace resources) in addition to the format validator.
+func TestResourceTemplate_StringDefaultAndNamespaceOneOf(t *testing.T) {
+	if !strings.Contains(ResourceTemplate, "stringdefault.StaticString(") {
+		t.Error("ResourceTemplate must emit stringdefault.StaticString for StringDefault attributes")
+	}
+	if !strings.Contains(ResourceTemplate, `if ne .StringDefault ""`) {
+		t.Error("the StringDefault emission must be guarded by a non-empty check")
+	}
+	// The namespace validator branch must also emit OneOf when EnumValues are present,
+	// not only NamespaceValidator(). Inspect the window until the next branch.
+	nsIdx := strings.Index(ResourceTemplate, `eq .TfsdkTag "namespace"`)
+	if nsIdx == -1 {
+		t.Fatal("namespace validator branch not found in ResourceTemplate")
+	}
+	window := ResourceTemplate[nsIdx:]
+	if end := strings.Index(window, "else if and (eq .Type"); end != -1 {
+		window = window[:end]
+	}
+	if !strings.Contains(window, "stringvalidator.OneOf(") {
+		t.Error("namespace branch must emit stringvalidator.OneOf when EnumValues are present")
+	}
+}
+
 // The recursive emitters must reach the deep list block and convert it: marshal via
 // ElementsAs, unmarshal via ListValueFrom, referencing the deep model's AttrTypes.
 func TestRecursiveEmitters_DeepListConversion(t *testing.T) {


### PR DESCRIPTION
`Build and Test / Lint` ran `golangci-lint run ./internal/... .` over the whole tree — including the ~400k-line **generated** `internal/provider` + `internal/client` — at default concurrency, OOM-killing the runner (exit 143). `on-merge`'s `regenerate-provider` `needs: build-test`, so this consistently **skipped regeneration and blocked the release** (the on-merge for #984 failed here → no v3.61.16).

## Fix
- Lint **hand-written code only** (generated packages are `DO NOT EDIT`), with `GOGC=20` + `--concurrency=1` to bound peak memory. `go vet` is clean on those 9 packages.
- Add a codegen test covering the #984 template change (guarded `stringdefault.StaticString` + namespace `OneOf`). This `tools/` change also re-triggers the regeneration that #984's merge skipped, so v3.61.16 (with the spec-driven namespace schema) can finally publish.

Closes #986 · Refs #984