### PR TITLE
fix(codegen): object-reference tenant — inconsistent/invalid result on newly-added blocks (#1079)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -698,3 +698,44 @@ func TestResourceTemplate_ImportIDExtraFields(t *testing.T) {
 		}
 	}
 }
+
+// #1079 part 2: the read-back for an object-reference nested block must reconstruct
+// from the API response (so Computed-only tenant/uid/kind become known), NOT preserve
+// the planned value (which carries an unknown tenant -> "invalid result object after
+// apply"). Non-reference single blocks keep the drift-preserving behavior.
+func TestRenderUnmarshalSingleChild_ObjectRefReadsFromAPI(t *testing.T) {
+	ref := openapi.TerraformAttribute{
+		GoName: "MaliciousUserMitigation", JsonName: "malicious_user_mitigation", TfsdkTag: "malicious_user_mitigation",
+		NestedAttributes: []openapi.TerraformAttribute{
+			{GoName: "Name", TfsdkTag: "name", JsonName: "name", Type: "string"},
+			{GoName: "Namespace", TfsdkTag: "namespace", JsonName: "namespace", Type: "string"},
+			{GoName: "Tenant", TfsdkTag: "tenant", JsonName: "tenant", Type: "string"},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "R", "EnableChallengeMaliciousUserMitigation", ref,
+		"blockData", "data.EnableChallenge", "data.EnableChallenge != nil", "single", "\t")
+	out := sb.String()
+	if strings.Contains(out, "return data.EnableChallenge.MaliciousUserMitigation") {
+		t.Errorf("object-reference block must NOT preserve the planned value (carries unknown tenant):\n%s", out)
+	}
+	if !strings.Contains(out, `MaliciousUserMitigationData["tenant"]`) {
+		t.Errorf("object-reference block read-back must read tenant from the API response:\n%s", out)
+	}
+}
+
+// A non-reference single block (no tenant child) keeps the drift-preserving early return.
+func TestRenderUnmarshalSingleChild_NonRefPreserves(t *testing.T) {
+	nonRef := openapi.TerraformAttribute{
+		GoName: "Policy", JsonName: "policy", TfsdkTag: "policy",
+		NestedAttributes: []openapi.TerraformAttribute{
+			{GoName: "CookieExpiry", TfsdkTag: "cookie_expiry", JsonName: "cookie_expiry", Type: "int64"},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "R", "Policy", nonRef,
+		"blockData", "data", "data != nil", "single", "\t")
+	if !strings.Contains(sb.String(), "return data.Policy") {
+		t.Errorf("non-reference single block must keep the drift-preserving early return:\n%s", sb.String())
+	}
+}

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -693,6 +693,25 @@ func renderUnmarshalScalarChild(sb *strings.Builder, rc string, attr openapi.Ter
 	}
 }
 
+// isObjectReferenceBlock reports whether a nested block is an F5 XC object reference
+// (kind/name/namespace/tenant/uid pattern). Such blocks have a server-derived "tenant"
+// child. Their server fields (tenant/uid/kind) are Computed-only, so the read-back must
+// reconstruct them from the API response rather than preserving the planned value — a
+// preserved unknown tenant yields "invalid result object after apply" and a preserved
+// null yields "inconsistent result after apply" on newly-added blocks. See #1079.
+func isObjectReferenceBlock(attr openapi.TerraformAttribute) bool {
+	for _, child := range attr.NestedAttributes {
+		tag := child.TfsdkTag
+		if tag == "" {
+			tag = child.JsonName
+		}
+		if tag == "tenant" {
+			return true
+		}
+	}
+	return false
+}
+
 // renderUnmarshalSingleChild emits the closure entry for a single nested block child.
 func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr openapi.TerraformAttribute, srcMap, stateBase, stateGuard, container, indent string) {
 	fieldName := attr.GoName
@@ -739,7 +758,10 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 
 	model := rc + childPath + "Model"
 	dataVar := fieldName + "Data"
-	preserveWhole := container == "single" && stateBase != ""
+	// Object-reference blocks must reconstruct from the API response (their
+	// tenant/uid/kind are Computed-only and server-derived); preserving the planned
+	// value would carry an unknown/null tenant. See isObjectReferenceBlock / #1079.
+	preserveWhole := container == "single" && stateBase != "" && !isObjectReferenceBlock(attr)
 
 	sb.WriteString(fmt.Sprintf("%s%s: func() *%s {\n", indent, fieldName, model))
 	if preserveWhole {

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -227,12 +227,12 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	}
 
 	attr := openapi.TerraformAttribute{
-		Name:        name,
-		GoName:      goName,
-		TfsdkTag:    tfsdkName,
-		Required:    required,
-		Optional:    !required,
-		OneOfGroup:  oneOfGroup,
+		Name:          name,
+		GoName:        goName,
+		TfsdkTag:      tfsdkName,
+		Required:      required,
+		Optional:      !required,
+		OneOfGroup:    oneOfGroup,
 		MaxDepth:      depth,
 		IsSpecField:   true, // Attributes from OpenAPI spec are spec fields
 		JsonName:      name, // Original OpenAPI property name for JSON marshaling
@@ -516,10 +516,20 @@ func ExtractNestedAttributes(schema openapi.Schema, spec *openapi.Spec, depth in
 		// Object Reference types have pattern: kind, name, namespace, tenant, uid
 		// Using UseStateForUnknown plan modifier prevents perpetual drift.
 		propNameLower := strings.ToLower(propName)
-		if (propNameLower == "namespace" || propNameLower == "tenant" || propNameLower == "uid" || propNameLower == "kind") && !attr.Required {
-			attr.Computed = true
-			attr.Optional = true
-			attr.PlanModifier = "UseStateForUnknown"
+		if !attr.Required {
+			switch propNameLower {
+			case "tenant", "uid", "kind":
+				// Server-derived, never user-set. Computed-only so a newly-added
+				// reference block plans them unknown (server fills), avoiding
+				// "inconsistent result after apply" (was null, now <value>). #1079.
+				attr.Computed = true
+				attr.Optional = false
+				attr.PlanModifier = ""
+			case "namespace":
+				attr.Computed = true
+				attr.Optional = true
+				attr.PlanModifier = "UseStateForUnknown"
+			}
 		}
 
 		attrs = append(attrs, attr)

--- a/tools/pkg/schema/convert_test.go
+++ b/tools/pkg/schema/convert_test.go
@@ -279,8 +279,8 @@ func TestConvertToTerraformAttribute_RequiredForCreate(t *testing.T) {
 
 func TestConvertToTerraformAttribute_RequiredForCreate_NestedIgnored(t *testing.T) {
 	schema := openapi.Schema{
-		Type:        "string",
-		Description: "A nested field",
+		Type:             "string",
+		Description:      "A nested field",
 		XF5XCRequiredFor: openapi.RequiredFor{Create: true},
 	}
 	spec := &openapi.Spec{Components: openapi.Components{Schemas: map[string]openapi.Schema{}}}
@@ -464,5 +464,39 @@ func TestConvertToTerraformAttribute_AllOfRef_PreservesExtensions(t *testing.T) 
 	}
 	if attr.Type != "string" {
 		t.Errorf("allOf-wrapped $ref to string should produce Type=string, got %q", attr.Type)
+	}
+}
+
+// #1079 part 1: object-reference server fields (tenant/uid/kind) must be Computed-only,
+// not Optional+Computed+UseStateForUnknown (which plans null on a newly-added block ->
+// "inconsistent result after apply"). namespace stays user-settable.
+func TestExtractNestedAttributes_ObjectReferenceServerFieldsComputedOnly(t *testing.T) {
+	ref := openapi.Schema{
+		Type: "object",
+		Properties: map[string]openapi.Schema{
+			"name": {Type: "string"}, "namespace": {Type: "string"},
+			"tenant": {Type: "string"}, "uid": {Type: "string"},
+		},
+	}
+	attrs := ExtractNestedAttributes(ref, &openapi.Spec{}, 1, "some_ref")
+	get := func(n string) *openapi.TerraformAttribute {
+		for i := range attrs {
+			if attrs[i].Name == n {
+				return &attrs[i]
+			}
+		}
+		return nil
+	}
+	for _, name := range []string{"tenant", "uid"} {
+		a := get(name)
+		if a == nil {
+			t.Fatalf("%s attribute missing", name)
+		}
+		if a.Optional || !a.Computed || a.PlanModifier != "" {
+			t.Errorf("%s must be Computed-only (Optional=false, no plan modifier), got Optional=%v Computed=%v PM=%q", name, a.Optional, a.Computed, a.PlanModifier)
+		}
+	}
+	if ns := get("namespace"); ns == nil || !ns.Optional || !ns.Computed || ns.PlanModifier != "UseStateForUnknown" {
+		t.Errorf("namespace must stay Optional+Computed+UseStateForUnknown, got %+v", ns)
 	}
 }


### PR DESCRIPTION
> **Draft — intentional.** Merging provider `tools/**` triggers the on-merge auto-regenerate + release chain; kept draft for a supervised, coordinated release (same posture as #1078). The fix is complete and live-verified.

## Summary

Fixes "Provider produced inconsistent result after apply" / "invalid result object after apply" on **newly-added object-reference blocks** (kind/name/namespace/tenant/uid). Closes #1079.

## Root cause (two coupled defects)

Object references have server-derived fields the caller never sets. When a reference block is **newly added in an update** (e.g. an LB switching `user_id_client_ip` → `user_identification`, or adding `enable_challenge.malicious_user_mitigation`):

1. **Schema** — `tenant`/`uid`/`kind` were `Optional+Computed+UseStateForUnknown`. A newly-added block has no prior state, so `UseStateForUnknown` cannot hold a value and the field **plans as null**; the server then fills it → *inconsistent result*.
2. **Read-back** — `renderUnmarshalSingleChild` **preserved the planned block value** for single nested blocks, carrying an unknown/null `tenant` into state → *invalid result* (still unknown after apply).

Both must be fixed together: part 1 alone just flips the error from "inconsistent" to "invalid".

## Fix

- `tools/pkg/schema/convert.go` — `tenant`/`uid`/`kind` are now **Computed-only** (plan unknown → server fills). `namespace` stays `Optional+Computed+UseStateForUnknown` (user-settable).
- `tools/pkg/codegen/render.go` — new `isObjectReferenceBlock` (has a `tenant` child); object-reference single blocks **reconstruct from the API response** instead of preserving the planned value. Non-reference blocks keep the drift-preserving behavior.

## Verification

- Unit (TDD): `TestExtractNestedAttributes_ObjectReferenceServerFieldsComputedOnly`, `TestRenderUnmarshalSingleChild_ObjectRefReadsFromAPI` + `_NonRefPreserves`. `go test ./tools/...` green; gofmt/vet clean.
- **Live** (webapp LB, pre-prod): `client_ip → cookie_name` (fresh user_identification create + newly-added block) applies clean, idempotent, round-trip-import clean; `challenge none → enable_challenge` (newly-added malicious_user_mitigation) applies clean. Canonical restored, idempotent.

Generator-source-only (no `internal/provider/*.go`); generated code lands via the auto-regenerate PR on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
