### PR TITLE
codegen: fix nested same-name single-block marshal shadowing (drops ref, 400) (#1108)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -3,6 +3,7 @@
 package codegen
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -936,5 +937,49 @@ func TestRenderUnmarshalListChild_PreservesElementStatePositionally(t *testing.T
 	}
 	if !strings.Contains(out, "ApiEndpointRulesExisting[ApiEndpointRulesIdx].ApiEndpointMethod.InvertMatcher") {
 		t.Errorf("nested list element leaf must preserve the planned value positionally:\n%s", out)
+	}
+}
+
+// Coverage Batch F (#61): a single nested block whose child is another single nested
+// block with the SAME GoName (F5 XC "view ref" wrappers like http_loadbalancer {
+// http_loadbalancer { name } }) must not collide the marshal map variable. The old
+// code named both maps "<GoName>Map", so the inner `:= make` shadowed the outer and
+// emitted `XMap["http_loadbalancer"] = XMap` (self-reference) while the OUTER map sent
+// to the API stayed empty {} — dropping the LB association (live 400). The map var
+// must be unique per nesting level (childPath-based), so the outer map receives the
+// inner map, not itself.
+func TestRenderMarshalBlock_NestedSameNameNoShadow(t *testing.T) {
+	ref := openapi.TerraformAttribute{
+		GoName: "HTTPLoadBalancer", TfsdkTag: "http_loadbalancer", JsonName: "http_loadbalancer",
+		IsBlock: true, NestedBlockType: "single",
+		NestedAttributes: []openapi.TerraformAttribute{
+			{GoName: "Name", TfsdkTag: "name", JsonName: "name"},
+			{GoName: "Namespace", TfsdkTag: "namespace", JsonName: "namespace"},
+		},
+	}
+	outer := openapi.TerraformAttribute{
+		GoName: "HTTPLoadBalancer", TfsdkTag: "http_loadbalancer", JsonName: "http_loadbalancer",
+		IsBlock: true, NestedBlockType: "single",
+		NestedAttributes: []openapi.TerraformAttribute{ref},
+	}
+	var sb strings.Builder
+	renderMarshalBlock(&sb, "AppAPIGroup", "", outer, "data.HTTPLoadBalancer", "createReq.Spec", "\t", false)
+	got := sb.String()
+
+	// No map may be assigned to its own key (the shadow self-reference bug).
+	selfRef := regexp.MustCompile(`(\w+)\["[a-z_]+"\] = (\w+)`)
+	for _, m := range selfRef.FindAllStringSubmatch(got, -1) {
+		if m[1] == m[2] {
+			t.Errorf("marshal emits self-referential map assignment %q (shadowed nested block); got:\n%s", m[0], got)
+		}
+	}
+	// The two nested maps must be declared with DISTINCT identifiers.
+	decl := regexp.MustCompile(`(\w+) := make\(map\[string\]interface\{\}\)`)
+	names := map[string]bool{}
+	for _, m := range decl.FindAllStringSubmatch(got, -1) {
+		if names[m[1]] {
+			t.Errorf("duplicate marshal map var %q (shadow); got:\n%s", m[1], got)
+		}
+		names[m[1]] = true
 	}
 }

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -292,7 +292,12 @@ func renderMarshalBlock(sb *strings.Builder, resourceTitleCase, prefixPath strin
 		sb.WriteString(fmt.Sprintf("%s}\n", indent))
 		return
 	}
-	subVar := base + "Map"
+	// Name the map var by the full nested path (childPath), not just the leaf GoName:
+	// a single nested block whose child is another single block with the SAME GoName
+	// (F5 XC view-ref wrappers, e.g. http_loadbalancer { http_loadbalancer { name } })
+	// would otherwise collide the map var, shadowing the outer and emitting a
+	// self-referential assignment while the outer map sent to the API stayed empty.
+	subVar := childPath + "Map"
 	sb.WriteString(fmt.Sprintf("%sif %s != nil {\n", indent, src))
 	sb.WriteString(fmt.Sprintf("%s\t%s := make(map[string]interface{})\n", indent, subVar))
 	for _, child := range attr.NestedAttributes {


### PR DESCRIPTION
Closes #1108. Names the marshal map var by `childPath` so a single block wrapping a same-named single block (view-ref wrappers like `http_loadbalancer{http_loadbalancer{}}`) no longer shadows the outer map / drops the ref. TDD `TestRenderMarshalBlock_NestedSameNameNoShadow`; verified live via dev_overrides (xcsh_app_api_group applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)