### PR TITLE
fix(codegen): state-thread lists nested in list elements + preserve list-element empty markers (#1099)

### DIFF
--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -3,7 +3,8 @@
     "strict_schema_origin"
   ],
   "APITesting": [
-    "every_week"
+    "every_week",
+    "standard"
   ],
   "AppFirewall": [
     "allow_all_response_codes",
@@ -36,6 +37,7 @@
     "round_robin",
     "service_policies_from_namespace",
     "skip_response_validation",
+    "standard",
     "user_id_client_ip"
   ],
   "Healthcheck": [

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -859,6 +859,55 @@ func TestRenderUnmarshalSingleChild_SpinePreservesOffSpineLeaves(t *testing.T) {
 	}
 }
 
+// #45 (SP4 API Testing): a list nested inside a LIST element (e.g. api_testing
+// domains[].credentials[]) must ALSO thread prior-state positionally, not only lists
+// inside single blocks. Without it, credential elements get stateBase="" and their
+// markers/secrets (standard, api_key.value) reconstruct from the API on apply/import.
+func TestRenderUnmarshalListChild_ThreadsInsideListElement(t *testing.T) {
+	list := openapi.TerraformAttribute{
+		GoName: "Credentials", JsonName: "credentials", TfsdkTag: "credentials",
+		IsBlock: true, NestedBlockType: "list",
+		NestedAttributes: []openapi.TerraformAttribute{
+			{GoName: "Standard", JsonName: "standard", TfsdkTag: "standard", IsBlock: true, NestedBlockType: "single"},
+		},
+	}
+	var sb strings.Builder
+	renderUnmarshalListChild(&sb, "R", "DomainsCredentials", list,
+		"domMap", "existingDomains[i]", "len(existingDomains) > i", "list", "\t")
+	out := sb.String()
+	if !strings.Contains(out, "existingDomains[i].Credentials.ElementsAs(ctx, &CredentialsExisting") {
+		t.Errorf("list nested in a list element must load prior-state elements for threading:\n%s", out)
+	}
+	if !strings.Contains(out, "CredentialsExisting[CredentialsIdx].Standard") {
+		t.Errorf("list-in-list-element child marker must preserve the planned value positionally:\n%s", out)
+	}
+}
+
+// #45 (SP4 API Testing): an empty-marker oneof member that is a direct child of a
+// LIST element (e.g. api_testing.domains[].credentials[].standard — the server-default
+// credentials_choice base marker) must preserve the PLANNED value (presence AND
+// absence) on the apply path when prior-state is threaded, exactly like a single-block
+// child. The old list-container branch only preserved presence (returned &Empty{} when
+// state had it) and otherwise fell through to the API populate, so a plan that omits
+// the marker while the server echoes it drifts ("was absent, now present"). Import
+// still reads the API.
+func TestRenderUnmarshalSingleChild_ListEmptyMarkerPreservesAbsence(t *testing.T) {
+	marker := openapi.TerraformAttribute{
+		GoName: "Standard", JsonName: "standard", TfsdkTag: "standard",
+		IsBlock: true, NestedBlockType: "single",
+	}
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "R", "CredentialsStandard", marker,
+		"credMap", "existingCreds[i]", "len(existingCreds) > i", "list", "\t")
+	out := sb.String()
+	if !strings.Contains(out, "return existingCreds[i].Standard") {
+		t.Errorf("list-element empty marker must preserve the planned value (return stateBase.Field), not materialize the server echo:\n%s", out)
+	}
+	if strings.Contains(out, "existingCreds[i].Standard != nil") {
+		t.Errorf("list-element empty marker must not use the presence-only guard (that drops absence):\n%s", out)
+	}
+}
+
 // #41 (SP3 API Protection): a list block nested inside a configured single block (e.g.
 // api_protection_rules.api_endpoint_rules[]) must thread the prior-state elements
 // positionally into element children, mirroring the top-level list renderer, so element

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -64,6 +64,15 @@ var importDefaultSuppressionsSeed = map[string][]string{
 		"any_client",
 		"any_ip",
 		"skip_response_validation",
+		// SP4 API Testing (#45): "standard" is the server-default base member of the
+		// api_testing credentials credentials_choice oneof, echoed on every credential.
+		// It appears on the LB inline api_testing block here and on the standalone
+		// xcsh_api_testing (APITesting, below). Suppress so a concrete-arm credential
+		// (api_key/basic_auth/bearer_token) is round-trip-import clean. Verified live.
+		"standard",
+	},
+	"APITesting": {
+		"standard",
 	},
 }
 

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -66,6 +66,20 @@ func TestImportSuppressions_DisableClientSideDefense(t *testing.T) {
 // the API on every open_api_validation_rules entry. Both must be suppressed on import.
 // Matched by leaf name at any depth. Verified live (f5-sales-demo webapp-api-protection
 // SP3 matrix: variants 004 ip_prefix and 006 custom_list).
+// #45 (SP4 API Testing): "standard" is the server-default base member of the
+// api_testing credentials credentials_choice oneof — the API echoes standard {} on
+// every credential. It appears on both the standalone xcsh_api_testing (APITesting)
+// and the LB inline api_testing block (HTTPLoadBalancer), so both must suppress it on
+// import (matched by leaf name at any depth), or a config that selects a concrete
+// credential arm drifts on round-trip import. Verified live (f5-sales-demo).
+func TestImportSuppressions_APITestingStandardMarker(t *testing.T) {
+	for _, rc := range []string{"APITesting", "HTTPLoadBalancer"} {
+		if !isImportDefaultSuppressed(rc, "standard") {
+			t.Errorf("%s.standard must be a suppressed server-default (credentials_choice base marker)", rc)
+		}
+	}
+}
+
 func TestImportSuppressions_APIProtectionServerDefaults(t *testing.T) {
 	// any_ip is the default member of the source-IP sub-oneof inside a client_matcher
 	// ip_threat_category_list arm: the API echoes any_ip {} alongside the configured

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -737,15 +737,19 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 		// Empty marker block.
 		sb.WriteString(fmt.Sprintf("%s%s: func() *%sEmptyModel {\n", indent, fieldName, rc))
 		if stateBase != "" {
-			if container == "single" {
-				sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s {\n", indent, stateGuard))
-				sb.WriteString(fmt.Sprintf("%s\t\treturn %s.%s\n", indent, stateBase, fieldName))
-				sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
-			} else {
-				sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s && %s.%s != nil {\n", indent, stateGuard, stateBase, fieldName))
-				sb.WriteString(fmt.Sprintf("%s\t\treturn &%sEmptyModel{}\n", indent, rc))
-				sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
-			}
+			// Preserve the PLANNED marker exactly (presence AND absence) on the apply
+			// path; import still reads the API below. stateBase is the state accessor
+			// at this level — for a single block a pointer (data.Foo.Field), for a list
+			// element a positional value (existingItems[idx].Field) — and stateGuard
+			// already includes the list len() bound, so returning stateBase.Field is
+			// nil-safe. Returning it (rather than the old list-only "&Empty{} when
+			// present" heuristic) preserves marker ABSENCE too, so a server-echoed
+			// default oneof member the plan omitted does not drift ("was absent, now
+			// present"). See #41 (single-container any_client) and #45 (list-element
+			// credentials_choice base marker "standard").
+			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s {\n", indent, stateGuard))
+			sb.WriteString(fmt.Sprintf("%s\t\treturn %s.%s\n", indent, stateBase, fieldName))
+			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		}
 		// Server-default oneof members must NOT be populated from the API
 		// response on import: there is no prior config to preserve, so importing
@@ -845,7 +849,9 @@ func renderUnmarshalListChild(sb *strings.Builder, rc, childPath string, attr op
 	// Preserve an unconfigured (null/empty) list block on normal Read/Create so a
 	// server-managed list the user did not configure does not drift the plan
 	// ("Provider produced inconsistent result after apply"). Import still reads the API.
-	if container == "single" && stateBase != "" {
+	// Applies whenever prior state is threaded at this level — including a list nested
+	// inside a LIST element (container=="list"), e.g. api_testing domains[].credentials[].
+	if stateBase != "" {
 		if isTypesList {
 			sb.WriteString(fmt.Sprintf("%s\tif !isImport && %s && (%s.%s.IsNull() || len(%s.%s.Elements()) == 0) {\n", indent, stateGuard, stateBase, fieldName, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t\treturn types.ListNull(%s)\n", indent, objType))
@@ -859,10 +865,12 @@ func renderUnmarshalListChild(sb *strings.Builder, rc, childPath string, attr op
 	// Thread prior-state elements positionally into element children so element Optional
 	// markers/scalars preserve the planned value on Read/Create (mirrors the top-level
 	// list renderer, render.go renderUnmarshalTopLevelList) instead of materializing
-	// server-echoed defaults. Only for a list configured inside a single block (nested
-	// lists are always modeled as types.List, so ElementsAs applies). Import reads the API.
-	// See #41 (SP3 API Protection: api_endpoint_rules[] api_endpoint_method/client_matcher).
-	threadElem := container == "single" && stateBase != "" && len(attr.NestedAttributes) > 0
+	// server-echoed defaults. Applies whenever prior state is threaded at this level,
+	// including a list nested inside a LIST element (container=="list") — e.g. the
+	// api_testing domains[].credentials[] where the server echoes the credentials_choice
+	// base marker "standard". Nested lists are always types.List, so ElementsAs applies.
+	// Import reads the API. See #41 (SP3 client_matcher) and #45 (SP4 credentials).
+	threadElem := stateBase != "" && len(attr.NestedAttributes) > 0
 	existingVar := fieldName + "Existing"
 	idxVar := fieldName + "Idx"
 	if threadElem {


### PR DESCRIPTION
## Summary

Fixes `Provider produced inconsistent result after apply` + round-trip import drift for `xcsh_api_testing` (standalone) and the `xcsh_http_loadbalancer.api_testing` inline block when a credential is configured.

Generator-source only (`tools/**`); generated `internal/`/`examples/` land via the auto-regenerate PR.

## Root cause

`credentials[]` is a list nested inside the `domains[]` list element. The read-back's positional state-threading only engaged for a list inside a **single** block, so a list inside a **list element** got `stateBase=""` and its children reconstructed from the API — materializing the server-default `credentials_choice` marker `standard` and dropping the write-only `api_key.value` secret. Same family as #1095, one level deeper.

## Changes

- **`renderUnmarshalListChild`** — thread positional prior-state whenever `stateBase != ""` (not only `container == "single"`); same relaxation for the null/empty-list preserve gate. Covers a list nested in a list element.
- **`renderUnmarshalSingleChild`** empty-marker branch — `return stateBase.Field` for both single- and list-container when threaded, preserving marker **absence** (was presence-only for list container).
- **Import-default suppression** — `standard` on `APITesting` + `HTTPLoadBalancer`.

## Verification

- New TDD: `TestRenderUnmarshalListChild_ThreadsInsideListElement`, `TestRenderUnmarshalSingleChild_ListEmptyMarkerPreservesAbsence`, `TestImportSuppressions_APITestingStandardMarker`.
- Existing SP3 object-ref/marker tests unchanged (no regression).
- `go test ./tools/... ./internal/...` green; 128 resources regenerate + compile; `gofmt`/`vet` clean.
- **Live** (f5-sales-demo): `xcsh_api_testing` + LB `api_testing` with an api_key clear credential — **apply idempotent** and **round-trip import clean** (write-only secret re-applied). The pre-fix apply failed with the inconsistent-result; post-fix it is clean.

Closes #1099. Builds on #1095 (v3.71.3). Surfaced by f5-sales-demo/webapp-api-protection#45 (SP4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)