### PR TITLE
feat(generate): gate namespace default+OneOf on constraint.enforced

### DIFF
--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -152,12 +152,14 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 
 	// Namespace emission is driven by the spec-declared namespace constraint
 	// (x-f5xc-namespace-profile). Precedence:
-	//   1. Profile restricts the resource to a single namespace (e.g. system-only DNS
-	//      objects) -> Optional+Computed, defaulted to that value + OneOf, so it may be
-	//      omitted and can't be set wrong.
-	//   2. Path has {namespace} but the resource allows multiple namespaces -> Required.
+	//   1. Profile restricts the resource to a single namespace AND that constraint is
+	//      enforced (verification-gated in the spec: only verified classifications set
+	//      enforced=true) -> Optional+Computed, defaulted to that value + OneOf, so it
+	//      may be omitted and can't be set wrong.
+	//   2. Path has {namespace} but the resource is multi-namespace or its single-namespace
+	//      constraint is unverified (enforced=false) -> Required (don't over-restrict).
 	//   3. No namespace in the API path -> Optional+Computed (omit/empty).
-	if prof, ok := namespace.GetProfile(resourceName); ok && len(prof.Allowed) == 1 {
+	if prof, ok := namespace.GetProfile(resourceName); ok && len(prof.Allowed) == 1 && prof.Enforced {
 		fixedNS := string(prof.Allowed[0])
 		idComponentAttrs = append(idComponentAttrs, openapi.TerraformAttribute{
 			Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string",

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -116,6 +116,33 @@ func TestExtractResourceSchema_NoProfileStaysRequired(t *testing.T) {
 	}
 }
 
+// A single-allowed profile that is NOT enforced (unverified classification) must not
+// be defaulted/locked — namespace stays Required so we don't over-restrict on a guess.
+func TestExtractResourceSchema_UnverifiedSingleAllowedStaysRequired(t *testing.T) {
+	namespace.ClearProfiles()
+	namespace.SetProfile("unverified_sys", namespace.Profile{
+		Allowed:  []namespace.NamespaceType{namespace.System},
+		Enforced: false,
+	})
+	defer namespace.ClearProfiles()
+
+	spec, extractAPIPath := systemOnlySpec("unverified_sys")
+	result, err := ExtractResourceSchema(spec, "unverified_sys", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns := findAttr(result.Attributes, "namespace")
+	if ns == nil {
+		t.Fatal("namespace attribute missing")
+	}
+	if !ns.Required {
+		t.Error("unverified (enforced=false) single-allowed namespace must stay Required")
+	}
+	if ns.StringDefault != "" || len(ns.EnumValues) != 0 {
+		t.Errorf("unverified namespace must not be defaulted/locked; got StringDefault=%q EnumValues=%v", ns.StringDefault, ns.EnumValues)
+	}
+}
+
 func TestExtractOneOfGroups_Empty(t *testing.T) {
 	spec := &openapi.Spec{}
 	result := ExtractOneOfGroups(spec, "NonExistent")


### PR DESCRIPTION
Companion to api-specs-enriched#933/#934. Emit the namespace default+OneOf only when the single-allowed constraint is `enforced` (verification-gated upstream). Unverified single-allowed resources keep `namespace` Required — no over-restriction on unverified classifications. Backward-safe with current specs. New unit test: enforced=false → Required; all namespace tests + build green.

Closes #990 · Refs #984