### PR TITLE
fix(codegen): guard nested Optional+Computed scalar preserve on IsUnknown()

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -294,6 +294,33 @@ func deepComputedTree() openapi.TerraformAttribute {
 	}
 }
 
+// A Computed+Optional scalar in a single nested block (e.g. http_health_check.use_http2)
+// that the user leaves unset has an unknown planned value. The unmarshal "preserve"
+// path must NOT return that unknown value — it must guard on !IsUnknown() and fall
+// through to the API response / null, else apply fails with "invalid result object
+// after apply". Regression test.
+func TestRenderUnmarshalScalarChild_PreserveGuardsUnknown(t *testing.T) {
+	var sb strings.Builder
+	attr := openapi.TerraformAttribute{
+		GoName: "UseHttp2", TfsdkTag: "use_http2", JsonName: "use_http2",
+		Type: "bool", Optional: true,
+	}
+	renderUnmarshalScalarChild(&sb, attr, "blockData", "data.HTTPHealthCheck", "data.HTTPHealthCheck != nil", "single", "\t")
+	got := sb.String()
+
+	if !strings.Contains(got, "!data.HTTPHealthCheck.UseHttp2.IsUnknown()") {
+		t.Errorf("preserve guard must check IsUnknown() before returning the planned value; got:\n%s", got)
+	}
+	// Still preserves a known explicitly-set value.
+	if !strings.Contains(got, "return data.HTTPHealthCheck.UseHttp2") {
+		t.Errorf("expected preserve path to return the prior value when known; got:\n%s", got)
+	}
+	// Still falls through to the API response.
+	if !strings.Contains(got, `blockData["use_http2"].(bool)`) {
+		t.Errorf("expected fallthrough to API response; got:\n%s", got)
+	}
+}
+
 func TestBlockHasComputedDescendant(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -573,7 +573,11 @@ func renderUnmarshalScalarChild(sb *strings.Builder, attr openapi.TerraformAttri
 	case "int64":
 		sb.WriteString(fmt.Sprintf("%s%s: func() types.Int64 {\n", indent, fieldName))
 		if preserve {
-			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s {\n", indent, stateGuard))
+			// Preserve an explicitly-set prior value to avoid API-default drift, but
+			// only when it is KNOWN. If the planned value is unknown (Computed+Optional
+			// field left unset by the user), fall through to the API response / null —
+			// returning an unknown here trips "invalid result object after apply".
+			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s && !%s.%s.IsUnknown() {\n", indent, stateGuard, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t\treturn %s.%s\n", indent, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		}
@@ -585,7 +589,11 @@ func renderUnmarshalScalarChild(sb *strings.Builder, attr openapi.TerraformAttri
 	case "bool":
 		sb.WriteString(fmt.Sprintf("%s%s: func() types.Bool {\n", indent, fieldName))
 		if preserve {
-			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s {\n", indent, stateGuard))
+			// Preserve an explicitly-set prior value to avoid API-default drift, but
+			// only when it is KNOWN. If the planned value is unknown (Computed+Optional
+			// field left unset by the user), fall through to the API response / null —
+			// returning an unknown here trips "invalid result object after apply".
+			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s && !%s.%s.IsUnknown() {\n", indent, stateGuard, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t\treturn %s.%s\n", indent, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		}


### PR DESCRIPTION
## Summary

Fixes the first of the two provider bugs in #1003. `renderUnmarshalScalarChild`'s single-block `preserve` path returned the prior **planned** value for Optional `int64`/`bool` fields without checking `IsUnknown()`. For a Computed+Optional field left unset by the user (e.g. `xcsh_healthcheck.http_health_check.use_http2`), the planned value is unknown, so Create/Update returned an unknown value → `Provider returned invalid result object after apply`.

The guard now also requires `!<field>.IsUnknown()`, so an unset field falls through to the API response (or null) instead of returning unknown. Explicitly-set (known) values are still preserved, avoiding API-default drift.

## Change

- `tools/pkg/codegen/render.go` — one guard in the int64/bool preserve branch.
- `tools/pkg/codegen/codegen_test.go` — regression test `TestRenderUnmarshalScalarChild_PreserveGuardsUnknown`.

Generated files are **not** included: run `make regenerate` to apply. (Kept out of this PR to avoid conflating the fix with unrelated latest-enriched-spec drift — that regen should be a separate, deliberate change.)

## Testing (evidence)

- `go test ./tools/pkg/codegen/` → ok; new regression test passes.
- `go vet ./tools/pkg/codegen/` → clean.
- **End-to-end against the staging tenant** (locally regenerated + built provider): an `xcsh_healthcheck` with an `http_health_check` block and `use_http2` omitted → `terraform apply` clean, second plan "No changes" (idempotent), `terraform destroy` clean. Before the fix the same config failed with "invalid result object after apply … use_http2".

## Not covered here

Bug 2 from #1003 (`http_loadbalancer.default_route_pools[].endpoint_subsets` empty oneof-member block added during read → "was absent, but now present") is a separate flatten/oneof issue and remains; it is currently worked around at config level in `webapp-api-protection`.

Closes #1005

Broader effort: #1003