### PR TITLE
feat: client-side defense — import-clean LB block + CSD domain resources

### DIFF
--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -19,6 +19,7 @@
     "disable_api_definition",
     "disable_api_discovery",
     "disable_api_testing",
+    "disable_client_side_defense",
     "disable_learn_from_redirect_traffic",
     "disable_malicious_user_detection",
     "disable_malware_protection",

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -31,6 +31,7 @@ var importDefaultSuppressionsSeed = map[string][]string{
 		"disable_api_definition",
 		"disable_api_discovery",
 		"disable_api_testing",
+		"disable_client_side_defense",
 		"disable_malicious_user_detection",
 		"disable_malware_protection",
 		"disable_rate_limit",

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -44,3 +44,14 @@ func TestImportSuppressions_EnableAPIDiscoveryInnerDefaults(t *testing.T) {
 		}
 	}
 }
+
+// disable_client_side_defense is the server default of the client_side_defense
+// oneof on the HTTP load balancer. On any LB that does not enable CSD, the server
+// materializes disable_client_side_defense {}, so it must be suppressed on import
+// (same pattern as disable_waf / disable_api_discovery) to keep round-trip import
+// clean.
+func TestImportSuppressions_DisableClientSideDefense(t *testing.T) {
+	if !isImportDefaultSuppressed("HTTPLoadBalancer", "disable_client_side_defense") {
+		t.Error("HTTPLoadBalancer.disable_client_side_defense must be a suppressed server-default (client_side_defense oneof)")
+	}
+}

--- a/tools/pkg/openapi/openapi_test.go
+++ b/tools/pkg/openapi/openapi_test.go
@@ -521,22 +521,22 @@ func TestTerraformAttribute_AllFields(t *testing.T) {
 		GoType:      "string",
 
 		// SP-1 additions
-		ServerDefault:        true,
-		Default:              "default-value",
+		ServerDefault:         true,
+		Default:               "default-value",
 		MinimumConfigRequired: true,
-		RecommendedValue:     "recommended-value",
-		ValidationRules:      map[string]string{"max_length": "256"},
-		Complexity:           "advanced",
-		UseCases:             []string{"use-case-1"},
-		DeprecationMessage:   "Deprecated: use new_field",
-		ConflictsWith:        []string{"other_field"},
-		MaxLength:            256,
-		Immutable:            true,
-		EnumValues:           []string{"a", "b", "c"},
-		MinLength:            1,
-		Pattern:              "^[a-z]+$",
-		MinItems:             1,
-		MaxItems:             10,
+		RecommendedValue:      "recommended-value",
+		ValidationRules:       map[string]string{"max_length": "256"},
+		Complexity:            "advanced",
+		UseCases:              []string{"use-case-1"},
+		DeprecationMessage:    "Deprecated: use new_field",
+		ConflictsWith:         []string{"other_field"},
+		MaxLength:             256,
+		Immutable:             true,
+		EnumValues:            []string{"a", "b", "c"},
+		MinLength:             1,
+		Pattern:               "^[a-z]+$",
+		MinItems:              1,
+		MaxItems:              10,
 	}
 
 	// Existing fields
@@ -785,4 +785,24 @@ func TestGenerationResult_AllFields(t *testing.T) {
 	assertEqual(t, "FilePath", result.FilePath, "/path/to/resource.go")
 	assertIntEqual(t, "AttrCount", result.AttrCount, 15)
 	assertIntEqual(t, "BlockCount", result.BlockCount, 3)
+}
+
+// Client-Side Defense domain-management objects live under /api/shape/csd/ (not
+// /api/config/), so resource discovery must recognize the shape-service pattern.
+// Without it, protected_domain/allowed_domain/mitigated_domain are never generated.
+func TestExtractResourcePaths_ShapeServiceCSD(t *testing.T) {
+	paths := map[string]interface{}{
+		"/api/shape/csd/namespaces/{namespace}/protected_domains": map[string]interface{}{"get": map[string]interface{}{}},
+		"/api/shape/csd/namespaces/{namespace}/allowed_domains":   map[string]interface{}{"get": map[string]interface{}{}},
+		"/api/shape/csd/namespaces/{namespace}/mitigated_domains": map[string]interface{}{"get": map[string]interface{}{}},
+	}
+	got := map[string]bool{}
+	for _, rp := range extractResourcePathsFromPaths(paths) {
+		got[rp.ResourceName] = true
+	}
+	for _, want := range []string{"protected_domain", "allowed_domain", "mitigated_domain"} {
+		if !got[want] {
+			t.Errorf("expected shape-service resource %q to be discovered; got %v", want, got)
+		}
+	}
 }

--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -330,6 +330,14 @@ func extractResourcePathsFromPaths(paths map[string]interface{}) []resourcePath 
 	// Secondary pattern: /api/web/{resource_plural} (for system-level resources like namespace)
 	webPathRegex := regexp.MustCompile(`^/api/web/([a-z_0-9]+s)$`)
 
+	// Shape-service pattern: /api/shape/{service}/namespaces/{namespace}/{resource_plural}
+	// (e.g. /api/shape/csd/namespaces/{namespace}/protected_domains — Client-Side Defense
+	// domain-management objects). These live outside /api/config. The resource name is kept
+	// as the natural API kind (protected_domain/allowed_domain/mitigated_domain) so the
+	// generator resolves its {resourceName}CreateSpecType schema; the full shape path is
+	// preserved as the resource's APIPath so the client targets /api/shape/... correctly.
+	shapeServicePathRegex := regexp.MustCompile(`^/api/shape/[a-z_0-9]+/namespaces/\{namespace\}/([a-z_0-9]+s)$`)
+
 	for path := range paths {
 		var resourcePlural string
 
@@ -341,6 +349,9 @@ func extractResourcePathsFromPaths(paths map[string]interface{}) []resourcePath 
 			resourcePlural = matches[1]
 		} else if matches := webPathRegex.FindStringSubmatch(path); len(matches) >= 2 {
 			// Try web pattern for system-level resources (e.g., namespace)
+			resourcePlural = matches[1]
+		} else if matches := shapeServicePathRegex.FindStringSubmatch(path); len(matches) >= 2 {
+			// Shape-service resources (e.g. Client-Side Defense protected_domains)
 			resourcePlural = matches[1]
 		} else {
 			continue


### PR DESCRIPTION
Adds Client-Side Defense (CSD) provider support. Generator-source only.

Closes #1043.

## What
1. **Import-clean the LB `client_side_defense` block** — add `disable_client_side_defense` to the `HTTPLoadBalancer` suppression set (JSON + Go seed). Fixes round-trip import drift on any LB without CSD.
2. **New CSD domain-management resources** — extend resource discovery with the `/api/shape/{service}/…` pattern so `/api/shape/csd/` objects generate: `xcsh_protected_domain`, `xcsh_allowed_domain`, `xcsh_mitigated_domain` (+ read-only data sources). Names kept as the natural API kinds so `{name}CreateSpecType` schema resolution works; the shape path is preserved as the resource API path.
3. **`with-client-side-defense.tf`** LB example.

## Verification
- New unit tests green: `TestImportSuppressions_DisableClientSideDefense`, `TestExtractResourcePaths_ShapeServiceCSD`. Full `tools/pkg/...` suite + `go build ./...` pass.
- `make generate` → 128 resources, 0 failures; the three CSD domain resources + data sources generate; their client targets `/api/shape/csd/namespaces/%s/…`.

Generator output (internal/provider, docs, generated examples) is intentionally **not** committed — it ships via the on-merge regenerate pipeline (Constitution Check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)