### PR TITLE
feat: 501-tolerant Read + register standalone entitlement data sources

### DIFF
--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -369,6 +369,19 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
+		// Some F5 XC APIs do not implement GET-by-name (read returns 501 Not
+		// Implemented — e.g. the shape/csd domain objects, which support only
+		// list/create/delete). Treat that as "cannot refresh" and preserve the
+		// prior state rather than erroring, so the resource stays manageable and
+		// idempotent (create/delete still work).
+		if strings.Contains(err.Error(), "501") {
+			tflog.Warn(ctx, "{{.TitleCase}} read not implemented by API (501); keeping prior state", map[string]interface{}{
+				"name":      data.Name.ValueString(),
+				"namespace": data.Namespace.ValueString(),
+			})
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read {{.TitleCase}}: %s", err))
 		return
 	}

--- a/tools/pkg/registration/registration.go
+++ b/tools/pkg/registration/registration.go
@@ -24,6 +24,16 @@ import (
 // Note: namespace was removed in v3.0.0 as part of backwards compatibility cleanup
 var CoreResources = []string{}
 
+// StandaloneDataSources are hand-written data sources that have no generated
+// resource companion (so they are not registered via CoreResources or the
+// spec-generation results). They must still be wired into provider.DataSources().
+// Each entry NAME must map (via naming.ToResourceTypeName) to an existing
+// New<TitleCase>DataSource constructor in internal/provider.
+var StandaloneDataSources = []string{
+	"addon_service",                  // xcsh_addon_service — addon tier/details
+	"addon_service_activation_status", // xcsh_addon_service_activation_status — entitlement/subscription state
+}
+
 // GenerateCombinedClientTypes is a no-op placeholder retained for interface
 // compatibility. Individual client type files are generated per-resource
 // during the main generation loop.
@@ -136,6 +146,15 @@ func GenerateProviderRegistration(results []openapi.GenerationResult, outputDir 
 			}
 			dataSources = append(dataSources, fmt.Sprintf("\t\tNew%sDataSource,", titleCase))
 		}
+	}
+
+	// Wire standalone hand-written data sources (no generated resource companion).
+	for _, ds := range StandaloneDataSources {
+		if added[ds] {
+			continue
+		}
+		titleCase := naming.ToResourceTypeName(ds)
+		dataSources = append(dataSources, fmt.Sprintf("\t\tNew%sDataSource,", titleCase))
 	}
 
 	// Sort for consistent output


### PR DESCRIPTION
Follow-ups from CSD wiring. Closes #1047.

- **Read template**: tolerate 501 (Not Implemented) from GET-by-name by keeping prior state — the shape/csd domain resources are list/create/delete only, so GET-by-name is 501. Makes them idempotent.
- **StandaloneDataSources**: register hand-written data sources with no generated resource companion — wires `xcsh_addon_service` + `xcsh_addon_service_activation_status` (the CSD entitlement guard), which were defined but never in `provider.DataSources()`.

Generator-source only (2 files); regenerated output ships via the pipeline. `tools/pkg/...` tests + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)