### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ wheels/
 *.test
 *.out
 vendor/
-/terraform-provider-xcsh
 
 # Terraform
 .terraform/


### PR DESCRIPTION
Closes #1001

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore