### PR TITLE
fix(codegen): reconstruct object-ref tenant at any nesting depth after apply

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -775,3 +775,37 @@ func TestRenderUnmarshalSingleChild_NonRefPreserves(t *testing.T) {
 		t.Errorf("non-reference single block must keep the drift-preserving early return:\n%s", sb.String())
 	}
 }
+
+// #1091: a single nested block that CONTAINS an object-reference descendant at any
+// depth (e.g. custom_api_auth_discovery -> api_discovery_ref) must NOT preserve the
+// planned value either — the planned api_discovery_ref.tenant is unknown (Computed-only),
+// so preserving the whole parent carries that unknown and yields "invalid result object
+// after apply". The parent must reconstruct from the API response so the nested ref's
+// tenant becomes known. #1080 only covered blocks that ARE references, not ones nesting one.
+func TestRenderUnmarshalSingleChild_NestedObjectRefReconstructs(t *testing.T) {
+	parent := openapi.TerraformAttribute{
+		GoName: "CustomAPIAuthDiscovery", JsonName: "custom_api_auth_discovery", TfsdkTag: "custom_api_auth_discovery",
+		IsBlock: true, NestedBlockType: "single",
+		NestedAttributes: []openapi.TerraformAttribute{
+			{
+				GoName: "APIDiscoveryRef", JsonName: "api_discovery_ref", TfsdkTag: "api_discovery_ref",
+				IsBlock: true, NestedBlockType: "single",
+				NestedAttributes: []openapi.TerraformAttribute{
+					{GoName: "Name", TfsdkTag: "name", JsonName: "name", Type: "string"},
+					{GoName: "Namespace", TfsdkTag: "namespace", JsonName: "namespace", Type: "string"},
+					{GoName: "Tenant", TfsdkTag: "tenant", JsonName: "tenant", Type: "string"},
+				},
+			},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "R", "EnableAPIDiscoveryCustomAPIAuthDiscovery", parent,
+		"blockData", "data.EnableAPIDiscovery", "data.EnableAPIDiscovery != nil", "single", "\t")
+	out := sb.String()
+	if strings.Contains(out, "return data.EnableAPIDiscovery.CustomAPIAuthDiscovery") {
+		t.Errorf("a block nesting an object reference must NOT preserve the planned value (carries unknown nested tenant):\n%s", out)
+	}
+	if !strings.Contains(out, `APIDiscoveryRefData["tenant"]`) {
+		t.Errorf("the nested object-reference read-back must read tenant from the API response:\n%s", out)
+	}
+}

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -706,6 +706,25 @@ func isObjectReferenceBlock(attr openapi.TerraformAttribute) bool {
 	return false
 }
 
+// hasObjectReferenceDescendant reports whether a nested block is, or transitively
+// contains at any depth, an F5 XC object reference (a block with a server-derived
+// "tenant" child). A block that merely nests a reference deeper down (e.g.
+// custom_api_auth_discovery -> api_discovery_ref) must also reconstruct from the API
+// response: preserving its planned value carries the nested ref's unknown Computed-only
+// tenant and yields "invalid result object after apply". #1080 only handled blocks that
+// ARE references; this generalizes it to any nesting depth. See #1091.
+func hasObjectReferenceDescendant(attr openapi.TerraformAttribute) bool {
+	if isObjectReferenceBlock(attr) {
+		return true
+	}
+	for _, child := range attr.NestedAttributes {
+		if hasObjectReferenceDescendant(child) {
+			return true
+		}
+	}
+	return false
+}
+
 // renderUnmarshalSingleChild emits the closure entry for a single nested block child.
 func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr openapi.TerraformAttribute, srcMap, stateBase, stateGuard, container, indent string) {
 	fieldName := attr.GoName
@@ -752,10 +771,12 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 
 	model := rc + childPath + "Model"
 	dataVar := fieldName + "Data"
-	// Object-reference blocks must reconstruct from the API response (their
-	// tenant/uid/kind are Computed-only and server-derived); preserving the planned
-	// value would carry an unknown/null tenant. See isObjectReferenceBlock / #1079.
-	preserveWhole := container == "single" && stateBase != "" && !isObjectReferenceBlock(attr)
+	// Object-reference blocks — and any block nesting one at any depth — must
+	// reconstruct from the API response (their tenant/uid/kind are Computed-only and
+	// server-derived); preserving the planned value would carry an unknown/null tenant
+	// (yielding "invalid result object after apply"). See hasObjectReferenceDescendant /
+	// #1079 (direct refs) and #1091 (nested refs, e.g. custom_api_auth_discovery).
+	preserveWhole := container == "single" && stateBase != "" && !hasObjectReferenceDescendant(attr)
 
 	sb.WriteString(fmt.Sprintf("%s%s: func() *%s {\n", indent, fieldName, model))
 	if preserveWhole {


### PR DESCRIPTION
## Problem

Applying an HTTP LB with `enable_api_discovery { custom_api_auth_discovery { api_discovery_ref { name, namespace } } }` (an object reference to a standalone `xcsh_api_discovery`) fails at apply:

```
Provider returned invalid result object after apply ... still indicated an unknown
value for ...custom_api_auth_discovery.api_discovery_ref.tenant. All values must be
known after apply.
```

The object-reference `tenant` (Computed field of `viewsObjectRefType`) is left UNKNOWN after apply.

## Root cause

The #1080 fix taught `renderUnmarshalSingleChild` to reconstruct object-reference blocks from the API response (instead of preserving the planned value, whose Computed-only `tenant`/`uid`/`kind` are unknown). But it only checked whether the block **itself** is a reference (`isObjectReferenceBlock` — a direct `tenant` child). A block that merely **nests** a reference deeper down — like `custom_api_auth_discovery`, which holds `api_discovery_ref` — still took the preserve-whole path and carried the nested ref's unknown `tenant` into the result.

## Fix (generic, in `tools/**`)

New `hasObjectReferenceDescendant` walks the nested-attribute tree and reports whether a block is, or transitively contains at any depth, an object reference. `preserveWhole` is now disabled for any such block, so it reconstructs from the API response and the recursive single-child render fills every `viewsObjectRefType` `tenant` (known or null) after apply. Non-reference blocks with no ref descendant keep the drift-preserving early return.

## Verification

- `go test ./tools/... ./internal/...` — all pass; new TDD test `TestRenderUnmarshalSingleChild_NestedObjectRefReconstructs`, plus #1080's `_ObjectRefReadsFromAPI` / `_NonRefPreserves` still green.
- Live webapp LB: `api_discovery_choice=enable`, `api_discovery_auth_mode=custom` applies clean (previously "invalid result object"), immediate plan idempotent; canonical LB restored with clean plan.
- `terraform test`: `api_discovery.tftest.hcl` 7/7, `mud_challenge.tftest.hcl` 3/3 (no #1080 regression).

Closes #1091.