### PR TITLE
feat: import-clean WAF + API-protection coverage; fix JSON-load regression

### DIFF
--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -240,15 +240,34 @@ var ResourceConfigs = map[string]MinimalConfig{
 	"app_firewall": {
 		Category:  CategorySecurity,
 		Namespace: true,
+		// Minimal: send only what's required so the API-applied defaults
+		// (blocking/monitoring mode, bot settings, detection settings, …) are
+		// observed as defaults rather than pre-sent.
 		RequiredSpec: map[string]interface{}{
-			"allow_all_response_codes": true,
-			"default_anonymization":    true,
-			"use_default_blocking_page": true,
-			"default_bot_setting":      true,
-			"default_detection_settings": true,
-			"use_loadbalancer_setting": true,
-			"blocking":                 map[string]interface{}{},
+			"blocking":                   map[string]interface{}{},
+			"default_detection_settings": map[string]interface{}{},
 		},
+	},
+	// API protection / discovery family (webapp-api-protection roadmap).
+	"api_definition": {
+		Category:     CategorySecurity,
+		Namespace:    true,
+		RequiredSpec: map[string]interface{}{},
+	},
+	"api_discovery": {
+		Category:     CategorySecurity,
+		Namespace:    true,
+		RequiredSpec: map[string]interface{}{},
+	},
+	"api_crawler": {
+		Category:     CategorySecurity,
+		Namespace:    true,
+		RequiredSpec: map[string]interface{}{},
+	},
+	"api_testing": {
+		Category:     CategorySecurity,
+		Namespace:    true,
+		RequiredSpec: map[string]interface{}{},
 	},
 	"service_policy": {
 		Category:  CategorySecurity,

--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -1,4 +1,17 @@
 {
+  "APIDefinition": [
+    "strict_schema_origin"
+  ],
+  "APITesting": [
+    "every_week"
+  ],
+  "AppFirewall": [
+    "allow_all_response_codes",
+    "default_anonymization",
+    "default_bot_setting",
+    "disable_ai_enhancements",
+    "use_default_blocking_page"
+  ],
   "HTTPLoadBalancer": [
     "add_location",
     "default_sensitive_data_policy",

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -68,17 +68,33 @@ func loadImportSuppressions() {
 	if _, file, _, ok := runtime.Caller(0); ok {
 		jsonPath := filepath.Join(filepath.Dir(file), "..", "..", "import-default-suppressions.json")
 		if data, err := os.ReadFile(jsonPath); err == nil {
-			var fromJSON map[string][]string
-			if json.Unmarshal(data, &fromJSON) == nil {
-				for r, members := range fromJSON {
-					if r == "_comment" {
-						continue
-					}
-					add(r, members)
-				}
+			for r, members := range parseSuppressionsJSON(data) {
+				add(r, members)
 			}
 		}
 	}
+}
+
+// parseSuppressionsJSON parses the suppression data file into resource -> members.
+// It parses via RawMessage so the string "_comment" field does not break
+// unmarshalling of the []string resource entries (a regression that silently
+// disabled the whole JSON, leaving only the built-in seed active).
+func parseSuppressionsJSON(data []byte) map[string][]string {
+	out := map[string][]string{}
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return out
+	}
+	for r, rawMembers := range raw {
+		if r == "_comment" {
+			continue
+		}
+		var members []string
+		if json.Unmarshal(rawMembers, &members) == nil {
+			out[r] = members
+		}
+	}
+	return out
 }
 
 // isImportDefaultSuppressed reports whether the given member of the given resource

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package codegen
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The suppression data file carries a string "_comment" field alongside the
+// []string resource entries. Parsing into map[string][]string fails on that
+// string, which silently disabled the whole JSON (only the built-in seed stayed
+// active). Regression test: _comment is skipped and resource entries load.
+func TestParseSuppressionsJSON_SkipsComment(t *testing.T) {
+	data := []byte(`{"_comment":"docs here","AppFirewall":["allow_all_response_codes","default_bot_setting"],"APIDefinition":["strict_schema_origin"]}`)
+	got := parseSuppressionsJSON(data)
+	want := map[string][]string{
+		"AppFirewall":   {"allow_all_response_codes", "default_bot_setting"},
+		"APIDefinition": {"strict_schema_origin"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseSuppressionsJSON() = %#v, want %#v", got, want)
+	}
+}
+
+// End-to-end: an entry present only in the JSON data file (not the Go seed) must
+// be honored, proving the file is actually loaded.
+func TestImportSuppressions_JSONEntryHonored(t *testing.T) {
+	if !isImportDefaultSuppressed("AppFirewall", "allow_all_response_codes") {
+		t.Error("AppFirewall.allow_all_response_codes (JSON-only) should be suppressed; JSON not loaded?")
+	}
+}


### PR DESCRIPTION
Completes import-clean coverage for the webapp-api-protection roadmap (LB → WAF → API protection).

- **discover-defaults**: minimal `app_firewall` config + new `api_definition`/`api_discovery`/`api_crawler`/`api_testing` configs (all discover standalone). Bounded self-cleaning staging runs derived their server-default markers.
- **import-default-suppressions.json**: AppFirewall (5), APIDefinition (1), APITesting (1).
- **Bug fix**: `import_suppressions.go` unmarshalled the JSON into `map[string][]string`, which fails on the string `_comment` → the entire file was silently discarded and only the Go seed was ever active (masked because the MVP resources were seeded). Now parsed via `RawMessage` (`parseSuppressionsJSON`), skipping `_comment`. Regression tests added.

## Verified (staging)
- `xcsh_app_firewall` + `xcsh_api_definition` apply and round-trip import cleanly (post-import plan: **No changes**).
- MVP (LB+pool+healthcheck) import unchanged (regression).
- `go test ./tools/pkg/{codegen,suppress,discovery}/` pass.

Closes #1027 · Broader effort: #1006