### PR TITLE
docs: note plan-time eTLD+1 validation in CSD pre-flight message

### DIFF
--- a/tools/preflight-requirements.json
+++ b/tools/preflight-requirements.json
@@ -6,7 +6,7 @@
       "list_path": "/api/shape/csd/namespaces/%s/protected_domains",
       "requires": "client_side_defense requires a protected_domain (eTLD+1) registered in the load balancer's own namespace",
       "error_title": "Client-Side Defense prerequisite missing",
-      "error_detail": "client_side_defense is enabled but no protected_domain is registered in namespace %s. F5 Distributed Cloud builds the Client-Side Defense JavaScript configuration from a protected_domain (an eTLD+1 such as \"example.com\") in the load balancer's own namespace; without one the API rejects the load balancer with 500 \"Failed to get CSD JS Configuration\". Create an xcsh_protected_domain in this namespace (set protected_domain to your eTLD+1) and have the load balancer depend on it before enabling client_side_defense."
+      "error_detail": "client_side_defense is enabled but no protected_domain is registered in namespace %s. F5 Distributed Cloud builds the Client-Side Defense JavaScript configuration from a protected_domain (an eTLD+1 such as \"example.com\"; the xcsh_protected_domain resource validates this format at plan time) in the load balancer's own namespace; without one the API rejects the load balancer with 500 \"Failed to get CSD JS Configuration\". Create an xcsh_protected_domain in this namespace (set protected_domain to your eTLD+1) and have the load balancer depend on it before enabling client_side_defense."
     }
   ]
 }


### PR DESCRIPTION
Small generator-source change to the `client_side_defense` pre-flight remediation text:
note that `xcsh_protected_domain` validates the eTLD+1 format at plan time (#1054).

Importantly, this triggers the **first provider regeneration since the textlint blocker
was cleared** (specs v2.1.173 prose fix + `.textlintrc` allowlist on main). The resulting
auto-regenerate PR should pass textlint and merge, finally landing the CSD domain
resources (#1044), the apply-time pre-flight (#1052), and the eTLD+1 validator (#1054)
in a published release (all absent from v3.69.0, which was cut from a non-regen commit).

Generator-source-only. JSON validated; openapi preflight tests green.

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)