### PR TITLE
WIP: clean terraform import — suppress server-default oneof markers (#1006)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -305,7 +305,7 @@ func TestRenderUnmarshalScalarChild_PreserveGuardsUnknown(t *testing.T) {
 		GoName: "UseHttp2", TfsdkTag: "use_http2", JsonName: "use_http2",
 		Type: "bool", Optional: true,
 	}
-	renderUnmarshalScalarChild(&sb, attr, "blockData", "data.HTTPHealthCheck", "data.HTTPHealthCheck != nil", "single", "\t")
+	renderUnmarshalScalarChild(&sb, "Healthcheck", attr, "blockData", "data.HTTPHealthCheck", "data.HTTPHealthCheck != nil", "single", "\t")
 	got := sb.String()
 
 	if !strings.Contains(got, "!data.HTTPHealthCheck.UseHttp2.IsUnknown()") {
@@ -353,6 +353,41 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault(t *testing.T) 
 	}
 	if isImportDefaultSuppressed("HTTPLoadBalancer", "advertise_on_public_default_vip") {
 		t.Error("advertise_on_public_default_vip is user intent and must NOT be suppressed")
+	}
+}
+
+// A suppressed non-empty server-default block (e.g. l7_ddos_protection, which the
+// API returns as an empty object for a minimal LB) must not be materialized on
+// import from an empty response — otherwise import creates an all-defaults block
+// the user never set. The build guard must require a non-empty response on import.
+func TestRenderUnmarshalTopLevelSingle_SuppressedNonEmptyRequiresContentOnImport(t *testing.T) {
+	attr := openapi.TerraformAttribute{
+		GoName: "L7DDOSProtection", TfsdkTag: "l7_ddos_protection", JsonName: "l7_ddos_protection",
+		IsBlock: true, NestedBlockType: "single", IsSpecField: true,
+		NestedAttributes: []openapi.TerraformAttribute{
+			{GoName: "L7DdosActionDefault", TfsdkTag: "l7_ddos_action_default", JsonName: "l7_ddos_action_default", IsBlock: true, NestedBlockType: "single"},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalTopLevelSingle(&sb, "HTTPLoadBalancer", attr, "\t")
+	got := sb.String()
+	if !strings.Contains(got, "isImport && len(blockData) > 0") {
+		t.Errorf("suppressed non-empty block must require non-empty response on import; got:\n%s", got)
+	}
+}
+
+// A suppressed Optional bool at its false server default must return null on
+// import (config omits it) — otherwise post-import plan shows "false -> null".
+func TestRenderUnmarshalScalarChild_ImportSuppressesDefaultBool(t *testing.T) {
+	attr := openapi.TerraformAttribute{
+		GoName: "DNSVolterraManaged", TfsdkTag: "dns_volterra_managed", JsonName: "dns_volterra_managed",
+		Type: "bool", Optional: true,
+	}
+	var sb strings.Builder
+	renderUnmarshalScalarChild(&sb, "HTTPLoadBalancer", attr, "blockData", "data.HTTP", "data.HTTP != nil", "single", "\t")
+	got := sb.String()
+	if !strings.Contains(got, "if isImport {") || !strings.Contains(got, "ok && !v {") {
+		t.Errorf("suppressed default bool must return null on import when false; got:\n%s", got)
 	}
 }
 

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -321,6 +321,41 @@ func TestRenderUnmarshalScalarChild_PreserveGuardsUnknown(t *testing.T) {
 	}
 }
 
+// Server-default oneof empty-marker members must not be populated from the API
+// response on import (they cause spurious post-import drift). The flatten must
+// guard the response-populate with !isImport for suppressed members, and leave
+// non-suppressed members (user-intent markers) untouched.
+func TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault(t *testing.T) {
+	mk := func(go_, tfsdk string) openapi.TerraformAttribute {
+		return openapi.TerraformAttribute{GoName: go_, TfsdkTag: tfsdk, JsonName: tfsdk, IsBlock: true, NestedBlockType: "single"}
+	}
+
+	// Suppressed default marker (disable_waf) -> guarded by !isImport.
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "HTTPLoadBalancer", "", mk("DisableWaf", "disable_waf"), "apiResource.Spec", "data", "true", "single", "\t")
+	got := sb.String()
+	if !strings.Contains(got, "if !isImport {") {
+		t.Errorf("suppressed member disable_waf must guard response-populate with !isImport; got:\n%s", got)
+	}
+
+	// Non-suppressed user-intent marker (advertise_on_public_default_vip) -> no import guard on the populate.
+	var sb2 strings.Builder
+	renderUnmarshalSingleChild(&sb2, "HTTPLoadBalancer", "", mk("AdvertiseOnPublicDefaultVip", "advertise_on_public_default_vip"), "apiResource.Spec", "data", "true", "single", "\t")
+	got2 := sb2.String()
+	// The only !isImport in a non-suppressed member is the preserve branch, not a wrapper
+	// around the response-populate. Assert the populate line is not nested under an extra guard.
+	if strings.Count(got2, "if !isImport {") != 0 {
+		t.Errorf("non-suppressed member must not add an import-suppression guard; got:\n%s", got2)
+	}
+
+	if !isImportDefaultSuppressed("HTTPLoadBalancer", "round_robin") {
+		t.Error("round_robin should be a suppressed server default for HTTPLoadBalancer")
+	}
+	if isImportDefaultSuppressed("HTTPLoadBalancer", "advertise_on_public_default_vip") {
+		t.Error("advertise_on_public_default_vip is user intent and must NOT be suppressed")
+	}
+}
+
 func TestBlockHasComputedDescendant(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package codegen
+
+// importDefaultSuppressions lists, per resource (title-case model prefix), the
+// empty-marker oneof members that the F5 XC API ALWAYS returns as the server
+// default for their oneof group. On `terraform import` there is no prior config
+// to preserve, so the flatten would otherwise populate every such default member
+// and the next plan would show spurious drift (it wants to remove blocks the user
+// never configured).
+//
+// Suppressing the DEFAULT member of a oneof on import is semantically safe:
+// omitting it means the server re-applies the same default, so behavior is
+// unchanged. Non-default members (e.g. app_firewall vs disable_waf) are NOT
+// listed and still import normally, as are user-intent markers such as
+// advertise_on_public_default_vip.
+//
+// Data source: discovered from the live tenant (create a minimal object, diff the
+// response against the request). Seeded here for http_loadbalancer from the
+// staging tenant; see tracking issue #1006 for auto-populating this from the
+// discover-defaults pipeline across all resources.
+var importDefaultSuppressions = map[string]map[string]bool{
+	"HTTPLoadBalancer": {
+		"default_sensitive_data_policy":    true,
+		"disable_api_definition":           true,
+		"disable_api_discovery":            true,
+		"disable_api_testing":              true,
+		"disable_malicious_user_detection": true,
+		"disable_malware_protection":       true,
+		"disable_rate_limit":               true,
+		"disable_threat_mesh":              true,
+		"disable_trust_client_ip_headers":  true,
+		"disable_waf":                      true,
+		"l7_ddos_protection":               true,
+		"no_challenge":                     true,
+		"round_robin":                      true,
+		"service_policies_from_namespace":  true,
+		"user_id_client_ip":                true,
+	},
+}
+
+// isImportDefaultSuppressed reports whether the given empty-marker member of the
+// given resource is a server-default oneof member that must not be populated from
+// the API response on the import path.
+func isImportDefaultSuppressed(resourceTitleCase, jsonName string) bool {
+	members, ok := importDefaultSuppressions[resourceTitleCase]
+	if !ok {
+		return false
+	}
+	return members[jsonName]
+}

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -26,6 +26,9 @@ var importDefaultSuppressions = map[string]map[string]bool{
 		"headers": true,
 	},
 	"HTTPLoadBalancer": {
+		// http.dns_volterra_managed: Optional bool, server default false. On import
+		// the API returns false; suppress so config omission doesn't drift.
+		"dns_volterra_managed":             true,
 		"default_sensitive_data_policy":    true,
 		"disable_api_definition":           true,
 		"disable_api_discovery":            true,

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -20,6 +20,11 @@ package codegen
 // staging tenant; see tracking issue #1006 for auto-populating this from the
 // discover-defaults pipeline across all resources.
 var importDefaultSuppressions = map[string]map[string]bool{
+	// Healthcheck: http_health_check.headers is a server-default empty marker
+	// (verified via live API — returned as {} for a minimal health check).
+	"Healthcheck": {
+		"headers": true,
+	},
 	"HTTPLoadBalancer": {
 		"default_sensitive_data_policy":    true,
 		"disable_api_definition":           true,

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -532,7 +532,15 @@ func renderUnmarshalTopLevelSingle(sb *strings.Builder, rc string, attr openapi.
 	}
 
 	model := rc + childPath + "Model"
-	sb.WriteString(fmt.Sprintf("%sif blockData, ok := apiResource.Spec[\"%s\"].(map[string]interface{}); ok && (isImport || data.%s != nil) {\n", indent, jsonName, fieldName))
+	// For server-default blocks (suppressed), skip building on import when the API
+	// returned an empty object — otherwise import materializes an all-defaults block
+	// the user never configured, causing post-import drift. A non-empty response
+	// (user configured something) still imports normally.
+	buildGuard := fmt.Sprintf("(isImport || data.%s != nil)", fieldName)
+	if isImportDefaultSuppressed(rc, jsonName) {
+		buildGuard = fmt.Sprintf("((isImport && len(blockData) > 0) || data.%s != nil)", fieldName)
+	}
+	sb.WriteString(fmt.Sprintf("%sif blockData, ok := apiResource.Spec[\"%s\"].(map[string]interface{}); ok && %s {\n", indent, jsonName, buildGuard))
 	sb.WriteString(fmt.Sprintf("%s\tdata.%s = &%s{\n", indent, fieldName, model))
 	for _, child := range attr.NestedAttributes {
 		renderUnmarshalChild(sb, rc, childPath, child, "blockData", "data."+fieldName, "data."+fieldName+" != nil", "single", indent+"\t\t")
@@ -548,7 +556,7 @@ func renderUnmarshalTopLevelSingle(sb *strings.Builder, rc string, attr openapi.
 // stateGuard is a boolean Go expr true when stateBase is safe to read. It recurses to any depth.
 func renderUnmarshalChild(sb *strings.Builder, rc, prefixPath string, child openapi.TerraformAttribute, srcMap, stateBase, stateGuard, container, indent string) {
 	if !child.IsBlock {
-		renderUnmarshalScalarChild(sb, child, srcMap, stateBase, stateGuard, container, indent)
+		renderUnmarshalScalarChild(sb, rc, child, srcMap, stateBase, stateGuard, container, indent)
 		return
 	}
 	childPath := prefixPath + naming.ToResourceTypeName(child.TfsdkTag)
@@ -560,7 +568,8 @@ func renderUnmarshalChild(sb *strings.Builder, rc, prefixPath string, child open
 }
 
 // renderUnmarshalScalarChild emits the closure entry for a primitive/list child.
-func renderUnmarshalScalarChild(sb *strings.Builder, attr openapi.TerraformAttribute, srcMap, stateBase, stateGuard, container, indent string) {
+// rc is the resource title-case prefix, used for import-default suppression lookups.
+func renderUnmarshalScalarChild(sb *strings.Builder, rc string, attr openapi.TerraformAttribute, srcMap, stateBase, stateGuard, container, indent string) {
 	fieldName := attr.GoName
 	jsonName := attr.JsonName
 	if jsonName == "" {
@@ -602,6 +611,16 @@ func renderUnmarshalScalarChild(sb *strings.Builder, attr openapi.TerraformAttri
 			// returning an unknown here trips "invalid result object after apply".
 			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s && !%s.%s.IsUnknown() {\n", indent, stateGuard, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t\treturn %s.%s\n", indent, stateBase, fieldName))
+			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+		}
+		if isImportDefaultSuppressed(rc, jsonName) {
+			// On import a suppressed server-default bool at its false default must not
+			// be populated (config omits it) — otherwise the next plan shows a spurious
+			// "false -> null". A true value is a real user choice and still imports.
+			sb.WriteString(fmt.Sprintf("%s\tif isImport {\n", indent))
+			sb.WriteString(fmt.Sprintf("%s\t\tif v, ok := %s[\"%s\"].(bool); ok && !v {\n", indent, srcMap, jsonName))
+			sb.WriteString(fmt.Sprintf("%s\t\t\treturn types.BoolNull()\n", indent))
+			sb.WriteString(fmt.Sprintf("%s\t\t}\n", indent))
 			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		}
 		sb.WriteString(fmt.Sprintf("%s\tif v, ok := %s[\"%s\"].(bool); ok {\n", indent, srcMap, jsonName))

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -518,9 +518,16 @@ func renderUnmarshalTopLevelSingle(sb *strings.Builder, rc string, attr openapi.
 	childPath := naming.ToResourceTypeName(attr.TfsdkTag)
 
 	if len(attr.NestedAttributes) == 0 {
-		sb.WriteString(fmt.Sprintf("%sif _, ok := apiResource.Spec[\"%s\"].(map[string]interface{}); ok && isImport && data.%s == nil {\n", indent, jsonName, fieldName))
-		sb.WriteString(fmt.Sprintf("%s\tdata.%s = &%sEmptyModel{}\n", indent, fieldName, rc))
-		sb.WriteString(fmt.Sprintf("%s}\n", indent))
+		// Skip populating server-default oneof empty markers on import: with no
+		// prior config to preserve, importing them causes spurious post-import
+		// drift. Omitting a default member = the server re-applies the same
+		// default, so behavior is unchanged. Non-default/user-intent markers still
+		// import normally.
+		if !isImportDefaultSuppressed(rc, jsonName) {
+			sb.WriteString(fmt.Sprintf("%sif _, ok := apiResource.Spec[\"%s\"].(map[string]interface{}); ok && isImport && data.%s == nil {\n", indent, jsonName, fieldName))
+			sb.WriteString(fmt.Sprintf("%s\tdata.%s = &%sEmptyModel{}\n", indent, fieldName, rc))
+			sb.WriteString(fmt.Sprintf("%s}\n", indent))
+		}
 		return
 	}
 
@@ -650,9 +657,23 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 				sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 			}
 		}
-		sb.WriteString(fmt.Sprintf("%s\tif _, ok := %s[\"%s\"].(map[string]interface{}); ok {\n", indent, srcMap, jsonName))
-		sb.WriteString(fmt.Sprintf("%s\t\treturn &%sEmptyModel{}\n", indent, rc))
-		sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+		// Server-default oneof members must NOT be populated from the API
+		// response on import: there is no prior config to preserve, so importing
+		// them causes spurious "was absent, now present" drift on the next plan.
+		// Guard the response-populate with !isImport for those members; omitting a
+		// default member means the server re-applies the same default (safe).
+		suppress := isImportDefaultSuppressed(rc, jsonName)
+		popIndent := indent
+		if suppress {
+			sb.WriteString(fmt.Sprintf("%s\tif !isImport {\n", indent))
+			popIndent = indent + "\t"
+		}
+		sb.WriteString(fmt.Sprintf("%s\tif _, ok := %s[\"%s\"].(map[string]interface{}); ok {\n", popIndent, srcMap, jsonName))
+		sb.WriteString(fmt.Sprintf("%s\t\treturn &%sEmptyModel{}\n", popIndent, rc))
+		sb.WriteString(fmt.Sprintf("%s\t}\n", popIndent))
+		if suppress {
+			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+		}
 		sb.WriteString(fmt.Sprintf("%s\treturn nil\n", indent))
 		sb.WriteString(fmt.Sprintf("%s}(),\n", indent))
 		return


### PR DESCRIPTION
**Draft / WIP** — first increment of the import-drift architecture (#1006).

## What this does
On `terraform import` there is no prior config to preserve, so the flatten populated every server-default oneof empty-marker member → post-import `plan` showed spurious drift (wanting to remove blocks the user never set). This adds a curated per-resource suppression map and skips populating those members on the **import path only** (create/read behaviour unchanged; omitting a default member = server re-applies the same default).

- `tools/pkg/codegen/import_suppressions.go` — curated map, seeded with http_loadbalancer's 15 top-level server-default markers (excludes user-intent `advertise_on_public_default_vip`).
- `render.go` — suppression in `renderUnmarshalTopLevelSingle` + `renderUnmarshalSingleChild`.
- Unit test `TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault`.

## Verified (staging)
LB post-import drift reduced from **15+ removals → a small tail**. Generator-source only (generated files come from the pipeline).

## Remaining (why still draft) — tracked in #1006
1. Nested empty markers (e.g. `http_health_check.headers`) — needs per-resource data for healthcheck.
2. Non-empty default blocks with a default sub-choice (e.g. `l7_ddos_protection`) — separate branch (`renderUnmarshalTopLevelSingle` non-empty path).
3. Optional non-computed scalars (e.g. `http.dns_volterra_managed`).
4. Auto-populate the suppression map from the `discover-defaults` pipeline (fix LB discovery) instead of hand-curation.

Refs #1006

---
Closes #1014 · Broader effort: #1006