### PR TITLE
fix(codegen): model nested list blocks as types.List so they hold plan-time unknowns (#1083)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -423,29 +423,23 @@ func TestRenderUnmarshalScalarChild_ImportSuppressesDefaultBool(t *testing.T) {
 	}
 }
 
-func TestBlockHasComputedDescendant(t *testing.T) {
+// Every nested list block is modeled as types.List, regardless of whether it has a
+// Computed descendant: a native Go slice cannot represent the unknown values a config may
+// carry at plan time (a Computed descendant, or an element sourced from an unresolved
+// reference such as the inline API crawler domains[].simple_login.password). See #1083.
+func TestNestedListUsesTypesList(t *testing.T) {
 	tests := []struct {
 		name string
 		attr openapi.TerraformAttribute
 		want bool
 	}{
 		{
-			name: "direct computed child",
-			attr: openapi.TerraformAttribute{
-				IsBlock: true, NestedBlockType: "list",
-				NestedAttributes: []openapi.TerraformAttribute{
-					{GoName: "Uid", TfsdkTag: "uid", Type: "string", Computed: true},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "computed deep at depth >= 3",
+			name: "list block with computed descendant",
 			attr: deepComputedTree(),
 			want: true,
 		},
 		{
-			name: "no computed descendant",
+			name: "list block with no computed descendant",
 			attr: openapi.TerraformAttribute{
 				IsBlock: true, NestedBlockType: "list",
 				NestedAttributes: []openapi.TerraformAttribute{
@@ -458,19 +452,24 @@ func TestBlockHasComputedDescendant(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
-			name: "no nested attributes",
+			name: "empty list block",
 			attr: openapi.TerraformAttribute{IsBlock: true, NestedBlockType: "list"},
+			want: true,
+		},
+		{
+			name: "single nested block is not a list",
+			attr: openapi.TerraformAttribute{IsBlock: true, NestedBlockType: "single"},
 			want: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := blockHasComputedDescendant(tt.attr); got != tt.want {
-				t.Errorf("blockHasComputedDescendant() = %v, want %v", got, tt.want)
+			if got := nestedListUsesTypesList(tt.attr); got != tt.want {
+				t.Errorf("nestedListUsesTypesList() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -492,8 +491,10 @@ func TestRenderNestedModelTypes_ComputedDescendantList(t *testing.T) {
 	}
 }
 
-// A list block with NO computed descendant keeps the native slice representation.
-func TestRenderNestedModelTypes_NoComputedKeepsSlice(t *testing.T) {
+// A nested list block with NO computed descendant is still modeled as types.List: a
+// native slice cannot hold an unknown value a config may supply at plan time (e.g. an
+// element field sourced from an unresolved reference). See #1083.
+func TestRenderNestedModelTypes_NestedListAlwaysTypesList(t *testing.T) {
 	attrs := []openapi.TerraformAttribute{
 		{
 			GoName: "Outer", TfsdkTag: "outer", IsBlock: true, NestedBlockType: "single",
@@ -508,8 +509,11 @@ func TestRenderNestedModelTypes_NoComputedKeepsSlice(t *testing.T) {
 		},
 	}
 	got := RenderNestedModelTypes("Test", attrs)
-	if !strings.Contains(got, "Items []TestOuterItemsModel `tfsdk:\"items\"`") {
-		t.Errorf("expected items to remain a native slice, got:\n%s", got)
+	if !strings.Contains(got, "Items types.List `tfsdk:\"items\"`") {
+		t.Errorf("expected items to be types.List, got:\n%s", got)
+	}
+	if strings.Contains(got, "Items []TestOuterItemsModel") {
+		t.Errorf("expected no native slice for nested list items, got:\n%s", got)
 	}
 }
 

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -62,22 +62,16 @@ type NestedModelInfo struct {
 	IsEmpty     bool
 }
 
-// blockHasComputedDescendant reports whether any descendant attribute (at any depth)
-// of the given block is Computed. Nested list blocks with a Computed descendant must be
-// modeled as types.List rather than a native Go slice, because a slice cannot represent
-// the unknown values that Computed fields carry during planning. The same predicate drives
-// both the model-type decision (RenderNestedModelTypes) and the marshal/unmarshal emitters,
-// so the two never diverge.
-func blockHasComputedDescendant(attr openapi.TerraformAttribute) bool {
-	for _, nested := range attr.NestedAttributes {
-		if nested.Computed {
-			return true
-		}
-		if nested.IsBlock && blockHasComputedDescendant(nested) {
-			return true
-		}
-	}
-	return false
+// nestedListUsesTypesList reports whether a nested block is a list block, which is always
+// modeled as types.List rather than a native Go slice. A native slice cannot represent the
+// unknown values a config may carry during planning — whether from a Computed descendant or
+// from an element field sourced by an unresolved reference (e.g. the inline API crawler
+// domains[].simple_login.password). This matches the top-level list representation
+// (RenderBlockFields), and the same predicate drives the model-type decision
+// (RenderNestedModelTypes) and the marshal/unmarshal emitters, so they never diverge.
+// See #1083.
+func nestedListUsesTypesList(attr openapi.TerraformAttribute) bool {
+	return attr.NestedBlockType == "list"
 }
 
 // EscapeGoString escapes a string for use in a Go string literal
@@ -259,7 +253,7 @@ func renderMarshalBlock(sb *strings.Builder, resourceTitleCase, prefixPath strin
 			for _, child := range attr.NestedAttributes {
 				childSrc := loopVar + "." + child.GoName
 				if child.IsBlock {
-					renderMarshalBlock(sb, resourceTitleCase, childPath, child, childSrc, mapVar, bodyIndent+"\t", blockHasComputedDescendant(child))
+					renderMarshalBlock(sb, resourceTitleCase, childPath, child, childSrc, mapVar, bodyIndent+"\t", nestedListUsesTypesList(child))
 				} else {
 					renderMarshalScalar(sb, child, childSrc, mapVar, bodyIndent+"\t")
 				}
@@ -304,7 +298,7 @@ func renderMarshalBlock(sb *strings.Builder, resourceTitleCase, prefixPath strin
 	for _, child := range attr.NestedAttributes {
 		childSrc := src + "." + child.GoName
 		if child.IsBlock {
-			renderMarshalBlock(sb, resourceTitleCase, childPath, child, childSrc, subVar, indent+"\t", blockHasComputedDescendant(child))
+			renderMarshalBlock(sb, resourceTitleCase, childPath, child, childSrc, subVar, indent+"\t", nestedListUsesTypesList(child))
 		} else {
 			renderMarshalScalar(sb, child, childSrc, subVar, indent+"\t")
 		}
@@ -780,15 +774,15 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 	sb.WriteString(fmt.Sprintf("%s}(),\n", indent))
 }
 
-// renderUnmarshalListChild emits the closure entry for a list nested block child. It returns
-// types.List when the block has a Computed descendant (matching the Go model), else a native slice.
+// renderUnmarshalListChild emits the closure entry for a list nested block child. It always
+// returns types.List, matching the Go model (a native slice cannot hold unknown values).
 func renderUnmarshalListChild(sb *strings.Builder, rc, childPath string, attr openapi.TerraformAttribute, srcMap, stateBase, stateGuard, container, indent string) {
 	fieldName := attr.GoName
 	jsonName := attr.JsonName
 	if jsonName == "" {
 		jsonName = attr.TfsdkTag
 	}
-	isTypesList := blockHasComputedDescendant(attr)
+	isTypesList := nestedListUsesTypesList(attr)
 	elemModel := nestedElemModel(rc, childPath, attr)
 	objType := nestedObjectTypeExpr(rc, childPath, attr)
 	loopVar := fieldName + "Item"
@@ -1117,16 +1111,12 @@ func RenderNestedModelTypes(resourceTitleCase string, attrs []openapi.TerraformA
 				nestedTypeName = resourceTitleCase + "EmptyModel"
 			}
 
-			// Nested list blocks with a Computed descendant must be modeled as types.List:
-			// a native slice cannot hold the unknown values Computed fields carry during
-			// planning. Lists without a Computed descendant stay native slices; single blocks
-			// stay pointers.
+			// Nested list blocks are always modeled as types.List (matching top-level lists):
+			// a native slice cannot hold the unknown values a config may carry during planning,
+			// whether from a Computed descendant or an element sourced by an unresolved
+			// reference. Single blocks stay pointers. See #1083.
 			if attr.NestedBlockType == "list" {
-				if blockHasComputedDescendant(attr) {
-					sb.WriteString(fmt.Sprintf("\t%s types.List `tfsdk:\"%s\"`\n", attr.GoName, attr.TfsdkTag))
-				} else {
-					sb.WriteString(fmt.Sprintf("\t%s []%s `tfsdk:\"%s\"`\n", attr.GoName, nestedTypeName, attr.TfsdkTag))
-				}
+				sb.WriteString(fmt.Sprintf("\t%s types.List `tfsdk:\"%s\"`\n", attr.GoName, attr.TfsdkTag))
 			} else {
 				sb.WriteString(fmt.Sprintf("\t%s *%s `tfsdk:\"%s\"`\n", attr.GoName, nestedTypeName, attr.TfsdkTag))
 			}


### PR DESCRIPTION
## Problem

Nested `ListNestedBlock`s were modeled as native `[]Model` slices, which cannot carry an unknown value. When a `oneof` child inside such a block is unknown at plan time — e.g. `app_firewall`'s `custom_anonymization.anonymization_config` — the framework raised a **Value Conversion Error** because the slice type cannot represent a `ListValue` holding unknowns.

## Fix

Nested `ListNestedBlock`s now always model as `types.List`, matching how top-level list blocks are already handled. A single predicate drives the model, marshal, and unmarshal paths at any nesting depth, so the behavior is uniform. This also unblocks the API crawler `domains` block that hit the same issue.

Changed files (this PR): `tools/pkg/codegen/render.go`, `tools/pkg/codegen/codegen_test.go`. Per the release model, regenerated `internal/**` and `examples/**` land via the auto-regenerate PR after merge.

## Verification

- `go test ./tools/... ./internal/...` — all pass
- webapp `api_secret.tftest.hcl` renders cleanly
- `waf_top_level.tftest.hcl` still passes (no regression)

Closes #1083.