### PR TITLE
fix(codegen): preserve off-spine oneof markers + suppress API-protection server defaults (#1095)

### DIFF
--- a/SP3-PROVIDER-FIX-DIAGNOSIS.md
+++ b/SP3-PROVIDER-FIX-DIAGNOSIS.md
@@ -1,0 +1,63 @@
+# SP3 provider codegen fix — diagnosis & design
+
+Branch: `fix/sp3-nested-marker-and-optional-scalar-suppression`
+Surfaced by: webapp-api-protection SP3 API-Protection live matrix (issue #41).
+
+## Symptom
+Applying `api_protection_rules.api_endpoint_rules[]` (and `validation_custom_list`)
+fails with either:
+- `Provider produced inconsistent result after apply: ...client_matcher.any_client:
+  was absent, but now present` (and `...api_endpoint_method.invert_matcher: was null,
+  but now cty.False`), or
+- round-trip import-drift on the same fields.
+
+## Root cause (precise)
+`renderUnmarshalSingleChild` sets
+`preserveWhole = container=="single" && stateBase!="" && !hasObjectReferenceDescendant(attr)`
+(render.go:779). `hasObjectReferenceDescendant` returns true if the block contains an
+object-ref (a `tenant` child) at ANY depth. `api_protection_rules.api_endpoint_rules[]
+.client_matcher` contains object-ref arms in its *deep, rarely-used* branches
+(`ip_matcher.prefix_sets`, `asn_matcher.asn_sets` — kind/name/namespace/tenant/uid).
+So `hasObjectReferenceDescendant(api_protection_rules)` is true → `preserveWhole=false`
+→ the whole block is RECONSTRUCTED from the API response.
+
+The server normalizes `client_matcher` to include `any_client: {}` as a base marker
+ALONGSIDE `ip_prefix_list` (verified live: the GET returns both), and returns
+`invert_matcher: false`. Reconstruction materializes these server-echoed
+defaults, but the plan omitted them → "was absent/null, now present/false".
+
+The same class hits `validation_custom_list` (deep block, server-materialized optionals)
+on the import path.
+
+## Why the existing mechanisms don't cover it
+- `isImportDefaultSuppressed` guards response-populate with `!isImport` — helps IMPORT
+  only, not the apply-time (Create/Update) inconsistency.
+- `preserveWhole` is all-or-nothing: any object-ref descendant disables preservation
+  for the ENTIRE block, even when the actually-configured arms carry no object-ref.
+
+## Fix design (chosen: preserve + tenant-patch merge)
+On the apply path (`!isImport`), preserve the PLANNED block value even when it has
+object-ref descendants, then recursively patch ONLY the object-ref Computed leaves
+(`tenant`, and `uid`/`kind` where server-derived) from the API response into the
+preserved value. This keeps user-set Optional markers/scalars (any_client absence,
+invert_matcher) intact while still fixing the #1091 tenant-unknown problem.
+
+Implementation sketch:
+- Replace the `preserveWhole` gate so single blocks are preserved whenever configured
+  (`stateBase!=""` and planned non-nil), regardless of object-ref descendants.
+- Add a generated `patchObjectRefTenants(planned, apiResponse)` walk (per resource,
+  over the object-ref descendant paths) invoked in the preserve branch, copying
+  server tenant/uid/kind into the preserved value.
+- For LIST-nested blocks (api_endpoint_rules), thread the prior-state list positionally
+  so element Optional leaves are preserved too (currently stateBase="" for list-child
+  reconstruction — render.go:858).
+- Regen + `go test ./tools/... ./internal/...` + rebuild + re-run the webapp SP3 matrix
+  to full green; release; bump webapp versions.tf.
+
+## Interim module state (webapp)
+The SP3 module explicitly sets `invert_matcher=false` and
+`request_validation_properties` to satisfy F5 XC; `metadata{name}` added to
+api_endpoint_rules + data_guard_rules. Live-clean arms: rate_limit, sensitive_data
+(custom), data_guard, api_protection with the default `any_client` matcher. The
+`ip_prefix`/`ip_threat` client-matcher on protection rules + `validation_custom_list`
+await this provider fix to be round-trip import-clean.

--- a/SP3-PROVIDER-FIX-DIAGNOSIS.md
+++ b/SP3-PROVIDER-FIX-DIAGNOSIS.md
@@ -35,24 +35,45 @@ on the import path.
 - `preserveWhole` is all-or-nothing: any object-ref descendant disables preservation
   for the ENTIRE block, even when the actually-configured arms carry no object-ref.
 
-## Fix design (chosen: preserve + tenant-patch merge)
-On the apply path (`!isImport`), preserve the PLANNED block value even when it has
-object-ref descendants, then recursively patch ONLY the object-ref Computed leaves
-(`tenant`, and `uid`/`kind` where server-derived) from the API response into the
-preserved value. This keeps user-set Optional markers/scalars (any_client absence,
-invert_matcher) intact while still fixing the #1091 tenant-unknown problem.
+## Fix design (implemented: state-threaded reconstruction)
+The originally-sketched "preserve whole + separate patchObjectRefTenants walk" was
+replaced by a cleaner, lower-risk equivalent that reuses the provider's existing,
+already-tested per-leaf preserve logic (scalar preserve at render.go:612, empty-marker
+preserve at render.go:740) instead of generating a new recursive patch walker per
+resource. Same semantics — off-spine Optional markers/scalars reflect the PLAN, object
+references reconstruct their Computed `tenant` from the API — but achieved by threading
+the prior-state accessor down into the reconstruction rather than post-patching a
+preserved copy.
 
-Implementation sketch:
-- Replace the `preserveWhole` gate so single blocks are preserved whenever configured
-  (`stateBase!=""` and planned non-nil), regardless of object-ref descendants.
-- Add a generated `patchObjectRefTenants(planned, apiResponse)` walk (per resource,
-  over the object-ref descendant paths) invoked in the preserve branch, copying
-  server tenant/uid/kind into the preserved value.
-- For LIST-nested blocks (api_endpoint_rules), thread the prior-state list positionally
-  so element Optional leaves are preserved too (currently stateBase="" for list-child
-  reconstruction — render.go:858).
-- Regen + `go test ./tools/... ./internal/...` + rebuild + re-run the webapp SP3 matrix
-  to full green; release; bump webapp versions.tf.
+Two changes in `tools/pkg/codegen/render.go`:
+
+1. **`renderUnmarshalSingleChild` — thread state into a "spine" block's children.**
+   `preserveWhole` is unchanged (still only for blocks with NO object-ref descendant, so
+   direct/nested refs still reconstruct — #1079/#1091 preserved). When a block merely
+   CONTAINS a reference on one arm and so cannot be preserved whole, its children are now
+   reconstructed with the prior-state accessor threaded in (`childStateBase =
+   stateBase.<Field>`), UNLESS the block *is* itself an object reference (all its leaves
+   are server-derived). Off-spine children then hit their existing preserve paths (return
+   the planned marker/scalar); the reference arm, when recursion reaches it, reads its
+   Computed tenant from the API.
+
+2. **`renderUnmarshalListChild` — positional element-state threading.** A list configured
+   inside a single block now loads its prior-state elements (`<Field>.ElementsAs` — nested
+   lists are always `types.List`) and threads `existing[idx]` + `len(existing) > idx` into
+   each element's children, mirroring `renderUnmarshalTopLevelList`. This preserves element
+   Optional leaves (api_endpoint_method.invert_matcher, client_matcher.any_client) that
+   were previously reconstructed from the API (stateBase="" at the old render.go:857).
+
+Why this is correct and low-risk: it makes NESTED reconstruction consistent with the
+TOP-LEVEL list renderer, which already threads positional state. The three existing
+object-ref tests (`ObjectRefReadsFromAPI`, `NonRefPreserves`, `NestedObjectRefReconstructs`)
+still pass unchanged — they exercise ref leaves only, whose behavior is untouched. New
+TDD tests: `TestRenderUnmarshalSingleChild_SpinePreservesOffSpineLeaves`,
+`TestRenderUnmarshalListChild_PreservesElementStatePositionally`.
+
+Verification: `go test ./tools/... ./internal/...` green; all 128 resources regenerate
+and compile; webapp defaults plan 0-change; SP3 live matrix to full green; then release +
+bump webapp versions.tf.
 
 ## Interim module state (webapp)
 The SP3 module explicitly sets `invert_matcher=false` and

--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -15,6 +15,8 @@
   ],
   "HTTPLoadBalancer": [
     "add_location",
+    "any_client",
+    "any_ip",
     "default_api_auth_discovery",
     "default_sensitive_data_policy",
     "disable_api_definition",
@@ -33,6 +35,7 @@
     "no_challenge",
     "round_robin",
     "service_policies_from_namespace",
+    "skip_response_validation",
     "user_id_client_ip"
   ],
   "Healthcheck": [

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -809,3 +809,83 @@ func TestRenderUnmarshalSingleChild_NestedObjectRefReconstructs(t *testing.T) {
 		t.Errorf("the nested object-reference read-back must read tenant from the API response:\n%s", out)
 	}
 }
+
+// #41 (SP3 API Protection): a single block that CONTAINS an object reference on one
+// arm (a "spine" block, e.g. client_matcher whose deep ip_matcher.prefix_sets arm is a
+// reference) must reconstruct only the reference arm from the API while PRESERVING its
+// off-spine Optional markers/scalars from the planned state. Reconstructing the whole
+// block materializes server-echoed defaults the plan omitted (any_client:{},
+// invert_matcher:false) -> "Provider produced inconsistent result after apply: was
+// absent/null, now present/false". The reference arm must still read its Computed tenant
+// from the API.
+func TestRenderUnmarshalSingleChild_SpinePreservesOffSpineLeaves(t *testing.T) {
+	clientMatcher := openapi.TerraformAttribute{
+		GoName: "ClientMatcher", JsonName: "client_matcher", TfsdkTag: "client_matcher",
+		IsBlock: true, NestedBlockType: "single",
+		NestedAttributes: []openapi.TerraformAttribute{
+			// off-spine empty-marker oneof member
+			{GoName: "AnyClient", JsonName: "any_client", TfsdkTag: "any_client", IsBlock: true, NestedBlockType: "single"},
+			// off-spine Optional scalar
+			{GoName: "InvertMatcher", JsonName: "invert_matcher", TfsdkTag: "invert_matcher", Type: "bool", Optional: true},
+			// spine: ip_matcher -> prefix_sets (an object reference with a tenant child)
+			{
+				GoName: "IpMatcher", JsonName: "ip_matcher", TfsdkTag: "ip_matcher",
+				IsBlock: true, NestedBlockType: "single",
+				NestedAttributes: []openapi.TerraformAttribute{
+					{
+						GoName: "PrefixSets", JsonName: "prefix_sets", TfsdkTag: "prefix_sets",
+						IsBlock: true, NestedBlockType: "single",
+						NestedAttributes: []openapi.TerraformAttribute{
+							{GoName: "Name", TfsdkTag: "name", JsonName: "name", Type: "string"},
+							{GoName: "Tenant", TfsdkTag: "tenant", JsonName: "tenant", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "R", "ApiEndpointRulesClientMatcher", clientMatcher,
+		"itemMap", "apiEndpointRulesItem", "len(existing) > i", "single", "\t")
+	out := sb.String()
+	if !strings.Contains(out, "return apiEndpointRulesItem.ClientMatcher.AnyClient") {
+		t.Errorf("off-spine empty-marker must preserve the planned value (not materialize any_client from the API):\n%s", out)
+	}
+	if !strings.Contains(out, "return apiEndpointRulesItem.ClientMatcher.InvertMatcher") {
+		t.Errorf("off-spine Optional scalar must preserve the planned value (not materialize invert_matcher from the API):\n%s", out)
+	}
+	if !strings.Contains(out, `PrefixSetsData["tenant"]`) {
+		t.Errorf("the spine's object-reference arm must still reconstruct its tenant from the API:\n%s", out)
+	}
+}
+
+// #41 (SP3 API Protection): a list block nested inside a configured single block (e.g.
+// api_protection_rules.api_endpoint_rules[]) must thread the prior-state elements
+// positionally into element children, mirroring the top-level list renderer, so element
+// Optional markers/scalars preserve the planned value on Read/Create instead of
+// materializing server-echoed defaults. Import still reads the API.
+func TestRenderUnmarshalListChild_PreservesElementStatePositionally(t *testing.T) {
+	list := openapi.TerraformAttribute{
+		GoName: "ApiEndpointRules", JsonName: "api_endpoint_rules", TfsdkTag: "api_endpoint_rules",
+		IsBlock: true, NestedBlockType: "list",
+		NestedAttributes: []openapi.TerraformAttribute{
+			{
+				GoName: "ApiEndpointMethod", JsonName: "api_endpoint_method", TfsdkTag: "api_endpoint_method",
+				IsBlock: true, NestedBlockType: "single",
+				NestedAttributes: []openapi.TerraformAttribute{
+					{GoName: "InvertMatcher", JsonName: "invert_matcher", TfsdkTag: "invert_matcher", Type: "bool", Optional: true},
+				},
+			},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalListChild(&sb, "R", "ApiProtectionRulesApiEndpointRules", list,
+		"apiProtectionRulesData", "data.ApiProtectionRules", "data.ApiProtectionRules != nil", "single", "\t")
+	out := sb.String()
+	if !strings.Contains(out, "data.ApiProtectionRules.ApiEndpointRules.ElementsAs(ctx, &ApiEndpointRulesExisting") {
+		t.Errorf("nested list must load prior-state elements from the parent state for positional preservation:\n%s", out)
+	}
+	if !strings.Contains(out, "ApiEndpointRulesExisting[ApiEndpointRulesIdx].ApiEndpointMethod.InvertMatcher") {
+		t.Errorf("nested list element leaf must preserve the planned value positionally:\n%s", out)
+	}
+}

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -50,6 +50,20 @@ var importDefaultSuppressionsSeed = map[string][]string{
 		// Matched by leaf name at any depth (see isImportDefaultSuppressed).
 		"default_api_auth_discovery",
 		"disable_learn_from_redirect_traffic",
+		// SP3 API Protection (#41) server-default oneof base markers: the API echoes
+		// any_client {} alongside a concrete client_matcher arm (ip_prefix_list /
+		// ip_threat_category_list), and skip_response_validation {} on every
+		// open_api_validation_rules entry's validation_mode. The module never declares
+		// either (it omits client_matcher for "match any"), so both must be suppressed
+		// on import to keep api_protection_rules / validation_custom_list round-trip
+		// clean. discover-defaults.go can't observe them (its probe LB configures no
+		// api_protection_rules / validation_custom_list). Verified live (f5-sales-demo
+		// webapp-api-protection SP3 matrix variants 004, 006). any_ip is the same class:
+		// the default source-IP sub-oneof member inside a client_matcher
+		// ip_threat_category_list arm, echoed alongside ip_threat_categories (variant 002).
+		"any_client",
+		"any_ip",
+		"skip_response_validation",
 	},
 }
 

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -56,6 +56,27 @@ func TestImportSuppressions_DisableClientSideDefense(t *testing.T) {
 	}
 }
 
+// #41 (SP3 API Protection): any_client is the server-default base member of the
+// client_matcher oneof. Whenever a client_matcher is configured with a concrete arm
+// (ip_prefix_list / ip_threat_category_list), the API normalizes the response to ALSO
+// include any_client {} alongside it. A config that selects a concrete arm (and never
+// declares any_client — the module omits client_matcher entirely for "match any") then
+// drifts on round-trip import. skip_response_validation is the same class: the default
+// member of the response-validation sub-oneof inside validation_mode, materialized by
+// the API on every open_api_validation_rules entry. Both must be suppressed on import.
+// Matched by leaf name at any depth. Verified live (f5-sales-demo webapp-api-protection
+// SP3 matrix: variants 004 ip_prefix and 006 custom_list).
+func TestImportSuppressions_APIProtectionServerDefaults(t *testing.T) {
+	// any_ip is the default member of the source-IP sub-oneof inside a client_matcher
+	// ip_threat_category_list arm: the API echoes any_ip {} alongside the configured
+	// ip_threat_categories, and the module never declares it (same class as any_client).
+	for _, m := range []string{"any_client", "any_ip", "skip_response_validation"} {
+		if !isImportDefaultSuppressed("HTTPLoadBalancer", m) {
+			t.Errorf("HTTPLoadBalancer.%s must be a suppressed server-default (SP3 API Protection oneof base marker)", m)
+		}
+	}
+}
+
 // violations_view is the server-materialized catalog of WAF violation checks:
 // whenever detection_settings is configured, the API populates the full
 // violations_view list (name/title/description_spec/enabled/enabled_by_default)

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -771,12 +771,25 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 
 	model := rc + childPath + "Model"
 	dataVar := fieldName + "Data"
-	// Object-reference blocks — and any block nesting one at any depth — must
-	// reconstruct from the API response (their tenant/uid/kind are Computed-only and
-	// server-derived); preserving the planned value would carry an unknown/null tenant
-	// (yielding "invalid result object after apply"). See hasObjectReferenceDescendant /
-	// #1079 (direct refs) and #1091 (nested refs, e.g. custom_api_auth_discovery).
+	isRef := isObjectReferenceBlock(attr)
+	// Preserve the whole planned block only when it is configured and contains NO object
+	// reference anywhere: an object-ref's tenant/uid/kind are Computed-only and unknown in
+	// state on create, so any block ON THE PATH to a reference must read those leaves from
+	// the API. See #1079 (direct refs) and #1091 (nested refs, e.g. custom_api_auth_discovery).
 	preserveWhole := container == "single" && stateBase != "" && !hasObjectReferenceDescendant(attr)
+
+	// When a block cannot be preserved whole because it merely CONTAINS a reference on one
+	// arm (a "spine" block), reconstruct from the API but thread the prior-state accessor
+	// into its children so off-spine Optional markers/scalars still preserve the planned
+	// value (avoiding server-echoed defaults materializing as "was absent/null, now
+	// present/false"), while the reference arm reconstructs its Computed tenant from the
+	// API. A block that IS itself a reference threads no state — all its leaves are
+	// server-derived. See #41 (SP3 API Protection: client_matcher any_client/invert_matcher).
+	childStateBase, childStateGuard := "", ""
+	if stateBase != "" && !isRef {
+		childStateBase = stateBase + "." + fieldName
+		childStateGuard = fmt.Sprintf("%s && %s != nil", stateGuard, childStateBase)
+	}
 
 	sb.WriteString(fmt.Sprintf("%s%s: func() *%s {\n", indent, fieldName, model))
 	if preserveWhole {
@@ -787,7 +800,7 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 	sb.WriteString(fmt.Sprintf("%s\tif %s, ok := %s[\"%s\"].(map[string]interface{}); ok {\n", indent, dataVar, srcMap, jsonName))
 	sb.WriteString(fmt.Sprintf("%s\t\treturn &%s{\n", indent, model))
 	for _, child := range attr.NestedAttributes {
-		renderUnmarshalChild(sb, rc, childPath, child, dataVar, "", "", "single", indent+"\t\t\t")
+		renderUnmarshalChild(sb, rc, childPath, child, dataVar, childStateBase, childStateGuard, "single", indent+"\t\t\t")
 	}
 	sb.WriteString(fmt.Sprintf("%s\t\t}\n", indent))
 	sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
@@ -843,6 +856,21 @@ func renderUnmarshalListChild(sb *strings.Builder, rc, childPath string, attr op
 			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		}
 	}
+	// Thread prior-state elements positionally into element children so element Optional
+	// markers/scalars preserve the planned value on Read/Create (mirrors the top-level
+	// list renderer, render.go renderUnmarshalTopLevelList) instead of materializing
+	// server-echoed defaults. Only for a list configured inside a single block (nested
+	// lists are always modeled as types.List, so ElementsAs applies). Import reads the API.
+	// See #41 (SP3 API Protection: api_endpoint_rules[] api_endpoint_method/client_matcher).
+	threadElem := container == "single" && stateBase != "" && len(attr.NestedAttributes) > 0
+	existingVar := fieldName + "Existing"
+	idxVar := fieldName + "Idx"
+	if threadElem {
+		sb.WriteString(fmt.Sprintf("%s\tvar %s []%s\n", indent, existingVar, elemModel))
+		sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s && !%s.%s.IsNull() && !%s.%s.IsUnknown() {\n", indent, stateGuard, stateBase, fieldName, stateBase, fieldName))
+		sb.WriteString(fmt.Sprintf("%s\t\t%s.%s.ElementsAs(ctx, &%s, false)\n", indent, stateBase, fieldName, existingVar))
+		sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
+	}
 	sb.WriteString(fmt.Sprintf("%s\tif rawList, ok := %s[\"%s\"].([]interface{}); ok && len(rawList) > 0 {\n", indent, srcMap, jsonName))
 	sb.WriteString(fmt.Sprintf("%s\t\tvar %s []%s\n", indent, resultVar, elemModel))
 	if len(attr.NestedAttributes) == 0 {
@@ -850,11 +878,19 @@ func renderUnmarshalListChild(sb *strings.Builder, rc, childPath string, attr op
 		sb.WriteString(fmt.Sprintf("%s\t\t\t%s = append(%s, %s{})\n", indent, resultVar, resultVar, elemModel))
 		sb.WriteString(fmt.Sprintf("%s\t\t}\n", indent))
 	} else {
-		sb.WriteString(fmt.Sprintf("%s\t\tfor _, %s := range rawList {\n", indent, loopVar))
+		childStateBase, childStateGuard := "", ""
+		if threadElem {
+			sb.WriteString(fmt.Sprintf("%s\t\tfor %s, %s := range rawList {\n", indent, idxVar, loopVar))
+			sb.WriteString(fmt.Sprintf("%s\t\t\t_ = %s\n", indent, idxVar))
+			childStateBase = fmt.Sprintf("%s[%s]", existingVar, idxVar)
+			childStateGuard = fmt.Sprintf("len(%s) > %s", existingVar, idxVar)
+		} else {
+			sb.WriteString(fmt.Sprintf("%s\t\tfor _, %s := range rawList {\n", indent, loopVar))
+		}
 		sb.WriteString(fmt.Sprintf("%s\t\t\tif %s, ok := %s.(map[string]interface{}); ok {\n", indent, mapVar, loopVar))
 		sb.WriteString(fmt.Sprintf("%s\t\t\t\t%s = append(%s, %s{\n", indent, resultVar, resultVar, elemModel))
 		for _, child := range attr.NestedAttributes {
-			renderUnmarshalChild(sb, rc, childPath, child, mapVar, "", "", "list", indent+"\t\t\t\t\t")
+			renderUnmarshalChild(sb, rc, childPath, child, mapVar, childStateBase, childStateGuard, "list", indent+"\t\t\t\t\t")
 		}
 		sb.WriteString(fmt.Sprintf("%s\t\t\t\t})\n", indent))
 		sb.WriteString(fmt.Sprintf("%s\t\t\t}\n", indent))


### PR DESCRIPTION
## Summary

Fixes apply-time inconsistency + round-trip import-drift for `xcsh_http_loadbalancer.api_protection_rules` and `api_specification.validation_custom_list` when a concrete `client_matcher` arm (ip_prefix / ip_threat) or custom OpenAPI validation is configured.

Generator-source only (`tools/**`); generated `internal/`/`examples/` land via the auto-regenerate PR on merge.

## Changes

- **`renderUnmarshalSingleChild`** — a "spine" block (contains an object-reference on one arm but is not itself a reference) now reconstructs from the API while **threading the prior-state accessor** into its children, so off-spine Optional markers/scalars preserve the planned value (no more materialized `any_client {}` / `invert_matcher:false`), while the reference arm still reconstructs its Computed `tenant`. A block that IS a reference threads no state (unchanged).
- **`renderUnmarshalListChild`** — a list configured inside a single block now threads prior-state elements **positionally** (`ElementsAs` + `existing[idx]`), mirroring `renderUnmarshalTopLevelList`.
- **Import-default suppression** — added `any_client`, `any_ip`, `skip_response_validation` (HTTPLoadBalancer server-default oneof base markers; matched by leaf name at any depth).

## Verification

- New TDD: `TestRenderUnmarshalSingleChild_SpinePreservesOffSpineLeaves`, `TestRenderUnmarshalListChild_PreservesElementStatePositionally`, `TestImportSuppressions_APIProtectionServerDefaults`.
- Existing object-ref tests unchanged (no regression): `ObjectRefReadsFromAPI`, `NonRefPreserves`, `NestedObjectRefReconstructs`.
- `go test ./tools/... ./internal/...` green; all 128 resources regenerate + compile; `gofmt`/`go vet` clean.
- **Live F5 XC** (f5-sales-demo, webapp-api-protection SP3 all-pairs matrix): **13/13 idempotent + round-trip-import clean** (pre-fix: 5/13).

## Notes for reviewers

- The three suppressed markers are all optional oneof "match-any"/default members (never `Required` in the schema); `any_ip` is the broadest (56 schema occurrences, all optional empty-marker oneof members). Suppression is import-path-only and semantically safe (omitting a default oneof member = the server re-applies the same default). Consistent with the existing `no_challenge` / `round_robin` / `default_api_auth_discovery` precedent; leaf-name-at-any-depth is the only available match mechanism.
- Markers are seeded in both `import_suppressions.go` and `import-default-suppressions.json`, matching the `enable_api_discovery` precedent (seed is the durable fallback).

Closes #1095. Related #1003, #1006. Surfaced by f5-sales-demo/webapp-api-protection#41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)