### PR TITLE
fix(discover-defaults): cascade-delete throwaway namespace on cleanup

### DIFF
--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -568,13 +568,17 @@ func main() {
 		time.Sleep(2 * time.Second)
 	}
 
-	// Cleanup function for test namespace
+	// Cleanup function for test namespace. F5 XC namespaces require a cascade
+	// delete (a plain DELETE does not remove them and leaves an orphan namespace).
 	defer func() {
 		if createdNamespace && testNamespace != "" {
 			fmt.Printf("\nCleaning up test namespace: %s\n", testNamespace)
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			_ = apiClient.Delete(ctx, fmt.Sprintf("/api/web/namespaces/%s", testNamespace))
+			var resp map[string]interface{}
+			if err := apiClient.Post(ctx, fmt.Sprintf("/api/web/namespaces/%s/cascade_delete", testNamespace), map[string]interface{}{"name": testNamespace}, &resp); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to cascade-delete test namespace %s: %v\n", testNamespace, err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Broad discovery run for #1006 (the operational frontier), plus the fix it surfaced.

## Broad run (staging, isolated throwaway namespace)
`discover-defaults -all -create-namespace` → **18/26 discovered, 8 safe failures** (create rejected = nothing created). Result: **import-suppression coverage is already complete** for every discoverable resource that needs it — only 5 complex-oneof resources have server-default markers (http_loadbalancer 17, app_firewall 5, healthcheck 2, api_definition 1, api_testing 1); the other 13 (origin_pool, service_policy, rate_limiter, virtual_site, …) have **none** and don't have the import-drift problem. No new suppressions needed.

## Fix
The `-create-namespace` cleanup used a plain `DELETE`, which does not remove F5 XC namespaces → orphan namespaces after the run (I cascade-deleted the two it left). Now uses `POST /api/web/namespaces/<name>/cascade_delete`.

## Follow-up
8 resources (certificate, contact, data_group/type, filter_set, forwarding_class, geo_location_set, tcp_loadbalancer) need richer minimal configs to discover — low suppression value (simple/non-oneof); tcp_loadbalancer would need a pool prerequisite like http_loadbalancer if TCP LBs enter scope.

Closes #1029 · Broader effort: #1006