### PR TITLE
feat: import-suppress enable_api_discovery inner oneof defaults

### DIFF
--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -14,10 +14,12 @@
   ],
   "HTTPLoadBalancer": [
     "add_location",
+    "default_api_auth_discovery",
     "default_sensitive_data_policy",
     "disable_api_definition",
     "disable_api_discovery",
     "disable_api_testing",
+    "disable_learn_from_redirect_traffic",
     "disable_malicious_user_detection",
     "disable_malware_protection",
     "disable_rate_limit",

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -42,6 +42,13 @@ var importDefaultSuppressionsSeed = map[string][]string{
 		"round_robin",
 		"service_policies_from_namespace",
 		"user_id_client_ip",
+		// enable_api_discovery inner oneof defaults: the server materializes these
+		// whenever discovery is enabled, but discover-defaults.go can't observe them
+		// (its probe LB never enables discovery). Hand-seeded so a bare
+		// enable_api_discovery {} is import-clean and consistent on first apply.
+		// Matched by leaf name at any depth (see isImportDefaultSuppressed).
+		"default_api_auth_discovery",
+		"disable_learn_from_redirect_traffic",
 	},
 }
 

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -30,3 +30,17 @@ func TestImportSuppressions_JSONEntryHonored(t *testing.T) {
 		t.Error("AppFirewall.allow_all_response_codes (JSON-only) should be suppressed; JSON not loaded?")
 	}
 }
+
+// enable_api_discovery's inner oneof defaults are materialized by the server
+// whenever discovery is enabled, but discover-defaults.go cannot observe them
+// (its probe LB never enables discovery — it's the non-default side of the
+// disable/enable oneof). Without suppression, a bare `enable_api_discovery {}`
+// hard-errors on first apply and drifts on round-trip import. They are matched by
+// leaf name at any depth, so listing them under HTTPLoadBalancer suffices.
+func TestImportSuppressions_EnableAPIDiscoveryInnerDefaults(t *testing.T) {
+	for _, m := range []string{"default_api_auth_discovery", "disable_learn_from_redirect_traffic"} {
+		if !isImportDefaultSuppressed("HTTPLoadBalancer", m) {
+			t.Errorf("HTTPLoadBalancer.%s must be a suppressed server-default (enable_api_discovery inner oneof)", m)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the `enable_api_discovery {}` determinism gap on `xcsh_http_loadbalancer`.

## What

Adds `default_api_auth_discovery` and `disable_learn_from_redirect_traffic` to the `HTTPLoadBalancer` import-default-suppression set (JSON data file + Go seed), plus a unit test.

## Why

F5 XC always materializes these two inner oneof defaults when discovery is enabled. Without suppression, a bare `enable_api_discovery {}`:
- hard-errors on first apply (`Provider produced inconsistent result after apply`), and
- drifts on round-trip import (plan wants to remove the two inner markers).

They can't be auto-discovered (`discover-defaults.go`'s probe LB never enables discovery), so they're hand-seeded. Matching is by leaf name at any depth, so this also fixes the guard-less `single_lb_app.enable_discovery` grandchild.

## Verification

- New test `TestImportSuppressions_EnableAPIDiscoveryInnerDefaults` (red before, green after); `tools/pkg/codegen`, `suppress`, `discovery` suites pass; `go build ./...` clean.
- After `make generate`, the emitted populate is wrapped in `if !isImport {}` at all 4 sites.
- Against the live production tenant: a bare `enable_api_discovery {}` is now first-apply-consistent and round-trip-import-clean (`terraform plan` = No changes).

Generator-source only — regenerated files ship via the on-merge pipeline (Constitution Check).

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)