### PR TITLE
feat: compile x-f5xc-requires into an apply-time pre-flight (CSD prerequisite)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -606,3 +606,46 @@ func TestRecursiveEmitters_DeepListConversion(t *testing.T) {
 		t.Errorf("expected unmarshal to ListValueFrom the deep rr_set with its AttrTypes, got:\n%s", unmarshal)
 	}
 }
+
+// RenderRequirementPreflights emits, for each declared prerequisite, an apply-time
+// guard: nil-check the triggering block, LIST the requirement's collection in the
+// resource namespace, and fail fast with the remediation message when it is empty.
+// This is the shipped-binary enforcement of x-f5xc-requires.
+func TestRenderRequirementPreflights_CSD(t *testing.T) {
+	pf := []openapi.RequirementPreflight{{
+		WhenField:   "client_side_defense",
+		WhenGoField: "ClientSideDefense",
+		ListPath:    "/api/shape/csd/namespaces/%s/protected_domains",
+		Requires:    "client_side_defense requires a same-namespace protected_domain",
+		ErrorTitle:  "Client-Side Defense prerequisite missing",
+		ErrorDetail: `no protected_domain in namespace %s; create an xcsh_protected_domain (the API says "Failed to get CSD JS Configuration")`,
+	}}
+	got := RenderRequirementPreflights(pf, "r")
+
+	for _, want := range []string{
+		"if data.ClientSideDefense != nil {",
+		`fmt.Sprintf("/api/shape/csd/namespaces/%s/protected_domains", data.Namespace.ValueString())`,
+		"r.client.Get(ctx,",
+		"Items []map[string]interface{} `json:\"items\"`",
+		"len(preflightResp.Items) == 0",
+		`resp.Diagnostics.AddError(`,
+		`"Client-Side Defense prerequisite missing"`,
+		"return",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("preflight code missing %q, got:\n%s", want, got)
+		}
+	}
+	// The detail string carries embedded quotes and a %s verb; it must be emitted as a
+	// valid, correctly-escaped Go literal (via strconv.Quote), not spliced raw.
+	if strings.Contains(got, `Configuration")`) && !strings.Contains(got, `Configuration\")`) {
+		t.Errorf("error_detail quotes must be escaped in the generated literal, got:\n%s", got)
+	}
+}
+
+// No declared preflights -> no emitted code (so unaffected resources are byte-identical).
+func TestRenderRequirementPreflights_Empty(t *testing.T) {
+	if got := RenderRequirementPreflights(nil, "r"); strings.TrimSpace(got) != "" {
+		t.Errorf("want empty output for no preflights, got:\n%s", got)
+	}
+}

--- a/tools/pkg/codegen/generate.go
+++ b/tools/pkg/codegen/generate.go
@@ -34,6 +34,7 @@ func GenerateResourceFile(resource *openapi.ResourceTemplate, outputDir string) 
 		"renderSpecMarshalCode":           RenderSpecMarshalCode,
 		"renderSpecMarshalCodeForCreate":  RenderSpecMarshalCodeForCreate,
 		"renderSpecUnmarshalCode":         RenderSpecUnmarshalCode,
+		"renderPreflights":                RenderRequirementPreflights,
 		"renderCreateComputedFieldsCode":  RenderCreateComputedFieldsCode,
 		"renderUpdateComputedFieldsCode":  RenderUpdateComputedFieldsCode,
 		"renderFetchedComputedFieldsCode": RenderFetchedComputedFieldsCode,

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -7,12 +7,51 @@ package codegen
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/schema"
 )
+
+// RenderRequirementPreflights emits apply-time prerequisite guards for a resource's
+// Create/Update. For each declared preflight it nil-checks the triggering block, LISTs
+// the requirement's collection in the resource's own namespace, and fails fast with the
+// remediation message when the collection is empty — turning an opaque server error
+// (e.g. CSD's 500 "Failed to get CSD JS Configuration") into an actionable diagnostic.
+// This compiles the dependency declared by x-f5xc-requires into the shipped binary, so
+// every remote workstation enforces it identically. recvVar is the resource receiver
+// (typically "r"); the emitted code also references the ambient ctx, data, and resp
+// that both the Create and Update method bodies provide. Empty input emits nothing, so
+// resources without preflights are byte-identical to before.
+func RenderRequirementPreflights(preflights []openapi.RequirementPreflight, recvVar string) string {
+	if len(preflights) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, p := range preflights {
+		listErr := "Failed to verify the " + p.WhenField + " prerequisite (namespace %s): %s"
+		sb.WriteString("\n")
+		sb.WriteString("\t// Requirement pre-flight (generated; source: x-f5xc-requires):\n")
+		sb.WriteString("\t// " + p.Requires + "\n")
+		fmt.Fprintf(&sb, "\tif data.%s != nil {\n", p.WhenGoField)
+		fmt.Fprintf(&sb, "\t\tpreflightPath := fmt.Sprintf(%s, data.Namespace.ValueString())\n", strconv.Quote(p.ListPath))
+		sb.WriteString("\t\tvar preflightResp struct {\n")
+		sb.WriteString("\t\t\tItems []map[string]interface{} `json:\"items\"`\n")
+		sb.WriteString("\t\t}\n")
+		fmt.Fprintf(&sb, "\t\tif err := %s.client.Get(ctx, preflightPath, &preflightResp); err != nil {\n", recvVar)
+		fmt.Fprintf(&sb, "\t\t\tresp.Diagnostics.AddError(%s, fmt.Sprintf(%s, data.Namespace.ValueString(), err))\n", strconv.Quote(p.ErrorTitle), strconv.Quote(listErr))
+		sb.WriteString("\t\t\treturn\n")
+		sb.WriteString("\t\t}\n")
+		sb.WriteString("\t\tif len(preflightResp.Items) == 0 {\n")
+		fmt.Fprintf(&sb, "\t\t\tresp.Diagnostics.AddError(%s, fmt.Sprintf(%s, data.Namespace.ValueString()))\n", strconv.Quote(p.ErrorTitle), strconv.Quote(p.ErrorDetail))
+		sb.WriteString("\t\t\treturn\n")
+		sb.WriteString("\t\t}\n")
+		sb.WriteString("\t}\n")
+	}
+	return sb.String()
+}
 
 // NestedModelInfo holds information needed to generate a nested model type
 type NestedModelInfo struct {

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -281,7 +281,7 @@ func (r *{{.TitleCase}}Resource) Create(ctx context.Context, req resource.Create
 
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
-
+{{ renderPreflights .Preflights "r" }}
 	tflog.Debug(ctx, "Creating {{.Name}}", map[string]interface{}{
 		"name":      data.Name.ValueString(),
 		"namespace": data.Namespace.ValueString(),
@@ -458,7 +458,7 @@ func (r *{{.TitleCase}}Resource) Update(ctx context.Context, req resource.Update
 
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
-
+{{ renderPreflights .Preflights "r" }}
 	apiResource := &client.{{.TitleCase}}{
 		Metadata: client.Metadata{
 			Name:      data.Name.ValueString(),

--- a/tools/pkg/openapi/preflight.go
+++ b/tools/pkg/openapi/preflight.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// Apply-time requirement pre-flights are declared in tools/preflight-requirements.json
+// (source of truth: x-f5xc-requires in api-specs-enriched) and compiled into each
+// resource's Create/Update by the codegen. This encodes the prerequisite in the
+// shipped provider binary, so every remote workstation enforces it identically
+// instead of relying on out-of-band knowledge. See RequirementPreflight (types.go).
+
+var (
+	preflightOnce sync.Once
+	preflightMap  map[string][]RequirementPreflight
+)
+
+// loadPreflights reads tools/preflight-requirements.json (relative to this source
+// file) into the resource-keyed map. A missing or malformed file yields an empty
+// map — resources then generate with no pre-flight, exactly as before.
+func loadPreflights() {
+	preflightMap = map[string][]RequirementPreflight{}
+	if _, file, _, ok := runtime.Caller(0); ok {
+		jsonPath := filepath.Join(filepath.Dir(file), "..", "..", "preflight-requirements.json")
+		if data, err := os.ReadFile(jsonPath); err == nil {
+			preflightMap = parsePreflightsJSON(data)
+		}
+	}
+}
+
+// parsePreflightsJSON parses the data file into resource TitleCase -> preflights.
+// It decodes via RawMessage so the string "_comment" documentation field does not
+// break unmarshalling of the []RequirementPreflight resource entries.
+func parsePreflightsJSON(data []byte) map[string][]RequirementPreflight {
+	out := map[string][]RequirementPreflight{}
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return out
+	}
+	for resource, rawEntries := range raw {
+		if resource == "_comment" {
+			continue
+		}
+		var entries []RequirementPreflight
+		if json.Unmarshal(rawEntries, &entries) == nil {
+			out[resource] = entries
+		}
+	}
+	return out
+}
+
+// LoadPreflights returns the declared apply-time pre-flights for a resource
+// (by TitleCase), or an empty slice if none. WhenGoField is left unresolved here;
+// the schema extractor fills it from the resource's attributes.
+func LoadPreflights(resourceTitleCase string) []RequirementPreflight {
+	preflightOnce.Do(loadPreflights)
+	entries := preflightMap[resourceTitleCase]
+	out := make([]RequirementPreflight, len(entries))
+	copy(out, entries)
+	return out
+}

--- a/tools/pkg/openapi/preflight_test.go
+++ b/tools/pkg/openapi/preflight_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"strings"
+	"testing"
+)
+
+// parsePreflightsJSON must skip the string "_comment" field (same regression that
+// silently disabled import-default-suppressions.json) and load resource entries.
+func TestParsePreflightsJSON_SkipsComment(t *testing.T) {
+	data := []byte(`{"_comment":"docs here","HTTPLoadBalancer":[{"when_field":"client_side_defense","list_path":"/api/shape/csd/namespaces/%s/protected_domains","requires":"needs a protected_domain","error_title":"missing","error_detail":"none in %s"}]}`)
+	got := parsePreflightsJSON(data)
+	if _, isComment := got["_comment"]; isComment {
+		t.Error("_comment must be skipped, not parsed as a resource")
+	}
+	pf, ok := got["HTTPLoadBalancer"]
+	if !ok || len(pf) != 1 {
+		t.Fatalf("want exactly 1 HTTPLoadBalancer preflight, got %#v", got)
+	}
+	if pf[0].WhenField != "client_side_defense" {
+		t.Errorf("WhenField = %q, want client_side_defense", pf[0].WhenField)
+	}
+	if pf[0].ListPath != "/api/shape/csd/namespaces/%s/protected_domains" {
+		t.Errorf("ListPath = %q", pf[0].ListPath)
+	}
+	if pf[0].ErrorDetail != "none in %s" {
+		t.Errorf("ErrorDetail = %q", pf[0].ErrorDetail)
+	}
+}
+
+// End-to-end: the shipped tools/preflight-requirements.json must yield the
+// client_side_defense -> protected_domains preflight for HTTPLoadBalancer,
+// proving the file is actually loaded (not just the parser).
+func TestLoadPreflights_HTTPLoadBalancerFromFile(t *testing.T) {
+	got := LoadPreflights("HTTPLoadBalancer")
+	if len(got) == 0 {
+		t.Fatal("HTTPLoadBalancer must have at least one preflight from the data file")
+	}
+	found := false
+	for _, p := range got {
+		if p.WhenField == "client_side_defense" && strings.Contains(p.ListPath, "protected_domains") {
+			found = true
+			if n := strings.Count(p.ErrorDetail, "%s"); n != 1 {
+				t.Errorf("error_detail must contain exactly one namespace verb, got %d", n)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("client_side_defense -> protected_domains preflight not loaded; got %#v", got)
+	}
+}
+
+// A resource with no declared preflights returns an empty slice (no panic, no code emitted).
+func TestLoadPreflights_None(t *testing.T) {
+	if got := LoadPreflights("NoSuchResourceXYZ"); len(got) != 0 {
+		t.Errorf("want no preflights for unknown resource, got %#v", got)
+	}
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -188,6 +188,28 @@ type ResourceTemplate struct {
 	HasConflicts            bool   // True if any attribute has ConflictsWith
 	ConflictCheckCode       string // Generated Go code for conflict checks
 	IsReadOnly              bool   // True if resource has GetSpecType only (data source, no resource)
+
+	// Preflights are apply-time requirement checks compiled into Create/Update.
+	// Source of truth: x-f5xc-requires (api-specs-enriched). Loaded from
+	// tools/preflight-requirements.json keyed by TitleCase; see preflight.go.
+	Preflights []RequirementPreflight
+}
+
+// RequirementPreflight is one apply-time prerequisite the provider verifies
+// before writing a resource. When the model field WhenGoField is set (non-nil),
+// the generated Create/Update lists ListPath in the resource's namespace and, if
+// the collection is empty, fails fast with ErrorTitle/ErrorDetail — turning an
+// opaque server error into an actionable remediation. It encodes, in the shipped
+// binary, the dependency declared by x-f5xc-requires (e.g. client_side_defense
+// requires a same-namespace protected_domain), so every remote workstation
+// enforces it identically without relying on out-of-band knowledge.
+type RequirementPreflight struct {
+	WhenField   string `json:"when_field"`   // JSON/tfsdk name of the triggering field, e.g. "client_side_defense"
+	WhenGoField string `json:"-"`            // Go model field to nil-check, e.g. "ClientSideDefense" (resolved from attributes)
+	ListPath    string `json:"list_path"`    // LIST path with a single %s for the namespace
+	Requires    string `json:"requires"`     // Human-readable requirement (rendered as a code comment)
+	ErrorTitle  string `json:"error_title"`  // Diagnostic summary
+	ErrorDetail string `json:"error_detail"` // Diagnostic detail; must contain exactly one %s for the namespace
 }
 
 // GenerationResult tracks the result of generating a resource.

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -286,9 +286,16 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	conflictAttrs, goNameLookup := CollectConflictAttrs(attributes)
 	conflictCode := conflicts.GenerateChecks(conflictAttrs, goNameLookup)
 
+	// Compile declared apply-time prerequisites (x-f5xc-requires) into this resource,
+	// resolving each preflight's trigger field to its Go model field so Create/Update
+	// can nil-check it. Preflights whose trigger is not a top-level attribute are dropped.
+	titleCase := naming.ToResourceTypeName(resourceName)
+	preflights := ResolvePreflightGoFields(openapi.LoadPreflights(titleCase), attributes)
+
 	return &openapi.ResourceTemplate{
 		Name:                    resourceName,
-		TitleCase:               naming.ToResourceTypeName(resourceName),
+		TitleCase:               titleCase,
+		Preflights:              preflights,
 		APIPath:                 apiPath,
 		APIPathPlural:           resourceName + "s",
 		APIPathItem:             apiPathItem,
@@ -313,6 +320,31 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 		HasConflicts:            conflictCode != "",
 		ConflictCheckCode:       conflictCode,
 	}, nil
+}
+
+// ResolvePreflightGoFields binds each preflight's declared trigger field (WhenField,
+// a tfsdk tag such as "client_side_defense") to its generated Go model field name
+// (WhenGoField, e.g. "ClientSideDefense") using the resource's top-level attributes.
+// A preflight whose trigger is not a top-level attribute is dropped so the generator
+// never emits a reference to a field that does not exist.
+func ResolvePreflightGoFields(preflights []openapi.RequirementPreflight, attributes []openapi.TerraformAttribute) []openapi.RequirementPreflight {
+	if len(preflights) == 0 {
+		return nil
+	}
+	goByTfsdk := make(map[string]string, len(attributes))
+	for _, a := range attributes {
+		goByTfsdk[a.TfsdkTag] = a.GoName
+	}
+	resolved := make([]openapi.RequirementPreflight, 0, len(preflights))
+	for _, p := range preflights {
+		goName, ok := goByTfsdk[p.WhenField]
+		if !ok || goName == "" {
+			continue
+		}
+		p.WhenGoField = goName
+		resolved = append(resolved, p)
+	}
+	return resolved
 }
 
 // ExtractReadOnlyResourceSchema extracts a data-source-only schema from a GetSpecType.

--- a/tools/preflight-requirements.json
+++ b/tools/preflight-requirements.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Apply-time requirement pre-flights compiled into resource Create/Update by the codegen (tools/pkg/openapi/preflight.go loads this; tools/pkg/codegen RenderRequirementPreflights emits it). Source of truth is x-f5xc-requires in api-specs-enriched (config/minimum_configs.yaml resources.*.dependencies). Keyed by resource TitleCase. Each entry: when the model field 'when_field' is set, the generated resource LISTs 'list_path' (single %s = namespace) in the resource's own namespace before the API write; an empty collection fails fast with error_title/error_detail instead of the opaque server error. error_detail must contain exactly one %s for the namespace. This enforces the dependency in the shipped binary so every remote workstation behaves identically.",
+  "HTTPLoadBalancer": [
+    {
+      "when_field": "client_side_defense",
+      "list_path": "/api/shape/csd/namespaces/%s/protected_domains",
+      "requires": "client_side_defense requires a protected_domain (eTLD+1) registered in the load balancer's own namespace",
+      "error_title": "Client-Side Defense prerequisite missing",
+      "error_detail": "client_side_defense is enabled but no protected_domain is registered in namespace %s. F5 Distributed Cloud builds the Client-Side Defense JavaScript configuration from a protected_domain (an eTLD+1 such as \"example.com\") in the load balancer's own namespace; without one the API rejects the load balancer with 500 \"Failed to get CSD JS Configuration\". Create an xcsh_protected_domain in this namespace (set protected_domain to your eTLD+1) and have the load balancer depend on it before enabling client_side_defense."
+    }
+  ]
+}


### PR DESCRIPTION
## What

Compiles declared resource prerequisites (`x-f5xc-requires`) into an **apply-time
pre-flight** emitted by the codegen into each resource's `Create`/`Update`, so the rule
is enforced by the shipped provider binary rather than living only in docs, memory, or
the generation-time enriched spec.

First rule: **`HTTPLoadBalancer.client_side_defense` requires a same-namespace
`protected_domain`**. When CSD is enabled but no `protected_domain` exists in the LB's
namespace, apply now fails fast with `Client-Side Defense prerequisite missing` (with
remediation steps) **before** any API write — instead of the opaque
`500 "Failed to get CSD JS Configuration"`.

## How

- `tools/preflight-requirements.json` — declarative, keyed by resource TitleCase
  (mirrors `import-default-suppressions.json`). Source of truth: `x-f5xc-requires`.
- `tools/pkg/openapi`: `RequirementPreflight` type, `ResourceTemplate.Preflights`,
  `LoadPreflights` loader (skips `_comment`, file-backed).
- `tools/pkg/schema`: `ResolvePreflightGoFields` binds the trigger tfsdk field to its
  Go model field (drops any that don't resolve).
- `tools/pkg/codegen`: `RenderRequirementPreflights` helper + `renderPreflights` funcMap
  + injection after the timeout setup in the `Create` and `Update` templates.

The check LISTs `/api/shape/csd/namespaces/{ns}/protected_domains` and blocks on an empty
`items` collection.

## Verification

- `go vet ./tools/...` + `go test ./tools/...` green (loader + render-helper tests, TDD).
- `make generate`: guard present in **both** `Create` and `Update` of
  `http_loadbalancer_resource.go`, and in **no other** resource; `go build ./...` OK.
- Live (pre-prod `f5-sales-demo`): a minimal LB with `client_side_defense` in a fresh
  namespace with no `protected_domain` fails with the remediation error before any PUT;
  the real webapp plan (namespace has a `protected_domain`) stays **No changes**.

Generator-source-only — no generated `internal/provider/`, `docs/`, or `examples/`
committed; regeneration ships via the pipeline.

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)