### PR TITLE
feat(codegen): auto-derive apply-time preflights from x-f5xc-requires

### DIFF
--- a/tools/pkg/openapi/derive_preflight.go
+++ b/tools/pkg/openapi/derive_preflight.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"sort"
+	"strings"
+)
+
+// RequiresEntry is one x-f5xc-requires descriptor stamped on a spec property by
+// api-specs-enriched. It carries both the opaque requires_field string (for
+// documentation/other consumers) and, for cross-resource requirements, the
+// structured RequiresResource the provider uses to auto-derive an apply-time
+// preflight. See api-specs-enriched#967.
+type RequiresEntry struct {
+	Field            string            `json:"field"`
+	RequiresField    string            `json:"requires_field"`
+	RequiresResource *RequiresResource `json:"requires_resource"`
+	Required         bool              `json:"required"`
+	MinItems         int               `json:"min_items"`
+	Reason           string            `json:"reason"`
+}
+
+// RequiresResource is the structured form of a cross-resource requirement:
+// the triggering field needs a resource of the given kind to exist in the given
+// scope (currently only "same_namespace" is actionable as a namespace LIST).
+type RequiresResource struct {
+	Resource string `json:"resource"`
+	Scope    string `json:"scope"`
+}
+
+// scopeSameNamespace is the only requires_resource scope that maps to a
+// namespace-scoped LIST preflight.
+const scopeSameNamespace = "same_namespace"
+
+// DeriveRequirementPreflights builds apply-time preflights from a resource's
+// CreateSpecType schema's x-f5xc-requires cross-resource requirements. For each
+// property whose requirement names a same-namespace resource, resolveListPath
+// maps that target resource to its LIST path (with a single %s for the
+// namespace); an unresolvable target is skipped so the generator never emits a
+// broken list_path. The source of truth is the enriched spec, making
+// preflight-requirements.json an override rather than the sole declaration.
+func DeriveRequirementPreflights(createSpec Schema, resolveListPath func(resource string) (string, bool)) []RequirementPreflight {
+	var out []RequirementPreflight
+	// Deterministic order: iterate property names sorted.
+	propNames := make([]string, 0, len(createSpec.Properties))
+	for name := range createSpec.Properties {
+		propNames = append(propNames, name)
+	}
+	sort.Strings(propNames)
+
+	for _, propName := range propNames {
+		for _, entry := range createSpec.Properties[propName].XF5XCRequires {
+			rr := entry.RequiresResource
+			if rr == nil || rr.Scope != scopeSameNamespace || rr.Resource == "" {
+				continue // sibling-field or non-namespace requirement: not a preflight
+			}
+			listPath, ok := resolveListPath(rr.Resource)
+			if !ok || strings.Count(listPath, "%s") != 1 {
+				continue // cannot resolve a well-formed LIST path: skip, never emit broken
+			}
+			field := entry.Field
+			if field == "" {
+				field = propName
+			}
+			out = append(out, RequirementPreflight{
+				WhenField:   field,
+				ListPath:    listPath,
+				Requires:    requirementText(field, rr.Resource, entry.Reason),
+				ErrorTitle:  displayResource(rr.Resource) + " prerequisite missing",
+				ErrorDetail: requirementDetail(field, rr.Resource, entry.Reason),
+			})
+		}
+	}
+	return out
+}
+
+// MergePreflights overlays override entries (e.g. preflight-requirements.json)
+// onto derived entries: for a given WhenField the override wins, so hand-tuned
+// declarations keep byte-identical output while derived-only and override-only
+// entries both survive. The result is sorted by WhenField for determinism.
+func MergePreflights(derived, override []RequirementPreflight) []RequirementPreflight {
+	byField := make(map[string]RequirementPreflight, len(derived)+len(override))
+	for _, p := range derived {
+		byField[p.WhenField] = p
+	}
+	for _, p := range override {
+		byField[p.WhenField] = p
+	}
+	fields := make([]string, 0, len(byField))
+	for f := range byField {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+	out := make([]RequirementPreflight, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, byField[f])
+	}
+	return out
+}
+
+// requirementText renders the human-readable requirement (a code comment).
+func requirementText(field, resource, reason string) string {
+	if r := sanitizeReason(reason); r != "" {
+		return r
+	}
+	return field + " requires a " + resource + " in the same namespace"
+}
+
+// requirementDetail renders the apply-time diagnostic detail. It contains exactly
+// one %s (the namespace), which the generated Create/Update fills at runtime; the
+// reason is sanitized so it can never introduce a second format verb.
+func requirementDetail(field, resource, reason string) string {
+	detail := field + " is enabled but no " + resource +
+		" exists in namespace %s. Create one in the same namespace before applying."
+	if r := sanitizeReason(reason); r != "" {
+		detail += " " + r
+	}
+	return detail
+}
+
+// displayResource turns a snake_case resource name into a Title Case label.
+func displayResource(resource string) string {
+	words := strings.Split(resource, "_")
+	for i, w := range words {
+		if w != "" {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// sanitizeReason strips '%' so an interpolated reason cannot inject a stray
+// format verb into ErrorDetail (which is later passed to fmt.Sprintf).
+func sanitizeReason(reason string) string {
+	return strings.TrimSpace(strings.ReplaceAll(reason, "%", ""))
+}

--- a/tools/pkg/openapi/derive_preflight_test.go
+++ b/tools/pkg/openapi/derive_preflight_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func csdResolver(resource string) (string, bool) {
+	if resource == "protected_domain" {
+		return "/api/shape/csd/namespaces/%s/protected_domains", true
+	}
+	return "", false
+}
+
+func schemaWithRequires(prop string, entries []RequiresEntry) Schema {
+	return Schema{
+		Properties: map[string]Schema{
+			prop: {XF5XCRequires: entries},
+		},
+	}
+}
+
+func TestDeriveRequirementPreflights_SameNamespaceResource(t *testing.T) {
+	createSpec := schemaWithRequires("client_side_defense", []RequiresEntry{
+		{
+			Field:            "client_side_defense",
+			RequiresResource: &RequiresResource{Resource: "protected_domain", Scope: "same_namespace"},
+			Reason:           "CSD needs a protected_domain in the same namespace.",
+		},
+	})
+
+	got := DeriveRequirementPreflights(createSpec, csdResolver)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 derived preflight, got %d", len(got))
+	}
+	p := got[0]
+	if p.WhenField != "client_side_defense" {
+		t.Errorf("WhenField = %q, want client_side_defense", p.WhenField)
+	}
+	if p.ListPath != "/api/shape/csd/namespaces/%s/protected_domains" {
+		t.Errorf("ListPath = %q", p.ListPath)
+	}
+	// Well-formed invariants (mirror TestLoadPreflights_AllEntriesWellFormed).
+	if strings.Count(p.ListPath, "%s") != 1 {
+		t.Errorf("ListPath must contain exactly one %%s: %q", p.ListPath)
+	}
+	if strings.Count(p.ErrorDetail, "%s") != 1 {
+		t.Errorf("ErrorDetail must contain exactly one %%s: %q", p.ErrorDetail)
+	}
+	if p.ErrorTitle == "" || p.Requires == "" {
+		t.Errorf("ErrorTitle/Requires must be non-empty: %+v", p)
+	}
+}
+
+func TestDeriveRequirementPreflights_SiblingFieldIgnored(t *testing.T) {
+	createSpec := schemaWithRequires("foo", []RequiresEntry{
+		{Field: "foo", RequiresField: "spec.enable_waf"},
+	})
+	if got := DeriveRequirementPreflights(createSpec, csdResolver); len(got) != 0 {
+		t.Errorf("sibling-field requires must not derive a preflight, got %d", len(got))
+	}
+}
+
+func TestDeriveRequirementPreflights_UnresolvableResourceSkipped(t *testing.T) {
+	createSpec := schemaWithRequires("thing", []RequiresEntry{
+		{Field: "thing", RequiresResource: &RequiresResource{Resource: "nonexistent", Scope: "same_namespace"}},
+	})
+	// resolver returns ok=false for unknown resources -> never emit a broken list_path.
+	if got := DeriveRequirementPreflights(createSpec, csdResolver); len(got) != 0 {
+		t.Errorf("unresolvable target must be skipped, got %d", len(got))
+	}
+}
+
+func TestMergePreflights_JSONOverridesByWhenField(t *testing.T) {
+	derived := []RequirementPreflight{
+		{WhenField: "client_side_defense", ListPath: "derived/%s/x", ErrorDetail: "d %s"},
+		{WhenField: "only_derived", ListPath: "d/%s", ErrorDetail: "e %s"},
+	}
+	override := []RequirementPreflight{
+		{WhenField: "client_side_defense", ListPath: "json/%s/protected_domains", ErrorDetail: "j %s"},
+		{WhenField: "only_json", ListPath: "j/%s", ErrorDetail: "k %s"},
+	}
+	merged := MergePreflights(derived, override)
+	byField := map[string]RequirementPreflight{}
+	for _, p := range merged {
+		byField[p.WhenField] = p
+	}
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 merged (cds override + only_derived + only_json), got %d: %+v", len(merged), merged)
+	}
+	if byField["client_side_defense"].ListPath != "json/%s/protected_domains" {
+		t.Errorf("JSON must override derived for client_side_defense, got %q", byField["client_side_defense"].ListPath)
+	}
+	if _, ok := byField["only_derived"]; !ok {
+		t.Errorf("derived-only entry must survive")
+	}
+	if _, ok := byField["only_json"]; !ok {
+		t.Errorf("json-only entry must survive")
+	}
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -50,6 +50,7 @@ type Schema struct {
 	// Enrichment extensions (x-f5xc-*) - added by api-specs-enriched repository
 	XF5XCCategory         string                `json:"x-f5xc-category"`
 	XF5XCRequiresTier     string                `json:"x-f5xc-requires-tier"`
+	XF5XCRequires         []RequiresEntry       `json:"x-f5xc-requires"`
 	XF5XCComplexity       string                `json:"x-f5xc-complexity"`
 	XF5XCExample          string                `json:"x-f5xc-example"`
 	XF5XCDescriptionShort string                `json:"x-f5xc-description-short"`

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -286,11 +286,30 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	conflictAttrs, goNameLookup := CollectConflictAttrs(attributes)
 	conflictCode := conflicts.GenerateChecks(conflictAttrs, goNameLookup)
 
-	// Compile declared apply-time prerequisites (x-f5xc-requires) into this resource,
-	// resolving each preflight's trigger field to its Go model field so Create/Update
-	// can nil-check it. Preflights whose trigger is not a top-level attribute are dropped.
+	// Compile declared apply-time prerequisites into this resource. The source of
+	// truth is x-f5xc-requires in the enriched spec: DeriveRequirementPreflights
+	// turns each structured cross-resource requirement into a preflight, resolving
+	// the required resource's LIST path from the spec's own paths. Hand-maintained
+	// preflight-requirements.json entries override the derived ones by trigger
+	// field, so the file is an override/supplement rather than the sole source.
+	// Each preflight's trigger field is then resolved to its Go model field so
+	// Create/Update can nil-check it; those whose trigger is not a top-level
+	// attribute are dropped.
 	titleCase := naming.ToResourceTypeName(resourceName)
-	preflights := ResolvePreflightGoFields(openapi.LoadPreflights(titleCase), attributes)
+	// extractAPIPath already returns the collection path with the namespace
+	// placeholder substituted to %s (e.g. /api/shape/csd/namespaces/%s/protected_domains),
+	// which is exactly the LIST-path form a preflight needs. Require a namespaced
+	// path with a single %s so we never emit a malformed list_path.
+	resolveListPath := func(resource string) (string, bool) {
+		p, _, hasNamespace := extractAPIPath(spec, resource)
+		if p == "" || !hasNamespace || strings.Count(p, "%s") != 1 {
+			return "", false
+		}
+		return p, true
+	}
+	derivedPreflights := openapi.DeriveRequirementPreflights(createSpec, resolveListPath)
+	mergedPreflights := openapi.MergePreflights(derivedPreflights, openapi.LoadPreflights(titleCase))
+	preflights := ResolvePreflightGoFields(mergedPreflights, attributes)
 
 	return &openapi.ResourceTemplate{
 		Name:                    resourceName,

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -285,3 +285,60 @@ func TestExtractResourceSchema_Basic(t *testing.T) {
 		t.Error("Expected 'port' attribute in result")
 	}
 }
+
+// A resource whose CreateSpecType property declares a structured cross-resource
+// requirement (x-f5xc-requires.requires_resource) auto-derives an apply-time
+// preflight: the target resource's LIST path is resolved via extractAPIPath and
+// the trigger field is bound to its Go model field. This is the end-to-end wiring
+// that makes preflight-requirements.json an override rather than the sole source.
+func TestExtractResourceSchema_AutoDerivesPreflightFromRequires(t *testing.T) {
+	namespace.ClearProfiles()
+	defer namespace.ClearProfiles()
+
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"app_lbCreateSpecType": {
+					Type: "object",
+					Properties: map[string]openapi.Schema{
+						"client_side_defense": {
+							Type: "boolean",
+							XF5XCRequires: []openapi.RequiresEntry{{
+								Field:            "client_side_defense",
+								RequiresResource: &openapi.RequiresResource{Resource: "protected_domain", Scope: "same_namespace"},
+								Reason:           "CSD needs a protected_domain in the same namespace.",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	extractAPIPath := func(_ *openapi.Spec, resource string) (string, string, bool) {
+		if resource == "protected_domain" {
+			return "/api/shape/csd/namespaces/%s/protected_domains",
+				"/api/shape/csd/namespaces/%s/protected_domains/%s", true
+		}
+		return "/api/config/namespaces/%s/app_lbs", "/api/config/namespaces/%s/app_lbs/%s", true
+	}
+
+	result, err := ExtractResourceSchema(spec, "app_lb", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var found *openapi.RequirementPreflight
+	for i := range result.Preflights {
+		if result.Preflights[i].WhenField == "client_side_defense" {
+			found = &result.Preflights[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a derived preflight for client_side_defense, got %+v", result.Preflights)
+	}
+	if found.ListPath != "/api/shape/csd/namespaces/%s/protected_domains" {
+		t.Errorf("ListPath = %q, want the resolved protected_domains shape path", found.ListPath)
+	}
+	if found.WhenGoField == "" {
+		t.Error("WhenGoField must be resolved to the Go model field, got empty")
+	}
+}


### PR DESCRIPTION
> **Draft — intentional.** Merging provider `tools/**` triggers the on-merge
> auto-regenerate + release chain, and end-to-end activation needs the enriched
> spec carrying `requires_resource` (f5-sales-demo/api-specs-enriched#968) to be
> released first. Kept as draft for a supervised, coordinated merge/release. PR CI
> validates the change in the meantime.

## Summary

Auto-derives apply-time requirement preflights from the enriched spec's
`x-f5xc-requires`, so `tools/preflight-requirements.json` becomes an override/supplement
rather than the hand-maintained sole source of truth.

Closes #1077. Consumes api-specs-enriched#967/#968.

## What changed

- `openapi.Schema` parses `x-f5xc-requires` into typed `RequiresEntry` (incl. the structured
  `RequiresResource{resource,scope}`).
- `openapi.DeriveRequirementPreflights` converts each same-namespace cross-resource requirement
  into a `RequirementPreflight`, resolving the target resource's LIST path from the spec's own
  paths via `extractAPIPath` (which already substitutes `{namespace}`→`%s` and handles
  non-standard service paths like CSD's `/api/shape/csd/...`). Unresolvable or non-namespaced
  targets are skipped, so a malformed `list_path` is never emitted.
- `openapi.MergePreflights` overlays `preflight-requirements.json` over the derived set by
  trigger field — the JSON **overrides**, so hand-tuned entries (CSD) keep byte-identical
  output and new dependencies need no JSON entry.
- Wired into `schema.ExtractResourceSchema` before `ResolvePreflightGoFields`.

## Regression safety

With the currently-released spec (no `requires_resource` yet), `DeriveRequirementPreflights`
returns nothing and the JSON entries drive generation **exactly as before** — CSD output is
byte-identical. Auto-derive activates only once the enriched spec (api-specs-enriched#968) ships
the structured field.

## Verification

- New units: parse + derive (same-namespace resource, sibling-field ignored, unresolvable
  skipped) + merge (JSON overrides by trigger field; derived-only and JSON-only both survive).
- New end-to-end `ExtractResourceSchema` test: a property's `requires_resource` yields a derived
  preflight with the resolved shape LIST path and a bound Go model field.
- `go test ./tools/...` green (13 packages, 0 fail); `gofmt`/`go vet` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
