### PR TITLE
feat: data-driven import-suppression pipeline (discover -> JSON -> generator)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,14 @@ download-specs:
 generate: generate-schemas
 	@echo "Generation complete"
 
+# Derive the import-default suppression data file from discovered API defaults
+# (tools/api-defaults.json). Run after 'make discover' (or the discover-defaults
+# workflow) to auto-populate server-default oneof members suppressed on import.
+# Consumed by the code generator; see issue #1006.
+emit-import-suppressions:
+	@echo "Deriving import-default suppressions from $(TOOLS_DIR)/api-defaults.json..."
+	@$(GO) run $(TOOLS_DIR)/emit-import-suppressions.go
+
 generate-schemas:
 	@echo "Generating schemas from OpenAPI specs..."
 	@if [ -d "$(SPEC_DIR)" ] && [ -f "$(SPEC_DIR)/index.json" ] && [ -d "$(SPEC_DIR)/domains" ]; then \

--- a/tools/emit-import-suppressions.go
+++ b/tools/emit-import-suppressions.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+//go:build ignore
+// +build ignore
+
+// emit-import-suppressions derives the terraform-import default-suppression data
+// file (tools/import-default-suppressions.json, consumed by the code generator)
+// from the defaults discovered by discover-defaults.go (tools/api-defaults.json).
+// It unions newly-derived members over the existing file so hand-seeded entries
+// are preserved. Run: go run tools/emit-import-suppressions.go
+//
+// See issue #1006.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/suppress"
+)
+
+const defaultComment = "Per-resource (title-case model prefix) server-default oneof members suppressed on the terraform import path (consumed by the code generator). Auto-derived by tools/emit-import-suppressions.go from tools/api-defaults.json; hand-seeded fallback in tools/pkg/codegen/import_suppressions.go. See issue #1006."
+
+func main() {
+	inDB := flag.String("from-db", "tools/api-defaults.json", "discovered defaults database")
+	outFile := flag.String("out", "tools/import-default-suppressions.json", "suppression data file to write")
+	flag.Parse()
+
+	// Load existing suppression file (preserve hand-seeded entries + comment).
+	existing := map[string][]string{}
+	comment := defaultComment
+	if data, err := os.ReadFile(*outFile); err == nil {
+		var raw map[string]json.RawMessage
+		if json.Unmarshal(data, &raw) == nil {
+			for k, v := range raw {
+				if k == "_comment" {
+					_ = json.Unmarshal(v, &comment)
+					continue
+				}
+				var members []string
+				if json.Unmarshal(v, &members) == nil {
+					existing[k] = members
+				}
+			}
+		}
+	}
+
+	// Load discovered defaults.
+	data, err := os.ReadFile(*inDB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "emit-import-suppressions: %v\n", err)
+		os.Exit(1)
+	}
+	var db suppress.Database
+	if err := json.Unmarshal(data, &db); err != nil {
+		fmt.Fprintf(os.Stderr, "emit-import-suppressions: parse %s: %v\n", *inDB, err)
+		os.Exit(1)
+	}
+
+	derived := suppress.Derive(db)
+	merged := suppress.Merge(existing, derived)
+
+	// Write JSON with the comment first (maps marshal with sorted keys; "_comment"
+	// sorts before capitalized resource names).
+	out := map[string]interface{}{"_comment": comment}
+	for rc, members := range merged {
+		out[rc] = members
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "emit-import-suppressions: marshal: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*outFile, append(b, '\n'), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "emit-import-suppressions: write %s: %v\n", *outFile, err)
+		os.Exit(1)
+	}
+	fmt.Printf("emit-import-suppressions: %d resources in %s (%d derived from %s)\n", len(merged), *outFile, len(derived), *inDB)
+}

--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -1,0 +1,25 @@
+{
+  "HTTPLoadBalancer": [
+    "default_sensitive_data_policy",
+    "disable_api_definition",
+    "disable_api_discovery",
+    "disable_api_testing",
+    "disable_malicious_user_detection",
+    "disable_malware_protection",
+    "disable_rate_limit",
+    "disable_threat_mesh",
+    "disable_trust_client_ip_headers",
+    "disable_waf",
+    "dns_volterra_managed",
+    "l7_ddos_protection",
+    "no_challenge",
+    "round_robin",
+    "service_policies_from_namespace",
+    "user_id_client_ip"
+  ],
+  "Healthcheck": [
+    "headers",
+    "use_http2"
+  ],
+  "_comment": "Per-resource (title-case model prefix) server-default oneof members suppressed on the terraform import path. Auto-populated by tools/discover-defaults.go (create a minimal object in an isolated namespace, diff response vs request); hand-seeded entries live in tools/pkg/codegen/import_suppressions.go. See issue #1006."
+}

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -2,56 +2,91 @@
 
 package codegen
 
-// importDefaultSuppressions lists, per resource (title-case model prefix), the
-// empty-marker oneof members that the F5 XC API ALWAYS returns as the server
-// default for their oneof group. On `terraform import` there is no prior config
-// to preserve, so the flatten would otherwise populate every such default member
-// and the next plan would show spurious drift (it wants to remove blocks the user
-// never configured).
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// Import-default suppression: per resource (title-case model prefix), the oneof
+// members the F5 XC API ALWAYS returns as the server default for their group. On
+// `terraform import` there is no prior config to preserve, so the flatten would
+// otherwise populate every such default member and the next plan would show
+// spurious drift. Suppressing the DEFAULT member on import is semantically safe:
+// omitting it means the server re-applies the same default. Non-default and
+// user-intent markers (e.g. app_firewall, advertise_on_public_default_vip) are
+// NOT listed and still import normally.
 //
-// Suppressing the DEFAULT member of a oneof on import is semantically safe:
-// omitting it means the server re-applies the same default, so behavior is
-// unchanged. Non-default members (e.g. app_firewall vs disable_waf) are NOT
-// listed and still import normally, as are user-intent markers such as
-// advertise_on_public_default_vip.
-//
-// Data source: discovered from the live tenant (create a minimal object, diff the
-// response against the request). Seeded here for http_loadbalancer from the
-// staging tenant; see tracking issue #1006 for auto-populating this from the
-// discover-defaults pipeline across all resources.
-var importDefaultSuppressions = map[string]map[string]bool{
-	// Healthcheck: http_health_check.headers is a server-default empty marker
-	// (verified via live API — returned as {} for a minimal health check).
-	"Healthcheck": {
-		"headers": true,
-	},
+// Data lives in tools/import-default-suppressions.json (auto-populated by
+// tools/discover-defaults.go against a live tenant). The seed below is the
+// built-in fallback used when that file is absent; the JSON is merged over it.
+// See tracking issue #1006.
+var importDefaultSuppressionsSeed = map[string][]string{
+	"Healthcheck": {"headers"},
 	"HTTPLoadBalancer": {
-		// http.dns_volterra_managed: Optional bool, server default false. On import
-		// the API returns false; suppress so config omission doesn't drift.
-		"dns_volterra_managed":             true,
-		"default_sensitive_data_policy":    true,
-		"disable_api_definition":           true,
-		"disable_api_discovery":            true,
-		"disable_api_testing":              true,
-		"disable_malicious_user_detection": true,
-		"disable_malware_protection":       true,
-		"disable_rate_limit":               true,
-		"disable_threat_mesh":              true,
-		"disable_trust_client_ip_headers":  true,
-		"disable_waf":                      true,
-		"l7_ddos_protection":               true,
-		"no_challenge":                     true,
-		"round_robin":                      true,
-		"service_policies_from_namespace":  true,
-		"user_id_client_ip":                true,
+		"dns_volterra_managed",
+		"default_sensitive_data_policy",
+		"disable_api_definition",
+		"disable_api_discovery",
+		"disable_api_testing",
+		"disable_malicious_user_detection",
+		"disable_malware_protection",
+		"disable_rate_limit",
+		"disable_threat_mesh",
+		"disable_trust_client_ip_headers",
+		"disable_waf",
+		"l7_ddos_protection",
+		"no_challenge",
+		"round_robin",
+		"service_policies_from_namespace",
+		"user_id_client_ip",
 	},
 }
 
-// isImportDefaultSuppressed reports whether the given empty-marker member of the
-// given resource is a server-default oneof member that must not be populated from
-// the API response on the import path.
+var (
+	suppressOnce sync.Once
+	suppressMap  map[string]map[string]bool
+)
+
+// loadImportSuppressions builds the effective suppression map: the built-in seed
+// overlaid with tools/import-default-suppressions.json when present.
+func loadImportSuppressions() {
+	suppressMap = map[string]map[string]bool{}
+	add := func(resource string, members []string) {
+		if suppressMap[resource] == nil {
+			suppressMap[resource] = map[string]bool{}
+		}
+		for _, m := range members {
+			suppressMap[resource][m] = true
+		}
+	}
+	for r, members := range importDefaultSuppressionsSeed {
+		add(r, members)
+	}
+	if _, file, _, ok := runtime.Caller(0); ok {
+		jsonPath := filepath.Join(filepath.Dir(file), "..", "..", "import-default-suppressions.json")
+		if data, err := os.ReadFile(jsonPath); err == nil {
+			var fromJSON map[string][]string
+			if json.Unmarshal(data, &fromJSON) == nil {
+				for r, members := range fromJSON {
+					if r == "_comment" {
+						continue
+					}
+					add(r, members)
+				}
+			}
+		}
+	}
+}
+
+// isImportDefaultSuppressed reports whether the given member of the given resource
+// is a server-default oneof member that must not be populated from the API
+// response on the import path.
 func isImportDefaultSuppressed(resourceTitleCase, jsonName string) bool {
-	members, ok := importDefaultSuppressions[resourceTitleCase]
+	suppressOnce.Do(loadImportSuppressions)
+	members, ok := suppressMap[resourceTitleCase]
 	if !ok {
 		return false
 	}

--- a/tools/pkg/suppress/suppress.go
+++ b/tools/pkg/suppress/suppress.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+// Package suppress derives the terraform-import default-suppression map from the
+// defaults discovered by tools/discover-defaults.go. A discovered field is a
+// server default (safe to suppress on import) when it was absent from the create
+// request but present in the response as either an empty marker block or a bool
+// at its false zero-default. See issue #1006.
+package suppress
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
+)
+
+// FieldDefault mirrors the discovery tool's per-field record (subset used here).
+type FieldDefault struct {
+	Path          string      `json:"path"`
+	DefaultValue  interface{} `json:"default_value"`
+	Type          string      `json:"type"`
+	IsMarkerBlock bool        `json:"is_marker_block,omitempty"`
+}
+
+// ResourceResult mirrors the discovery tool's per-resource record (subset).
+type ResourceResult struct {
+	ResourceName string                  `json:"resource_name"`
+	Status       string                  `json:"status"`
+	Defaults     map[string]FieldDefault `json:"defaults,omitempty"`
+}
+
+// Database mirrors the discovery tool's output file (subset).
+type Database struct {
+	Resources map[string]*ResourceResult `json:"resources"`
+}
+
+// leaf returns the final dot-separated segment of a field path (the member name).
+func leaf(path string) string {
+	parts := strings.Split(path, ".")
+	return parts[len(parts)-1]
+}
+
+// isServerDefaultMember reports whether a discovered field is a server-default
+// oneof member that is safe to suppress on import.
+func isServerDefaultMember(fd FieldDefault) bool {
+	if fd.IsMarkerBlock {
+		return true
+	}
+	if fd.Type == "bool" {
+		if b, ok := fd.DefaultValue.(bool); ok && !b {
+			return true
+		}
+	}
+	return false
+}
+
+// Derive builds a resource(title-case) -> sorted member names map from discovered
+// defaults. Only successfully-discovered resources contribute.
+func Derive(db Database) map[string][]string {
+	acc := map[string]map[string]bool{}
+	for _, res := range db.Resources {
+		if res == nil || res.Status != "discovered" {
+			continue
+		}
+		rc := naming.ToResourceTypeName(res.ResourceName)
+		for _, fd := range res.Defaults {
+			if !isServerDefaultMember(fd) {
+				continue
+			}
+			if acc[rc] == nil {
+				acc[rc] = map[string]bool{}
+			}
+			acc[rc][leaf(fd.Path)] = true
+		}
+	}
+	out := map[string][]string{}
+	for rc, members := range acc {
+		list := make([]string, 0, len(members))
+		for m := range members {
+			list = append(list, m)
+		}
+		sort.Strings(list)
+		out[rc] = list
+	}
+	return out
+}
+
+// Merge unions derived members into an existing map (from the JSON data file),
+// preserving hand-seeded entries. Returns a fresh sorted map.
+func Merge(existing, derived map[string][]string) map[string][]string {
+	acc := map[string]map[string]bool{}
+	add := func(rc string, members []string) {
+		if acc[rc] == nil {
+			acc[rc] = map[string]bool{}
+		}
+		for _, m := range members {
+			acc[rc][m] = true
+		}
+	}
+	for rc, m := range existing {
+		add(rc, m)
+	}
+	for rc, m := range derived {
+		add(rc, m)
+	}
+	out := map[string][]string{}
+	for rc, members := range acc {
+		list := make([]string, 0, len(members))
+		for m := range members {
+			list = append(list, m)
+		}
+		sort.Strings(list)
+		out[rc] = list
+	}
+	return out
+}

--- a/tools/pkg/suppress/suppress_test.go
+++ b/tools/pkg/suppress/suppress_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package suppress
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDerive(t *testing.T) {
+	db := Database{
+		Resources: map[string]*ResourceResult{
+			"http_loadbalancer": {
+				ResourceName: "http_loadbalancer",
+				Status:       "discovered",
+				Defaults: map[string]FieldDefault{
+					"spec.disable_waf":               {Path: "spec.disable_waf", Type: "object", IsMarkerBlock: true},
+					"spec.http.dns_volterra_managed": {Path: "spec.http.dns_volterra_managed", Type: "bool", DefaultValue: false},
+					"spec.some_true_flag":            {Path: "spec.some_true_flag", Type: "bool", DefaultValue: true}, // user-meaningful, not suppressed
+					"spec.domains":                   {Path: "spec.domains", Type: "array"},                          // not a marker/bool
+				},
+			},
+			"failed_res": {ResourceName: "failed_res", Status: "failed"}, // ignored
+		},
+	}
+
+	got := Derive(db)
+	want := map[string][]string{
+		"HTTPLoadBalancer": {"disable_waf", "dns_volterra_managed"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Derive() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	existing := map[string][]string{"Healthcheck": {"headers"}, "HTTPLoadBalancer": {"disable_waf"}}
+	derived := map[string][]string{"HTTPLoadBalancer": {"round_robin", "disable_waf"}, "AppFirewall": {"disable_x"}}
+	got := Merge(existing, derived)
+	want := map[string][]string{
+		"Healthcheck":      {"headers"},
+		"HTTPLoadBalancer": {"disable_waf", "round_robin"},
+		"AppFirewall":      {"disable_x"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Merge() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
Automation for #1006: the import-default suppression map is now data-driven and auto-populatable.

- Generator loads `tools/import-default-suppressions.json` (merged over a built-in seed).
- `tools/pkg/suppress`: testable Derive/Merge (discovered defaults -> per-resource suppression members). Unit-tested.
- `tools/emit-import-suppressions.go` (`make emit-import-suppressions`): derives the JSON from `tools/api-defaults.json`, unioning over hand-seeded entries.

## Testing
- `go test ./tools/pkg/suppress/` + codegen tests pass.
- Ran the emitter against existing discovery data (derived Healthcheck.use_http2).
- MVP (LB+pool+healthcheck) still imports cleanly (post-import plan: No changes) against staging.

## Follow-up (broader coverage)
Populating complex resources needs discover-defaults to create prerequisite deps (e.g. LB needs a pool; API rejects dangling refs) and run across resources — best via the discover-defaults workflow in a controlled tenant. Tracked in #1006.

Closes #1017 · Broader effort: #1006