### PR TITLE
feat: generate eTLD+1 plan-time validator from etld_plus_one rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	golang.org/x/crypto v0.48.0
+	golang.org/x/net v0.51.0
 	golang.org/x/text v0.34.0
 	golang.org/x/tools v0.41.0
 )
@@ -54,7 +55,6 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.17.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"golang.org/x/net/publicsuffix"
 )
 
 // Common regex patterns for F5 XC resources
@@ -255,5 +256,40 @@ func RequiredNamespaceValidators() []validator.String {
 func OptionalDomainValidators() []validator.String {
 	return []validator.String{
 		DomainValidator(),
+	}
+}
+
+// ETLDPlusOneValidator enforces ves.io.schema.rules.string.etld_plus_one: the value must
+// itself be an effective-TLD-plus-one (registrable) domain — e.g. "example.com" or
+// "example.co.uk", not a subdomain ("www.example.com") or a bare label ("example"). A
+// single trailing dot (fully-qualified form) is tolerated. The public suffix list is
+// embedded in the binary, so the check is identical on every workstation.
+func ETLDPlusOneValidator() validator.String {
+	return &etldPlusOneValidator{}
+}
+
+type etldPlusOneValidator struct{}
+
+func (v etldPlusOneValidator) Description(ctx context.Context) string {
+	return "value must be an eTLD+1 (registrable) domain, e.g. example.com"
+}
+
+func (v etldPlusOneValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v etldPlusOneValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue.ValueString()
+	domain := strings.TrimSuffix(value, ".")
+	etld1, err := publicsuffix.EffectiveTLDPlusOne(domain)
+	if err != nil || etld1 != domain {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Domain",
+			fmt.Sprintf("Value %q must be an eTLD+1 (registrable) domain such as \"example.com\" or \"example.co.uk\" — not a subdomain (e.g. \"www.example.com\") or a bare label (e.g. \"example\").", value),
+		)
 	}
 }

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -349,3 +349,43 @@ func TestValidatorDescriptions(t *testing.T) {
 		})
 	}
 }
+
+func TestETLDPlusOneValidator(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		isNull      bool
+		expectError bool
+	}{
+		{"registrable .com", "example.com", false, false},
+		{"multi-level public suffix", "example.co.uk", false, false},
+		{"trailing dot tolerated", "example.com.", false, false},
+		{"real demo domain", "f5-sales-demo.com", false, false},
+		{"subdomain rejected", "www.example.com", false, true},
+		{"deep subdomain rejected", "a.b.example.com", false, true},
+		{"bare label rejected", "example", false, true},
+		{"empty string rejected", "", false, true},
+		{"null allowed", "", true, false},
+	}
+
+	ctx := context.Background()
+	v := ETLDPlusOneValidator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("protected_domain"),
+				ConfigValue: types.StringValue(tt.input),
+			}
+			if tt.isNull {
+				req.ConfigValue = types.StringNull()
+			}
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			if got := resp.Diagnostics.HasError(); got != tt.expectError {
+				t.Errorf("ETLDPlusOneValidator(%q): hasError = %v, want %v", tt.input, got, tt.expectError)
+			}
+		})
+	}
+}

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -649,3 +649,15 @@ func TestRenderRequirementPreflights_Empty(t *testing.T) {
 		t.Errorf("want empty output for no preflights, got:\n%s", got)
 	}
 }
+
+// A nested string attribute carrying the etld_plus_one flag must emit the eTLD+1
+// validator (the top-level path is exercised by regeneration of protected_domain).
+func TestRenderNestedAttributes_ETLDPlusOne(t *testing.T) {
+	attrs := []openapi.TerraformAttribute{
+		{GoName: "Domain", TfsdkTag: "domain", Type: "string", ETLDPlusOne: true},
+	}
+	got := RenderNestedAttributes(attrs, "\t")
+	if !strings.Contains(got, "validators.ETLDPlusOneValidator()") {
+		t.Errorf("expected ETLDPlusOneValidator for etld_plus_one attribute, got:\n%s", got)
+	}
+}

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -930,6 +930,9 @@ func RenderNestedAttributes(attrs []openapi.TerraformAttribute, indent string) s
 				}
 				stringValidators = append(stringValidators, fmt.Sprintf("stringvalidator.OneOf(%s)", strings.Join(quoted, ", ")))
 			}
+			if attr.ETLDPlusOne {
+				stringValidators = append(stringValidators, "validators.ETLDPlusOneValidator()")
+			}
 			if len(stringValidators) > 0 {
 				sb.WriteString(fmt.Sprintf("%s\t\tValidators: []validator.String{\n", indent))
 				for _, sv := range stringValidators {

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -143,7 +143,7 @@ func (r *{{.TitleCase}}Resource) Schema(ctx context.Context, req resource.Schema
 					stringvalidator.OneOf({{enumValuesLiteral .EnumValues}}),
 {{- end}}
 				},
-{{- else if and (eq .Type "string") (or (gt .MinLength 0) (gt .MaxLength 0) (ne .Pattern "") (gt (len .EnumValues) 0))}}
+{{- else if and (eq .Type "string") (or (gt .MinLength 0) (gt .MaxLength 0) (ne .Pattern "") (gt (len .EnumValues) 0) .ETLDPlusOne)}}
 				Validators: []validator.String{
 {{- if and (gt .MinLength 0) (gt .MaxLength 0)}}
 					stringvalidator.LengthBetween({{.MinLength}}, {{.MaxLength}}),
@@ -157,6 +157,9 @@ func (r *{{.TitleCase}}Resource) Schema(ctx context.Context, req resource.Schema
 {{- end}}
 {{- if gt (len .EnumValues) 0}}
 					stringvalidator.OneOf({{enumValuesLiteral .EnumValues}}),
+{{- end}}
+{{- if .ETLDPlusOne}}
+					validators.ETLDPlusOneValidator(),
 {{- end}}
 				},
 {{- else if and (or (eq .Type "list") (eq .Type "set")) (or (gt .MinItems 0) (gt .MaxItems 0))}}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -148,6 +148,7 @@ type TerraformAttribute struct {
 	StringDefault         string            // Spec-driven static string default (e.g. namespace fixed to "system"); empty = none
 	MinLength             int               // From validation rules
 	Pattern               string            // From validation rules
+	ETLDPlusOne           bool              // From ves.io.schema.rules.string.etld_plus_one — value must be an eTLD+1 domain
 	MinItems              int               // From x-f5xc-constraints.min_items
 	MaxItems              int               // From x-f5xc-constraints.max_items
 	Minimum               int

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -279,6 +279,12 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	if len(schema.XValidationRules) > 0 {
 		attr.ValidationRules = schema.XValidationRules
 	}
+	// etld_plus_one: the value must itself be an eTLD+1 (registrable) domain. Translate
+	// the F5 XC rule into a generated plan-time validator (see codegen templates).
+	const etldRule = "ves.io.schema.rules.string.etld_plus_one"
+	if schema.XVesValidationRules[etldRule] == "true" || schema.XValidationRules[etldRule] == "true" {
+		attr.ETLDPlusOne = true
+	}
 	// x-required / x-ves-required are additional Required signals, but only
 	// apply at depth 0 (top-level resource spec attributes). For nested
 	// attributes inside optional blocks, Required: true causes Terraform


### PR DESCRIPTION
## What

Closes the one determinism gap surfaced by the CSD audit: `ves.io.schema.rules.string.etld_plus_one`
is a real F5 XC rule, but the codegen never translated it into a validator — so "must be
an eTLD+1 domain" lived only in docs/operator memory and was rejected only at apply by the
API. Now it is a **generated plan-time validator**, enforced identically on every workstation.

## How

- `internal/validators`: `ETLDPlusOneValidator()` using `golang.org/x/net/publicsuffix`
  (embedded public-suffix list → deterministic). Accepts `example.com`, `example.co.uk`,
  a trailing dot; rejects subdomains (`www.example.com`) and bare labels (`example`).
- `openapi`: `TerraformAttribute.ETLDPlusOne` flag.
- `schema`: set the flag from `x-ves-validation-rules` / `x-validation-rules`.
- `codegen`: emit `validators.ETLDPlusOneValidator()` in the resource template and the
  nested-attribute render path, guarded by the flag.
- Promote `golang.org/x/net` to a direct dependency.

Applies to **every** `etld_plus_one` field; today that is `xcsh_protected_domain.protected_domain`.

## Verification

- TDD: validator unit tests (accept/reject matrix incl. `example.co.uk` and trailing dot)
  and a codegen emission test, written first; `go vet` + `go test ./internal/... ./tools/...` green.
- `make generate` wires `ETLDPlusOneValidator()` onto `protected_domain.protected_domain`;
  `go build ./...` OK.
- **Live plan (local binary):** `protected_domain = "www.example.com"` fails at plan with
  `Invalid Domain` **before any API call**; `"example.com"` passes validation and planning proceeds.

Generator-source-only — no generated `internal/provider/`, `docs/`, or `examples/` committed.

Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)