### PR TITLE
feat: tcp_loadbalancer discovery config + import-clean coverage

### DIFF
--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -226,13 +226,37 @@ var ResourceConfigs = map[string]MinimalConfig{
 	"tcp_loadbalancer": {
 		Category:  CategoryLoadBalancer,
 		Namespace: true,
+		// Like http_loadbalancer: origin_pools_weights must reference a real
+		// origin_pool (created as a prerequisite); send only the minimal so
+		// server defaults are discovered.
 		RequiredSpec: map[string]interface{}{
-			"domains":       []interface{}{"test.example.com"},
-			"listen_port":   8080,
-			"with_sni":      map[string]interface{}{},
-			"tcp":           map[string]interface{}{},
+			"domains": []interface{}{"tf-discover.example.com"},
+			// SNI on the shared public VIP requires a TLS-class port (443, 2053, …).
+			"listen_port": 443,
+			"sni":         map[string]interface{}{},
+			"tcp":         map[string]interface{}{},
+			"origin_pools_weights": []interface{}{
+				map[string]interface{}{
+					"pool": map[string]interface{}{
+						"name":      "@prereq:origin_pool",
+						"namespace": "@prereq-ns:origin_pool",
+					},
+					"weight": 1,
+				},
+			},
 			"advertise_on_public_default_vip": map[string]interface{}{},
-			"origin_pools_weights":            []interface{}{},
+		},
+		Prerequisites: []Prerequisite{
+			{Kind: "origin_pool", Spec: map[string]interface{}{
+				"port": 80,
+				"origin_servers": []interface{}{
+					map[string]interface{}{
+						"public_name": map[string]interface{}{"dns_name": "example.com"},
+					},
+				},
+				"no_tls":                map[string]interface{}{},
+				"same_as_endpoint_port": map[string]interface{}{},
+			}},
 		},
 	},
 

--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -35,5 +35,11 @@
     "headers",
     "use_http2"
   ],
+  "TCPLoadBalancer": [
+    "dns_volterra_managed",
+    "hash_policy_choice_round_robin",
+    "retract_cluster",
+    "service_policies_from_namespace"
+  ],
   "_comment": "Per-resource (title-case model prefix) server-default oneof members suppressed on the terraform import path. Auto-populated by tools/discover-defaults.go (create a minimal object in an isolated namespace, diff response vs request); hand-seeded entries live in tools/pkg/codegen/import_suppressions.go. See issue #1006."
 }


### PR DESCRIPTION
Fills the highest-value discovery-config gap from the broad run (#1006).

- **tcp_loadbalancer**: was failing discovery (BAD_REQUEST — no origin pool ref; `listen_port 8080` invalid for SNI on the shared public VIP, which requires 443/2053/…). Fixed: origin_pool prerequisite + `origin_pools_weights` reference + `sni {}`/`tcp {}` + `listen_port 443`. Now discovers (12 defaults) → 4 server-default markers → **TCPLoadBalancer** suppressions.

## Verified (staging)
`xcsh_tcp_loadbalancer` applies and round-trip imports cleanly (post-import plan: **No changes**), same pattern as http_loadbalancer.

## Not addressed (low value, documented)
The other broad-run failures (certificate, contact, data_group/data_type, filter_set, forwarding_class, geo_location_set) are simple/non-oneof resources — the broad run confirmed such resources have **0 suppressible markers**, so richer configs add nothing to the suppression map. Some hit NOT_FOUND endpoints in the staging tenant (feature/path unavailable).

Closes #1033 · Broader effort: #1006