### PR TITLE
chore: auto-regenerate provider and documentation

### DIFF
--- a/examples/guides/addon-activation/main.tf
+++ b/examples/guides/addon-activation/main.tf
@@ -2,7 +2,7 @@
 # =========================================================
 #
 # This example demonstrates how to activate F5XC addon services
-# using Terraform. It shows the complete workflow from checkinggggggggggggggggggggggggggggggggggggggggggggggg
+# using Terraform. It shows the complete workflow from checkingggggggggggggggggggggggggggggggggggggggggggggggg
 # eligibility to activating and using addon features.
 #
 # QUICK START:

--- a/examples/resources/xcsh_app_firewall/blocking.tf
+++ b/examples/resources/xcsh_app_firewall/blocking.tf
@@ -9,18 +9,11 @@ resource "xcsh_app_firewall" "test" {
   # Use default detection settings
   default_detection_settings {}
 
-  # Allow all response codes
-  allow_all_response_codes {}
-
   # Blocking mode - actively block malicious requests
   blocking {}
 
-  # Use default blocking page
-  use_default_blocking_page {}
-
-  # Use default bot settings
-  default_bot_setting {}
-
-  # Use default anonymization
-  default_anonymization {}
+  # allow_all_response_codes / use_default_blocking_page / default_bot_setting /
+  # default_anonymization are server-default oneof markers the provider import-suppresses.
+  # Declaring them makes the config import-unclean (config has them, imported state does
+  # not), so they are intentionally omitted here — the server still materializes them.
 }

--- a/internal/provider/address_allocator_resource.go
+++ b/internal/provider/address_allocator_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -675,7 +676,36 @@ func (r *AddressAllocatorResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAddressAllocator(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAddressAllocator(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AddressAllocator delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AddressAllocator (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/advertise_policy_resource.go
+++ b/internal/provider/advertise_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3504,7 +3505,36 @@ func (r *AdvertisePolicyResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAdvertisePolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAdvertisePolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AdvertisePolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AdvertisePolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/alert_gen_policy_resource.go
+++ b/internal/provider/alert_gen_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -624,7 +625,36 @@ func (r *AlertGenPolicyResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAlertGenPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAlertGenPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AlertGenPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AlertGenPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2290,7 +2291,36 @@ func (r *AlertPolicyResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAlertPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAlertPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AlertPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AlertPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/alert_receiver_resource.go
+++ b/internal/provider/alert_receiver_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3730,7 +3731,36 @@ func (r *AlertReceiverResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAlertReceiver(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAlertReceiver(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AlertReceiver delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AlertReceiver (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/alert_template_resource.go
+++ b/internal/provider/alert_template_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -540,7 +541,36 @@ func (r *AlertTemplateResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAlertTemplate(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAlertTemplate(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AlertTemplate delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AlertTemplate (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/allowed_domain_resource.go
+++ b/internal/provider/allowed_domain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -456,7 +457,36 @@ func (r *AllowedDomainResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAllowedDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAllowedDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AllowedDomain delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AllowedDomain (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/api_crawler_resource.go
+++ b/internal/provider/api_crawler_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -946,7 +947,36 @@ func (r *APICrawlerResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAPICrawler(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAPICrawler(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "APICrawler delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of APICrawler (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/api_definition_resource.go
+++ b/internal/provider/api_definition_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1066,7 +1067,36 @@ func (r *APIDefinitionResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAPIDefinition(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAPIDefinition(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "APIDefinition delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of APIDefinition (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/api_discovery_resource.go
+++ b/internal/provider/api_discovery_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -609,7 +610,36 @@ func (r *APIDiscoveryResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAPIDiscovery(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAPIDiscovery(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "APIDiscovery delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of APIDiscovery (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/api_testing_resource.go
+++ b/internal/provider/api_testing_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -2351,7 +2352,36 @@ func (r *APITestingResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAPITesting(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAPITesting(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "APITesting delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of APITesting (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/apm_resource.go
+++ b/internal/provider/apm_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -10537,7 +10538,36 @@ func (r *APMResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAPM(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAPM(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "APM delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of APM (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/app_api_group_resource.go
+++ b/internal/provider/app_api_group_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1225,7 +1226,36 @@ func (r *AppAPIGroupResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAppAPIGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAppAPIGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AppAPIGroup delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AppAPIGroup (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/app_firewall_resource.go
+++ b/internal/provider/app_firewall_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2600,7 +2601,36 @@ func (r *AppFirewallResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAppFirewall(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAppFirewall(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AppFirewall delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AppFirewall (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/app_setting_resource.go
+++ b/internal/provider/app_setting_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2057,7 +2058,36 @@ func (r *AppSettingResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAppSetting(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAppSetting(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AppSetting delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AppSetting (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/app_type_resource.go
+++ b/internal/provider/app_type_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -770,7 +771,36 @@ func (r *AppTypeResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAppType(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAppType(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AppType delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AppType (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/application_profiles_resource.go
+++ b/internal/provider/application_profiles_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -10127,7 +10128,36 @@ func (r *ApplicationProfilesResource) Delete(ctx context.Context, req resource.D
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteApplicationProfiles(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteApplicationProfiles(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ApplicationProfiles delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ApplicationProfiles (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/authentication_resource.go
+++ b/internal/provider/authentication_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1868,7 +1869,36 @@ func (r *AuthenticationResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAuthentication(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAuthentication(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Authentication delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Authentication (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/authorization_server_resource.go
+++ b/internal/provider/authorization_server_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -456,7 +457,36 @@ func (r *AuthorizationServerResource) Delete(ctx context.Context, req resource.D
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAuthorizationServer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAuthorizationServer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AuthorizationServer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AuthorizationServer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/aws_tgw_site_resource.go
+++ b/internal/provider/aws_tgw_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -10699,7 +10700,36 @@ func (r *AWSTGWSiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAWSTGWSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAWSTGWSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AWSTGWSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AWSTGWSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/aws_vpc_site_resource.go
+++ b/internal/provider/aws_vpc_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -14456,7 +14457,36 @@ func (r *AWSVPCSiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAWSVPCSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAWSVPCSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AWSVPCSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AWSVPCSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/azure_vnet_site_resource.go
+++ b/internal/provider/azure_vnet_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -27890,7 +27891,36 @@ func (r *AzureVNETSiteResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteAzureVNETSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteAzureVNETSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "AzureVNETSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of AzureVNETSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/bgp_asn_set_resource.go
+++ b/internal/provider/bgp_asn_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -495,7 +496,36 @@ func (r *BGPAsnSetResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteBGPAsnSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteBGPAsnSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "BGPAsnSet delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of BGPAsnSet (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/bgp_resource.go
+++ b/internal/provider/bgp_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3628,7 +3629,36 @@ func (r *BGPResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteBGP(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteBGP(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "BGP delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of BGP (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/bgp_routing_policy_resource.go
+++ b/internal/provider/bgp_routing_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1297,7 +1298,36 @@ func (r *BGPRoutingPolicyResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteBGPRoutingPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteBGPRoutingPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "BGPRoutingPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of BGPRoutingPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/bigip_http_proxy_resource.go
+++ b/internal/provider/bigip_http_proxy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -10989,7 +10990,36 @@ func (r *BigIPHTTPProxyResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteBigIPHTTPProxy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteBigIPHTTPProxy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "BigIPHTTPProxy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of BigIPHTTPProxy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/bot_defense_app_infrastructure_resource.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1348,7 +1349,36 @@ func (r *BotDefenseAppInfrastructureResource) Delete(ctx context.Context, req re
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteBotDefenseAppInfrastructure(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteBotDefenseAppInfrastructure(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "BotDefenseAppInfrastructure delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of BotDefenseAppInfrastructure (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/bot_infrastructure_resource.go
+++ b/internal/provider/bot_infrastructure_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -753,7 +754,36 @@ func (r *BotInfrastructureResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteBotInfrastructure(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteBotInfrastructure(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "BotInfrastructure delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of BotInfrastructure (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cdn_cache_rule_resource.go
+++ b/internal/provider/cdn_cache_rule_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -2684,7 +2685,36 @@ func (r *CDNCacheRuleResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCDNCacheRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCDNCacheRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CDNCacheRule delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CDNCacheRule (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cdn_loadbalancer_resource.go
+++ b/internal/provider/cdn_loadbalancer_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -49112,7 +49113,36 @@ func (r *CDNLoadBalancerResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCDNLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCDNLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CDNLoadBalancer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CDNLoadBalancer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cdn_purge_command_resource.go
+++ b/internal/provider/cdn_purge_command_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -769,7 +770,36 @@ func (r *CDNPurgeCommandResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCDNPurgeCommand(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCDNPurgeCommand(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CDNPurgeCommand delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CDNPurgeCommand (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/certificate_chain_resource.go
+++ b/internal/provider/certificate_chain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -456,7 +457,36 @@ func (r *CertificateChainResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCertificateChain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCertificateChain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CertificateChain delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CertificateChain (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/certificate_resource.go
+++ b/internal/provider/certificate_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1035,7 +1036,36 @@ func (r *CertificateResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCertificate(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCertificate(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Certificate delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Certificate (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cloud_connect_resource.go
+++ b/internal/provider/cloud_connect_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -3369,7 +3370,36 @@ func (r *CloudConnectResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCloudConnect(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCloudConnect(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CloudConnect delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CloudConnect (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cloud_credentials_resource.go
+++ b/internal/provider/cloud_credentials_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -2319,7 +2320,36 @@ func (r *CloudCredentialsResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCloudCredentials(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCloudCredentials(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CloudCredentials delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CloudCredentials (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cloud_elastic_ip_resource.go
+++ b/internal/provider/cloud_elastic_ip_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -745,7 +746,36 @@ func (r *CloudElasticIPResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCloudElasticIP(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCloudElasticIP(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CloudElasticIP delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CloudElasticIP (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cloud_link_resource.go
+++ b/internal/provider/cloud_link_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -2189,7 +2190,36 @@ func (r *CloudLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCloudLink(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCloudLink(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CloudLink delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CloudLink (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -4785,7 +4786,36 @@ func (r *ClusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCluster(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCluster(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Cluster delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Cluster (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/cminstance_resource.go
+++ b/internal/provider/cminstance_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -1152,7 +1153,36 @@ func (r *CminstanceResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCminstance(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCminstance(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Cminstance delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Cminstance (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/code_base_integration_resource.go
+++ b/internal/provider/code_base_integration_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3157,7 +3158,36 @@ func (r *CodeBaseIntegrationResource) Delete(ctx context.Context, req resource.D
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCodeBaseIntegration(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCodeBaseIntegration(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CodeBaseIntegration delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CodeBaseIntegration (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/container_registry_resource.go
+++ b/internal/provider/container_registry_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -816,7 +817,36 @@ func (r *ContainerRegistryResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteContainerRegistry(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteContainerRegistry(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ContainerRegistry delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ContainerRegistry (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/crl_resource.go
+++ b/internal/provider/crl_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -610,7 +611,36 @@ func (r *CRLResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteCRL(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteCRL(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "CRL delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of CRL (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/data_group_resource.go
+++ b/internal/provider/data_group_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -650,7 +651,36 @@ func (r *DataGroupResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDataGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDataGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DataGroup delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DataGroup (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/data_type_resource.go
+++ b/internal/provider/data_type_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1574,7 +1575,36 @@ func (r *DataTypeResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDataType(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDataType(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DataType delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DataType (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dc_cluster_group_resource.go
+++ b/internal/provider/dc_cluster_group_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -542,7 +543,36 @@ func (r *DcClusterGroupResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDcClusterGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDcClusterGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DcClusterGroup delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DcClusterGroup (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/discovery_resource.go
+++ b/internal/provider/discovery_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -4233,7 +4234,36 @@ func (r *DiscoveryResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDiscovery(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDiscovery(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Discovery delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Discovery (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_compliance_checks_resource.go
+++ b/internal/provider/dns_compliance_checks_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -631,7 +632,36 @@ func (r *DNSComplianceChecksResource) Delete(ctx context.Context, req resource.D
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSComplianceChecks(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSComplianceChecks(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSComplianceChecks delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSComplianceChecks (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_domain_resource.go
+++ b/internal/provider/dns_domain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -483,7 +484,36 @@ func (r *DNSDomainResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSDomain delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSDomain (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_lb_health_check_resource.go
+++ b/internal/provider/dns_lb_health_check_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1491,7 +1492,36 @@ func (r *DNSLBHealthCheckResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSLBHealthCheck(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSLBHealthCheck(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSLBHealthCheck delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSLBHealthCheck (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_lb_pool_resource.go
+++ b/internal/provider/dns_lb_pool_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -2438,7 +2439,36 @@ func (r *DNSLBPoolResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSLBPool(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSLBPool(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSLBPool delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSLBPool (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_load_balancer_resource.go
+++ b/internal/provider/dns_load_balancer_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2327,7 +2328,36 @@ func (r *DNSLoadBalancerResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSLoadBalancer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSLoadBalancer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_proxy_resource.go
+++ b/internal/provider/dns_proxy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -5221,7 +5222,36 @@ func (r *DNSProxyResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSProxy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSProxy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSProxy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSProxy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/dns_zone_resource.go
+++ b/internal/provider/dns_zone_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -11716,7 +11717,36 @@ func (r *DNSZoneResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteDNSZone(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteDNSZone(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "DNSZone delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of DNSZone (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/endpoint_resource.go
+++ b/internal/provider/endpoint_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2276,7 +2277,36 @@ func (r *EndpointResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteEndpoint(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteEndpoint(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Endpoint delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Endpoint (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/enhanced_firewall_policy_resource.go
+++ b/internal/provider/enhanced_firewall_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3349,7 +3350,36 @@ func (r *EnhancedFirewallPolicyResource) Delete(ctx context.Context, req resourc
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteEnhancedFirewallPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteEnhancedFirewallPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "EnhancedFirewallPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of EnhancedFirewallPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/external_connector_resource.go
+++ b/internal/provider/external_connector_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2912,7 +2913,36 @@ func (r *ExternalConnectorResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteExternalConnector(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteExternalConnector(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ExternalConnector delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ExternalConnector (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/fast_acl_resource.go
+++ b/internal/provider/fast_acl_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -4119,7 +4120,36 @@ func (r *FastACLResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteFastACL(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteFastACL(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "FastACL delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of FastACL (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/fast_acl_rule_resource.go
+++ b/internal/provider/fast_acl_rule_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1749,7 +1750,36 @@ func (r *FastACLRuleResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteFastACLRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteFastACLRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "FastACLRule delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of FastACLRule (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/filter_set_resource.go
+++ b/internal/provider/filter_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -958,7 +959,36 @@ func (r *FilterSetResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteFilterSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteFilterSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "FilterSet delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of FilterSet (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/fleet_resource.go
+++ b/internal/provider/fleet_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -14904,7 +14905,36 @@ func (r *FleetResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteFleet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteFleet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Fleet delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Fleet (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/forward_proxy_policy_resource.go
+++ b/internal/provider/forward_proxy_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -4641,7 +4642,36 @@ func (r *ForwardProxyPolicyResource) Delete(ctx context.Context, req resource.De
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteForwardProxyPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteForwardProxyPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ForwardProxyPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ForwardProxyPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/forwarding_class_resource.go
+++ b/internal/provider/forwarding_class_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -826,7 +827,36 @@ func (r *ForwardingClassResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteForwardingClass(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteForwardingClass(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ForwardingClass delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ForwardingClass (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/gcp_vpc_site_resource.go
+++ b/internal/provider/gcp_vpc_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -13401,7 +13402,36 @@ func (r *GCPVPCSiteResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteGCPVPCSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteGCPVPCSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "GCPVPCSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of GCPVPCSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/geo_location_set_resource.go
+++ b/internal/provider/geo_location_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -548,7 +549,36 @@ func (r *GeoLocationSetResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteGeoLocationSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteGeoLocationSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "GeoLocationSet delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of GeoLocationSet (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/global_log_receiver_resource.go
+++ b/internal/provider/global_log_receiver_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -11867,7 +11868,36 @@ func (r *GlobalLogReceiverResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteGlobalLogReceiver(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteGlobalLogReceiver(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "GlobalLogReceiver delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of GlobalLogReceiver (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/healthcheck_resource.go
+++ b/internal/provider/healthcheck_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -1122,7 +1123,36 @@ func (r *HealthcheckResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteHealthcheck(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteHealthcheck(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Healthcheck delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Healthcheck (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/ike1_resource.go
+++ b/internal/provider/ike1_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -761,7 +762,36 @@ func (r *Ike1Resource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteIke1(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteIke1(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Ike1 delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Ike1 (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/ike2_resource.go
+++ b/internal/provider/ike2_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -709,7 +710,36 @@ func (r *Ike2Resource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteIke2(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteIke2(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Ike2 delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Ike2 (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/ike_phase1_profile_resource.go
+++ b/internal/provider/ike_phase1_profile_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -1021,7 +1022,36 @@ func (r *IKEPhase1ProfileResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteIKEPhase1Profile(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteIKEPhase1Profile(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "IKEPhase1Profile delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of IKEPhase1Profile (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/ike_phase2_profile_resource.go
+++ b/internal/provider/ike_phase2_profile_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -839,7 +840,36 @@ func (r *IKEPhase2ProfileResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteIKEPhase2Profile(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteIKEPhase2Profile(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "IKEPhase2Profile delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of IKEPhase2Profile (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/ip_prefix_set_resource.go
+++ b/internal/provider/ip_prefix_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -606,7 +607,36 @@ func (r *IPPrefixSetResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteIPPrefixSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteIPPrefixSet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "IPPrefixSet delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of IPPrefixSet (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/irule_resource.go
+++ b/internal/provider/irule_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -485,7 +486,36 @@ func (r *IruleResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteIrule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteIrule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Irule delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Irule (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/k8s_cluster_resource.go
+++ b/internal/provider/k8s_cluster_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -2896,7 +2897,36 @@ func (r *K8SClusterResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteK8SCluster(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteK8SCluster(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "K8SCluster delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of K8SCluster (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/k8s_cluster_role_binding_resource.go
+++ b/internal/provider/k8s_cluster_role_binding_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -870,7 +871,36 @@ func (r *K8SClusterRoleBindingResource) Delete(ctx context.Context, req resource
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteK8SClusterRoleBinding(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteK8SClusterRoleBinding(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "K8SClusterRoleBinding delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of K8SClusterRoleBinding (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/k8s_cluster_role_resource.go
+++ b/internal/provider/k8s_cluster_role_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1157,7 +1158,36 @@ func (r *K8SClusterRoleResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteK8SClusterRole(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteK8SClusterRole(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "K8SClusterRole delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of K8SClusterRole (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/k8s_pod_security_admission_resource.go
+++ b/internal/provider/k8s_pod_security_admission_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -771,7 +772,36 @@ func (r *K8SPodSecurityAdmissionResource) Delete(ctx context.Context, req resour
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteK8SPodSecurityAdmission(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteK8SPodSecurityAdmission(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "K8SPodSecurityAdmission delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of K8SPodSecurityAdmission (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/k8s_pod_security_policy_resource.go
+++ b/internal/provider/k8s_pod_security_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -2904,7 +2905,36 @@ func (r *K8SPodSecurityPolicyResource) Delete(ctx context.Context, req resource.
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteK8SPodSecurityPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteK8SPodSecurityPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "K8SPodSecurityPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of K8SPodSecurityPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/log_receiver_resource.go
+++ b/internal/provider/log_receiver_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1393,7 +1394,36 @@ func (r *LogReceiverResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteLogReceiver(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteLogReceiver(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "LogReceiver delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of LogReceiver (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/malicious_user_mitigation_resource.go
+++ b/internal/provider/malicious_user_mitigation_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -812,7 +813,36 @@ func (r *MaliciousUserMitigationResource) Delete(ctx context.Context, req resour
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteMaliciousUserMitigation(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteMaliciousUserMitigation(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "MaliciousUserMitigation delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of MaliciousUserMitigation (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/mitigated_domain_resource.go
+++ b/internal/provider/mitigated_domain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -456,7 +457,36 @@ func (r *MitigatedDomainResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteMitigatedDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteMitigatedDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "MitigatedDomain delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of MitigatedDomain (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -427,8 +428,37 @@ func (r *NamespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	// Namespace requires cascade_delete endpoint (standard DELETE returns 501)
-	err := r.client.CascadeDeleteNamespace(ctx, data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		// Namespace requires cascade_delete endpoint (standard DELETE returns 501)
+		err = r.client.CascadeDeleteNamespace(ctx, data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Namespace delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Namespace (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/nat_policy_resource.go
+++ b/internal/provider/nat_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -4974,7 +4975,36 @@ func (r *NATPolicyResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNATPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNATPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NATPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NATPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/network_connector_resource.go
+++ b/internal/provider/network_connector_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -2288,7 +2289,36 @@ func (r *NetworkConnectorResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNetworkConnector(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNetworkConnector(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NetworkConnector delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NetworkConnector (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/network_firewall_resource.go
+++ b/internal/provider/network_firewall_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1437,7 +1438,36 @@ func (r *NetworkFirewallResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNetworkFirewall(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNetworkFirewall(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NetworkFirewall delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NetworkFirewall (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/network_interface_resource.go
+++ b/internal/provider/network_interface_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -4672,7 +4673,36 @@ func (r *NetworkInterfaceResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNetworkInterface(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNetworkInterface(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NetworkInterface delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NetworkInterface (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/network_policy_resource.go
+++ b/internal/provider/network_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3563,7 +3564,36 @@ func (r *NetworkPolicyResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNetworkPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNetworkPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NetworkPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NetworkPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/network_policy_rule_resource.go
+++ b/internal/provider/network_policy_rule_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1241,7 +1242,36 @@ func (r *NetworkPolicyRuleResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNetworkPolicyRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNetworkPolicyRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NetworkPolicyRule delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NetworkPolicyRule (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/network_policy_view_resource.go
+++ b/internal/provider/network_policy_view_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3670,7 +3671,36 @@ func (r *NetworkPolicyViewResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNetworkPolicyView(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNetworkPolicyView(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NetworkPolicyView delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NetworkPolicyView (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/nfv_service_resource.go
+++ b/internal/provider/nfv_service_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -11099,7 +11100,36 @@ func (r *NfvServiceResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNfvService(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNfvService(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NfvService delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NfvService (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/nginx_service_discovery_resource.go
+++ b/internal/provider/nginx_service_discovery_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1272,7 +1273,36 @@ func (r *NginxServiceDiscoveryResource) Delete(ctx context.Context, req resource
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteNginxServiceDiscovery(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteNginxServiceDiscovery(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "NginxServiceDiscovery delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of NginxServiceDiscovery (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/origin_pool_resource.go
+++ b/internal/provider/origin_pool_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -8529,7 +8530,36 @@ func (r *OriginPoolResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteOriginPool(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteOriginPool(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "OriginPool delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of OriginPool (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/policer_resource.go
+++ b/internal/provider/policer_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -559,7 +560,36 @@ func (r *PolicerResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeletePolicer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeletePolicer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Policer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Policer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/policy_based_routing_resource.go
+++ b/internal/provider/policy_based_routing_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3574,7 +3575,36 @@ func (r *PolicyBasedRoutingResource) Delete(ctx context.Context, req resource.De
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeletePolicyBasedRouting(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeletePolicyBasedRouting(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "PolicyBasedRouting delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of PolicyBasedRouting (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/protected_application_resource.go
+++ b/internal/provider/protected_application_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -10527,7 +10528,36 @@ func (r *ProtectedApplicationResource) Delete(ctx context.Context, req resource.
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteProtectedApplication(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteProtectedApplication(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ProtectedApplication delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ProtectedApplication (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/protected_domain_resource.go
+++ b/internal/provider/protected_domain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -457,7 +458,36 @@ func (r *ProtectedDomainResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteProtectedDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteProtectedDomain(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ProtectedDomain delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ProtectedDomain (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {
@@ -482,21 +512,22 @@ func (r *ProtectedDomainResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (r *ProtectedDomainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import ID format: namespace/name
+	// Import ID format: namespace/name/protected_domain
+	// Trailing fields are create-only and not readable from the API (e.g. GET-by-name
+	// returns 501), so they ride in the import ID to keep round-trip import drift-free.
 	parts := strings.Split(req.ID, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Invalid Import ID",
-			fmt.Sprintf("Expected import ID format: namespace/name, got: %s", req.ID),
+			fmt.Sprintf("Expected import ID format: namespace/name/protected_domain, got: %s", req.ID),
 		)
 		return
 	}
-	namespace := parts[0]
-	name := parts[1]
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), namespace)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("protected_domain"), parts[2])...)
 
 	// Set private state marker to indicate this is an import operation
 	// This allows Read to populate all nested blocks from API response

--- a/internal/provider/protocol_inspection_resource.go
+++ b/internal/provider/protocol_inspection_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -816,7 +817,36 @@ func (r *ProtocolInspectionResource) Delete(ctx context.Context, req resource.De
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteProtocolInspection(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteProtocolInspection(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ProtocolInspection delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ProtocolInspection (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/protocol_policer_resource.go
+++ b/internal/provider/protocol_policer_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1116,7 +1117,36 @@ func (r *ProtocolPolicerResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteProtocolPolicer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteProtocolPolicer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ProtocolPolicer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ProtocolPolicer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/proxy_resource.go
+++ b/internal/provider/proxy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -14249,7 +14250,36 @@ func (r *ProxyResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteProxy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteProxy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Proxy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Proxy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/rate_limiter_policy_resource.go
+++ b/internal/provider/rate_limiter_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -3458,7 +3459,36 @@ func (r *RateLimiterPolicyResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteRateLimiterPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteRateLimiterPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "RateLimiterPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of RateLimiterPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/rate_limiter_resource.go
+++ b/internal/provider/rate_limiter_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1336,7 +1337,36 @@ func (r *RateLimiterResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteRateLimiter(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteRateLimiter(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "RateLimiter delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of RateLimiter (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -8520,7 +8521,36 @@ func (r *RouteResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteRoute(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteRoute(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Route delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Route (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/secret_management_access_resource.go
+++ b/internal/provider/secret_management_access_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -5373,7 +5374,36 @@ func (r *SecretManagementAccessResource) Delete(ctx context.Context, req resourc
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSecretManagementAccess(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSecretManagementAccess(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "SecretManagementAccess delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of SecretManagementAccess (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/securemesh_site_resource.go
+++ b/internal/provider/securemesh_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -11378,7 +11379,36 @@ func (r *SecuremeshSiteResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSecuremeshSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSecuremeshSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "SecuremeshSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of SecuremeshSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/securemesh_site_v2_resource.go
+++ b/internal/provider/securemesh_site_v2_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -39515,7 +39516,36 @@ func (r *SecuremeshSiteV2Resource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSecuremeshSiteV2(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSecuremeshSiteV2(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "SecuremeshSiteV2 delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of SecuremeshSiteV2 (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -463,7 +464,36 @@ func (r *SegmentResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSegment(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSegment(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Segment delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Segment (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/sensitive_data_policy_resource.go
+++ b/internal/provider/sensitive_data_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -841,7 +842,36 @@ func (r *SensitiveDataPolicyResource) Delete(ctx context.Context, req resource.D
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSensitiveDataPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSensitiveDataPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "SensitiveDataPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of SensitiveDataPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/service_policy_resource.go
+++ b/internal/provider/service_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -10942,7 +10943,36 @@ func (r *ServicePolicyResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteServicePolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteServicePolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ServicePolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ServicePolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/service_policy_rule_resource.go
+++ b/internal/provider/service_policy_rule_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -8540,7 +8541,36 @@ func (r *ServicePolicyRuleResource) Delete(ctx context.Context, req resource.Del
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteServicePolicyRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteServicePolicyRule(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "ServicePolicyRule delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of ServicePolicyRule (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/site_mesh_group_resource.go
+++ b/internal/provider/site_mesh_group_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1420,7 +1421,36 @@ func (r *SiteMeshGroupResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSiteMeshGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSiteMeshGroup(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "SiteMeshGroup delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of SiteMeshGroup (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -559,7 +560,36 @@ func (r *SiteResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Site delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Site (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/srv6_network_slice_resource.go
+++ b/internal/provider/srv6_network_slice_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -573,7 +574,36 @@ func (r *Srv6NetworkSliceResource) Delete(ctx context.Context, req resource.Dele
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSrv6NetworkSlice(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSrv6NetworkSlice(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Srv6NetworkSlice delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Srv6NetworkSlice (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1151,7 +1152,36 @@ func (r *SubnetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteSubnet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteSubnet(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Subnet delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Subnet (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/tcp_loadbalancer_resource.go
+++ b/internal/provider/tcp_loadbalancer_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -7403,7 +7404,36 @@ func (r *TCPLoadBalancerResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteTCPLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteTCPLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "TCPLoadBalancer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of TCPLoadBalancer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/tenant_configuration_resource.go
+++ b/internal/provider/tenant_configuration_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1497,7 +1498,36 @@ func (r *TenantConfigurationResource) Delete(ctx context.Context, req resource.D
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteTenantConfiguration(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteTenantConfiguration(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "TenantConfiguration delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of TenantConfiguration (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/trusted_ca_list_resource.go
+++ b/internal/provider/trusted_ca_list_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -456,7 +457,36 @@ func (r *TrustedCAListResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteTrustedCAList(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteTrustedCAList(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "TrustedCAList delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of TrustedCAList (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/tunnel_resource.go
+++ b/internal/provider/tunnel_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1929,7 +1930,36 @@ func (r *TunnelResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteTunnel(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteTunnel(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "Tunnel delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of Tunnel (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/udp_loadbalancer_resource.go
+++ b/internal/provider/udp_loadbalancer_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -3604,7 +3605,36 @@ func (r *UDPLoadBalancerResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteUDPLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteUDPLoadBalancer(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "UDPLoadBalancer delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of UDPLoadBalancer (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/usb_policy_resource.go
+++ b/internal/provider/usb_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -722,7 +723,36 @@ func (r *UsbPolicyResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteUsbPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteUsbPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "UsbPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of UsbPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/user_identification_resource.go
+++ b/internal/provider/user_identification_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -1090,7 +1091,36 @@ func (r *UserIdentificationResource) Delete(ctx context.Context, req resource.De
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteUserIdentification(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteUserIdentification(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "UserIdentification delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of UserIdentification (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/virtual_host_resource.go
+++ b/internal/provider/virtual_host_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -12156,7 +12157,36 @@ func (r *VirtualHostResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteVirtualHost(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteVirtualHost(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "VirtualHost delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of VirtualHost (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/virtual_k8s_resource.go
+++ b/internal/provider/virtual_k8s_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -898,7 +899,36 @@ func (r *VirtualK8SResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteVirtualK8S(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteVirtualK8S(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "VirtualK8S delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of VirtualK8S (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/virtual_network_resource.go
+++ b/internal/provider/virtual_network_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -1256,7 +1257,36 @@ func (r *VirtualNetworkResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteVirtualNetwork(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteVirtualNetwork(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "VirtualNetwork delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of VirtualNetwork (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/virtual_site_resource.go
+++ b/internal/provider/virtual_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -559,7 +560,36 @@ func (r *VirtualSiteResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteVirtualSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteVirtualSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "VirtualSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of VirtualSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/voltstack_site_resource.go
+++ b/internal/provider/voltstack_site_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"regexp"
 
@@ -32060,7 +32061,36 @@ func (r *VoltstackSiteResource) Delete(ctx context.Context, req resource.DeleteR
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteVoltstackSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteVoltstackSite(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "VoltstackSite delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of VoltstackSite (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/waf_exclusion_policy_resource.go
+++ b/internal/provider/waf_exclusion_policy_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1652,7 +1653,36 @@ func (r *WAFExclusionPolicyResource) Delete(ctx context.Context, req resource.De
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteWAFExclusionPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteWAFExclusionPolicy(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "WAFExclusionPolicy delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of WAFExclusionPolicy (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {

--- a/internal/provider/workload_flavor_resource.go
+++ b/internal/provider/workload_flavor_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -504,7 +505,36 @@ func (r *WorkloadFlavorResource) Delete(ctx context.Context, req resource.Delete
 
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
-	err := r.client.DeleteWorkloadFlavor(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+
+	// Delete with bounded retry on transient referential BAD_REQUEST: during teardown a
+	// resource can briefly still be referenced by another object (a healthcheck by an origin
+	// pool, an origin pool by a load balancer, etc.), which the API rejects with 400 until
+	// the referrer is gone. NOT_FOUND/404 (already deleted) and 501 (delete unsupported) are
+	// terminal and handled after the loop.
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = r.client.DeleteWorkloadFlavor(ctx, data.Namespace.ValueString(), data.Name.ValueString())
+		if err == nil {
+			break
+		}
+		msg := err.Error()
+		transient := (strings.Contains(msg, "400") || strings.Contains(msg, "BAD_REQUEST")) &&
+			!strings.Contains(msg, "NOT_FOUND") && !strings.Contains(msg, "404") && !strings.Contains(msg, "501")
+		if !transient || attempt >= 5 {
+			break
+		}
+		tflog.Warn(ctx, "WorkloadFlavor delete hit transient BAD_REQUEST (likely still referenced); retrying", map[string]interface{}{
+			"name":      data.Name.ValueString(),
+			"namespace": data.Namespace.ValueString(),
+			"attempt":   attempt + 1,
+		})
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Timed out retrying delete of WorkloadFlavor (still referenced): %s", err))
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		// If the resource is already gone, consider deletion successful (idempotent delete)
 		if strings.Contains(err.Error(), "NOT_FOUND") || strings.Contains(err.Error(), "404") {


### PR DESCRIPTION
## Summary
Automated regeneration of provider code and/or documentation.

## Triggered By
Commit: 9911f3388917f405a16eae4c29fd7acf6e34fda4

## Changes
- Provider code regenerated: true
- Documentation regenerated: true

Closes #1075