### PR TITLE
feat: provider hardening — delete-retry, import round-trip, example import-clean

### DIFF
--- a/internal/provider/app_firewall_resource_test.go
+++ b/internal/provider/app_firewall_resource_test.go
@@ -640,20 +640,13 @@ resource "xcsh_app_firewall" "test" {
   # Use default detection settings
   default_detection_settings {}
 
-  # Allow all response codes
-  allow_all_response_codes {}
-
   # Blocking mode - actively block malicious requests
   blocking {}
 
-  # Use default blocking page
-  use_default_blocking_page {}
-
-  # Use default bot settings
-  default_bot_setting {}
-
-  # Use default anonymization
-  default_anonymization {}
+  # allow_all_response_codes / use_default_blocking_page / default_bot_setting /
+  # default_anonymization are server-default oneof markers the provider import-suppresses.
+  # Declaring them makes the config import-unclean (config has them, imported state does
+  # not), so they are intentionally omitted here — the server still materializes them.
 }
 `, name)
 }

--- a/tools/import-id-fields.json
+++ b/tools/import-id-fields.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Resources whose create-only spec fields are NOT readable from the API (e.g. GET-by-name returns 501) and therefore cannot be recovered on import from state alone. For these, the import ID carries the field value(s) as trailing '/'-separated segments after namespace/name, so a round-trip import is drift-free. Keyed by resource TitleCase; loaded by tools/pkg/openapi/import_id_fields.go and emitted into ImportState by the codegen. Example import: `terraform import xcsh_protected_domain.x <namespace>/<name>/<protected_domain>`.",
+  "ProtectedDomain": ["protected_domain"]
+}

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -661,3 +661,40 @@ func TestRenderNestedAttributes_ETLDPlusOne(t *testing.T) {
 		t.Errorf("expected ETLDPlusOneValidator for etld_plus_one attribute, got:\n%s", got)
 	}
 }
+
+// The Delete template must retry transient referential BAD_REQUEST (a resource briefly
+// still referenced during teardown) with a bounded, context-aware loop, while leaving
+// NOT_FOUND/404 (already deleted) and 501 (unsupported) as terminal.
+func TestResourceTemplate_DeleteRetriesTransient400(t *testing.T) {
+	for _, want := range []string{
+		"for attempt := 0; ; attempt++ {",
+		`strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")`,
+		"attempt >= 5",
+		"time.After(5 * time.Second)",
+		"case <-ctx.Done():",
+	} {
+		if !strings.Contains(ResourceTemplate, want) {
+			t.Errorf("Delete template missing retry construct %q", want)
+		}
+	}
+	// The transient guard must exclude the terminal conditions so they aren't retried.
+	if !strings.Contains(ResourceTemplate, `!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")`) {
+		t.Error("transient guard must exclude NOT_FOUND/404/501")
+	}
+}
+
+// Resources with create-only, API-unreadable fields carry those fields in the import ID
+// (namespace/name/<field>...) so a round-trip import is drift-free. The ImportState
+// template must parse the extra segments and set the attributes.
+func TestResourceTemplate_ImportIDExtraFields(t *testing.T) {
+	for _, want := range []string{
+		"{{- if .ImportIDExtraFields}}",
+		"len(parts) != {{add 2 (len .ImportIDExtraFields)}}",
+		"{{- range $i, $f := .ImportIDExtraFields}}",
+		`path.Root("{{$f}}"), parts[{{add 2 $i}}]`,
+	} {
+		if !strings.Contains(ResourceTemplate, want) {
+			t.Errorf("ImportState template missing extra-fields construct %q", want)
+		}
+	}
+}

--- a/tools/pkg/codegen/generate.go
+++ b/tools/pkg/codegen/generate.go
@@ -35,6 +35,7 @@ func GenerateResourceFile(resource *openapi.ResourceTemplate, outputDir string) 
 		"renderSpecMarshalCodeForCreate":  RenderSpecMarshalCodeForCreate,
 		"renderSpecUnmarshalCode":         RenderSpecUnmarshalCode,
 		"renderPreflights":                RenderRequirementPreflights,
+		"add":                             func(a, b int) int { return a + b },
 		"renderCreateComputedFieldsCode":  RenderCreateComputedFieldsCode,
 		"renderUpdateComputedFieldsCode":  RenderUpdateComputedFieldsCode,
 		"renderFetchedComputedFieldsCode": RenderFetchedComputedFieldsCode,

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -539,12 +540,40 @@ func (r *{{.TitleCase}}Resource) Delete(ctx context.Context, req resource.Delete
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
 {{- if eq .TitleCase "Namespace"}}
-	// Namespace requires cascade_delete endpoint (standard DELETE returns 501)
-	err := r.client.CascadeDeleteNamespace(ctx, data.Name.ValueString())
+		// Namespace requires cascade_delete endpoint (standard DELETE returns 501)
+		err = r.client.CascadeDeleteNamespace(ctx, data.Name.ValueString())
 {{- else}}
-	err := r.client.Delete{{.TitleCase}}(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		err = r.client.Delete{{.TitleCase}}(ctx, data.Namespace.ValueString(), data.Name.ValueString())
 {{- end}}
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "{{.TitleCase}} delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of {{.TitleCase}} (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {
@@ -570,6 +599,26 @@ func (r *{{.TitleCase}}Resource) Delete(ctx context.Context, req resource.Delete
 
 func (r *{{.TitleCase}}Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 {{- if .HasNamespaceInPath}}
+{{- if .ImportIDExtraFields}}
+	// Import ID format: namespace/name{{range .ImportIDExtraFields}}/{{.}}{{end}}
+	// Trailing fields are create-only and not readable from the API (e.g. GET-by-name
+	// returns 501), so they ride in the import ID to keep round-trip import drift-free.
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != {{add 2 (len .ImportIDExtraFields)}} || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID format: namespace/name{{range .ImportIDExtraFields}}/{{.}}{{end}}, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
+{{- range $i, $f := .ImportIDExtraFields}}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("{{$f}}"), parts[{{add 2 $i}}])...)
+{{- end}}
+{{- else}}
 	// Import ID format: namespace/name
 	parts := strings.Split(req.ID, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -585,6 +634,7 @@ func (r *{{.TitleCase}}Resource) ImportState(ctx context.Context, req resource.I
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), namespace)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), name)...)
+{{- end}}
 {{- else}}
 	// Import ID format: name (no namespace for this resource type)
 	name := req.ID

--- a/tools/pkg/openapi/import_id_fields.go
+++ b/tools/pkg/openapi/import_id_fields.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// Some resources have create-only spec fields the API cannot return on read
+// (e.g. the CSD protected_domain: GET-by-name is 501 and the LIST projection is
+// empty). Such a field cannot be recovered on import from state, so its value is
+// supplied as a trailing segment of the import ID. tools/import-id-fields.json
+// (keyed by resource TitleCase) declares those fields; the codegen emits an
+// ImportState that parses and sets them. See RequirementPreflight for the sibling
+// data-driven codegen pattern.
+
+var (
+	importIDFieldsOnce sync.Once
+	importIDFieldsMap  map[string][]string
+)
+
+func loadImportIDFields() {
+	importIDFieldsMap = map[string][]string{}
+	if _, file, _, ok := runtime.Caller(0); ok {
+		jsonPath := filepath.Join(filepath.Dir(file), "..", "..", "import-id-fields.json")
+		if data, err := os.ReadFile(jsonPath); err == nil {
+			importIDFieldsMap = parseImportIDFieldsJSON(data)
+		}
+	}
+}
+
+// parseImportIDFieldsJSON decodes the data file into resource -> field names,
+// skipping the string "_comment" documentation key.
+func parseImportIDFieldsJSON(data []byte) map[string][]string {
+	out := map[string][]string{}
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return out
+	}
+	for resource, rawFields := range raw {
+		if resource == "_comment" {
+			continue
+		}
+		var fields []string
+		if json.Unmarshal(rawFields, &fields) == nil {
+			out[resource] = fields
+		}
+	}
+	return out
+}
+
+// LoadImportIDFields returns the create-only fields carried in a resource's import
+// ID (by TitleCase), or nil if none.
+func LoadImportIDFields(resourceTitleCase string) []string {
+	importIDFieldsOnce.Do(loadImportIDFields)
+	fields := importIDFieldsMap[resourceTitleCase]
+	out := make([]string, len(fields))
+	copy(out, fields)
+	return out
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -194,6 +194,11 @@ type ResourceTemplate struct {
 	// Source of truth: x-f5xc-requires (api-specs-enriched). Loaded from
 	// tools/preflight-requirements.json keyed by TitleCase; see preflight.go.
 	Preflights []RequirementPreflight
+
+	// ImportIDExtraFields are create-only spec fields the API cannot return on read,
+	// so their values ride in the import ID as trailing segments after namespace/name.
+	// Loaded from tools/import-id-fields.json keyed by TitleCase; see import_id_fields.go.
+	ImportIDExtraFields []string
 }
 
 // RequirementPreflight is one apply-time prerequisite the provider verifies

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -296,6 +296,7 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 		Name:                    resourceName,
 		TitleCase:               titleCase,
 		Preflights:              preflights,
+		ImportIDExtraFields:     openapi.LoadImportIDFields(titleCase),
 		APIPath:                 apiPath,
 		APIPathPlural:           resourceName + "s",
 		APIPathItem:             apiPathItem,


### PR DESCRIPTION
Three generator-source hardening fixes (from the follow-up list):

- **Delete-retry on transient referential 400** — teardown-ordering failures (healthcheck
  still referenced by a pool, pool by an LB) now retry with a bounded, context-aware loop
  instead of erroring; NOT_FOUND/404 and 501 stay terminal.
- **Create-only import round-trip** — `protected_domain` is unreadable (GET-by-name 501),
  so its value rides in the import ID (`namespace/name/protected_domain`) via a data-driven
  `tools/import-id-fields.json`; ImportState parses+sets it → drift-free round-trip.
- **app_firewall blocking.tf import-clean** — removed the import-suppressed server-default
  oneof markers from the blocking acceptance-test config (source of the generated example).

TDD: `TestResourceTemplate_DeleteRetriesTransient400`, `TestResourceTemplate_ImportIDExtraFields`.
`go vet` + `go test ./tools/...` green; provider builds; regeneration verified
(healthcheck Delete has the retry, protected_domain import parses 3 parts, blocking.tf clean).
Generator-source-only.

Closes #1073
🤖 Generated with [Claude Code](https://claude.com/claude-code)