### PR TITLE
Suppress RateLimiterPolicy server-default client-matcher markers on import (#1104)

### DIFF
--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -44,6 +44,11 @@
     "headers",
     "use_http2"
   ],
+  "RateLimiterPolicy": [
+    "any_asn",
+    "any_country",
+    "any_ip"
+  ],
   "TCPLoadBalancer": [
     "dns_volterra_managed",
     "hash_policy_choice_round_robin",

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -74,6 +74,17 @@ var importDefaultSuppressionsSeed = map[string][]string{
 	"APITesting": {
 		"standard",
 	},
+	// Coverage Batch B (#51): the server materializes the base member of each
+	// client-matcher oneof on a rate_limiter_policy rule that omits that matcher
+	// (any_country observed live on a rule with asn_list but no country; any_asn /
+	// any_ip are the same class for the ASN / IP oneofs). The module omits a matcher
+	// for "match any", so suppress these on import to keep the standalone
+	// xcsh_rate_limiter_policy round-trip clean.
+	"RateLimiterPolicy": {
+		"any_asn",
+		"any_country",
+		"any_ip",
+	},
 }
 
 var (

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -104,3 +104,18 @@ func TestImportSuppressions_AppFirewallViolationsView(t *testing.T) {
 		t.Error("AppFirewall.violations_view must be a suppressed server-computed field (detection_settings round-trip import drift)")
 	}
 }
+
+// Coverage Batch B (#51): a rate_limiter_policy rule that omits its country client
+// matcher gets any_country {} materialized by the server (verified live on
+// f5-sales-demo webapp-api-protection: a rule with asn_list but no country came
+// back with any_country). any_asn/any_ip are the same server-default base members
+// of the ASN/IP client-matcher oneofs. The module never declares them (it omits a
+// matcher for "match any"), so they must be suppressed on import to keep the
+// standalone xcsh_rate_limiter_policy round-trip clean.
+func TestImportSuppressions_RateLimiterPolicyClientMatcherDefaults(t *testing.T) {
+	for _, m := range []string{"any_asn", "any_country", "any_ip"} {
+		if !isImportDefaultSuppressed("RateLimiterPolicy", m) {
+			t.Errorf("RateLimiterPolicy.%s must be a suppressed server-default (rule client_matcher oneof)", m)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1104.

`RateLimiterPolicy` was missing from the import-default suppression list, so a
`xcsh_rate_limiter_policy` rule that omits a client matcher drifted on import
(server materializes `any_country`/`any_asn`/`any_ip`; cascades
`custom_rate_limiter.tenant` to known-after-apply).

Adds `RateLimiterPolicy: [any_asn, any_country, any_ip]` to the Go seed and the
JSON data file. TDD test added. Verified live on f5-sales-demo via dev_overrides:
policy import round-trip is now 0-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)