### PR TITLE
fix: import-idempotent empty nested blocks — origin_pool labels, http_lb endpoint_subsets (#1103)

### DIFF
--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -35,6 +35,7 @@ import (
 	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/discovery"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/resource"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/suppress"
 )
 
 // ============================================================================
@@ -43,49 +44,49 @@ import (
 
 // DefaultsDatabase stores all discovered defaults for the provider
 type DefaultsDatabase struct {
-	Version      string                      `json:"version"`
-	GeneratedAt  string                      `json:"generated_at"`
-	APIEndpoint  string                      `json:"api_endpoint"`
-	TotalResources int                       `json:"total_resources"`
-	Discovered   int                         `json:"discovered"`
-	Skipped      int                         `json:"skipped"`
-	Failed       int                         `json:"failed"`
-	Resources    map[string]*DiscoveryResult `json:"resources"`
+	Version        string                      `json:"version"`
+	GeneratedAt    string                      `json:"generated_at"`
+	APIEndpoint    string                      `json:"api_endpoint"`
+	TotalResources int                         `json:"total_resources"`
+	Discovered     int                         `json:"discovered"`
+	Skipped        int                         `json:"skipped"`
+	Failed         int                         `json:"failed"`
+	Resources      map[string]*DiscoveryResult `json:"resources"`
 }
 
 // DiscoveryResult holds the discovery result for a single resource type
 type DiscoveryResult struct {
-	ResourceName string                 `json:"resource_name"`
-	Category     string                 `json:"category"`
-	Status       string                 `json:"status"` // "discovered", "skipped", "failed"
-	SkipReason   string                 `json:"skip_reason,omitempty"`
-	Error        string                 `json:"error,omitempty"`
-	DiscoveredAt string                 `json:"discovered_at,omitempty"`
+	ResourceName string                  `json:"resource_name"`
+	Category     string                  `json:"category"`
+	Status       string                  `json:"status"` // "discovered", "skipped", "failed"
+	SkipReason   string                  `json:"skip_reason,omitempty"`
+	Error        string                  `json:"error,omitempty"`
+	DiscoveredAt string                  `json:"discovered_at,omitempty"`
 	Defaults     map[string]FieldDefault `json:"defaults,omitempty"`
-	RequestSent  map[string]interface{} `json:"request_sent,omitempty"`
-	ResponseGot  map[string]interface{} `json:"response_got,omitempty"`
+	RequestSent  map[string]interface{}  `json:"request_sent,omitempty"`
+	ResponseGot  map[string]interface{}  `json:"response_got,omitempty"`
 }
 
 // FieldDefault represents a single field's default value
 type FieldDefault struct {
-	Path         string      `json:"path"`
-	DefaultValue interface{} `json:"default_value"`
-	Type         string      `json:"type"` // "string", "int", "bool", "object", "array"
-	IsMarkerBlock bool       `json:"is_marker_block,omitempty"`
-	Description  string      `json:"description,omitempty"`
+	Path          string      `json:"path"`
+	DefaultValue  interface{} `json:"default_value"`
+	Type          string      `json:"type"` // "string", "int", "bool", "object", "array"
+	IsMarkerBlock bool        `json:"is_marker_block,omitempty"`
+	Description   string      `json:"description,omitempty"`
 }
 
 // ResourceCategory defines complexity categories for discovery
 type ResourceCategory string
 
 const (
-	CategorySimple      ResourceCategory = "simple"
+	CategorySimple       ResourceCategory = "simple"
 	CategoryLoadBalancer ResourceCategory = "load_balancer"
-	CategoryOriginPool  ResourceCategory = "origin_pool"
-	CategorySecurity    ResourceCategory = "security"
-	CategoryDNS         ResourceCategory = "dns"
-	CategoryCloudSite   ResourceCategory = "cloud_site"
-	CategoryTenant      ResourceCategory = "tenant"
+	CategoryOriginPool   ResourceCategory = "origin_pool"
+	CategorySecurity     ResourceCategory = "security"
+	CategoryDNS          ResourceCategory = "dns"
+	CategoryCloudSite    ResourceCategory = "cloud_site"
+	CategoryTenant       ResourceCategory = "tenant"
 )
 
 // ============================================================================
@@ -101,8 +102,8 @@ const (
 
 // MinimalConfig defines the minimal configuration needed to create a resource
 type MinimalConfig struct {
-	Category    ResourceCategory
-	Namespace   bool                   // true if resource requires namespace
+	Category     ResourceCategory
+	Namespace    bool                   // true if resource requires namespace
 	RequiredSpec map[string]interface{} // minimal spec fields required
 	// Prerequisites are dependency objects created (in order) before this resource
 	// and deleted (in reverse) after discovery. Reference a prerequisite's created
@@ -123,8 +124,8 @@ type Prerequisite struct {
 var ResourceConfigs = map[string]MinimalConfig{
 	// Simple resources - just name (and maybe namespace)
 	"namespace": {
-		Category:    CategorySimple,
-		Namespace:   false,
+		Category:     CategorySimple,
+		Namespace:    false,
 		RequiredSpec: map[string]interface{}{},
 	},
 	"healthcheck": {
@@ -132,13 +133,13 @@ var ResourceConfigs = map[string]MinimalConfig{
 		Namespace: true,
 		RequiredSpec: map[string]interface{}{
 			"http_health_check": map[string]interface{}{
-				"path":                    "/healthz",
+				"path":                   "/healthz",
 				"use_origin_server_name": map[string]interface{}{},
 			},
-			"timeout":              1,
-			"interval":             10,
-			"unhealthy_threshold":  2,
-			"healthy_threshold":    3,
+			"timeout":             1,
+			"interval":            10,
+			"unhealthy_threshold": 2,
+			"healthy_threshold":   3,
 		},
 	},
 	"alert_policy": {
@@ -297,7 +298,7 @@ var ResourceConfigs = map[string]MinimalConfig{
 		Category:  CategorySecurity,
 		Namespace: true,
 		RequiredSpec: map[string]interface{}{
-			"algo":    "FIRST_MATCH",
+			"algo":       "FIRST_MATCH",
 			"any_server": map[string]interface{}{},
 			"rule_list": map[string]interface{}{
 				"rules": []interface{}{},
@@ -308,8 +309,8 @@ var ResourceConfigs = map[string]MinimalConfig{
 		Category:  CategorySecurity,
 		Namespace: true,
 		RequiredSpec: map[string]interface{}{
-			"total_number": 100,
-			"unit":         "SECOND",
+			"total_number":     100,
+			"unit":             "SECOND",
 			"burst_multiplier": 1,
 		},
 	},
@@ -326,10 +327,10 @@ var ResourceConfigs = map[string]MinimalConfig{
 					},
 				},
 			},
-			"port":                    80,
-			"endpoint_selection":      "LOCAL_PREFERRED",
-			"loadbalancer_algorithm":  "LB_OVERRIDE",
-			"no_tls":                  map[string]interface{}{},
+			"port":                   80,
+			"endpoint_selection":     "LOCAL_PREFERRED",
+			"loadbalancer_algorithm": "LB_OVERRIDE",
+			"no_tls":                 map[string]interface{}{},
 		},
 	},
 
@@ -432,8 +433,8 @@ var ResourceConfigs = map[string]MinimalConfig{
 						"request_headers": map[string]interface{}{
 							"headers": []interface{}{
 								map[string]interface{}{
-									"name":       "X-Test",
-									"exact":      "value",
+									"name":           "X-Test",
+									"exact":          "value",
 									"invert_matcher": false,
 								},
 							},
@@ -460,8 +461,8 @@ var ResourceConfigs = map[string]MinimalConfig{
 		Category:  CategorySimple,
 		Namespace: true,
 		RequiredSpec: map[string]interface{}{
-			"priority":    "HIGH",
-			"dscp_value":  46,
+			"priority":   "HIGH",
+			"dscp_value": 46,
 		},
 	},
 }
@@ -471,16 +472,16 @@ var ResourceConfigs = map[string]MinimalConfig{
 // ============================================================================
 
 var (
-	flagAll        = flag.Bool("all", false, "Discover defaults for all resources")
-	flagResource   = flag.String("resource", "", "Discover defaults for a specific resource")
-	flagPattern    = flag.String("pattern", "", "Discover defaults for resources matching pattern")
-	flagOutput     = flag.String("output", "tools/api-defaults.json", "Output file path")
-	flagValidate   = flag.Bool("validate", false, "Validate stored defaults against current API")
-	flagVerbose    = flag.Bool("verbose", false, "Enable verbose output")
-	flagDryRun     = flag.Bool("dry-run", false, "Show what would be done without making API calls")
-	flagTestNS     = flag.String("test-namespace", "", "Use existing namespace for testing (skip namespace creation)")
-	flagCreateNS   = flag.Bool("create-namespace", false, "Create test namespace automatically")
-	flagNSPrefix   = flag.String("ns-prefix", "tf-discover", "Prefix for auto-created test namespace")
+	flagAll      = flag.Bool("all", false, "Discover defaults for all resources")
+	flagResource = flag.String("resource", "", "Discover defaults for a specific resource")
+	flagPattern  = flag.String("pattern", "", "Discover defaults for resources matching pattern")
+	flagOutput   = flag.String("output", "tools/api-defaults.json", "Output file path")
+	flagValidate = flag.Bool("validate", false, "Validate stored defaults against current API")
+	flagVerbose  = flag.Bool("verbose", false, "Enable verbose output")
+	flagDryRun   = flag.Bool("dry-run", false, "Show what would be done without making API calls")
+	flagTestNS   = flag.String("test-namespace", "", "Use existing namespace for testing (skip namespace creation)")
+	flagCreateNS = flag.Bool("create-namespace", false, "Create test namespace automatically")
+	flagNSPrefix = flag.String("ns-prefix", "tf-discover", "Prefix for auto-created test namespace")
 )
 
 // ============================================================================
@@ -791,8 +792,13 @@ func discoverResource(apiClient *client.Client, resourceName string) *DiscoveryR
 	result.Status = "discovered"
 	result.DiscoveredAt = time.Now().UTC().Format(time.RFC3339)
 
-	// Extract defaults by comparing request and response
-	result.Defaults = extractDefaults(request, response, "")
+	// Extract defaults by comparing request and response. The differ lives in the
+	// testable tools/pkg/suppress package (recurses into list elements — #1103).
+	sd := suppress.ExtractDefaults(request, response)
+	result.Defaults = make(map[string]FieldDefault, len(sd))
+	for k, v := range sd {
+		result.Defaults[k] = FieldDefault{Path: v.Path, DefaultValue: v.DefaultValue, Type: v.Type, IsMarkerBlock: v.IsMarkerBlock}
+	}
 
 	// Clean up - delete the test resource
 	cleanupResource(ctx, apiClient, resourceName, testNamespace, testName)
@@ -909,91 +915,11 @@ func pluralizeResource(name string) string {
 	return name + "s"
 }
 
-// ============================================================================
-// Default Extraction
-// ============================================================================
-
-func extractDefaults(request, response map[string]interface{}, prefix string) map[string]FieldDefault {
-	defaults := make(map[string]FieldDefault)
-
-	// Get spec from both
-	reqSpec, reqOk := request["spec"].(map[string]interface{})
-	respSpec, respOk := response["spec"].(map[string]interface{})
-
-	if !reqOk || !respOk {
-		return defaults
-	}
-
-	// Find fields in response that weren't in request
-	compareObjects(reqSpec, respSpec, "spec", defaults)
-
-	return defaults
-}
-
-func compareObjects(request, response map[string]interface{}, path string, defaults map[string]FieldDefault) {
-	for key, respValue := range response {
-		fullPath := path + "." + key
-
-		reqValue, existsInReq := request[key]
-
-		if !existsInReq {
-			// This is a default value - wasn't sent in request
-			fd := FieldDefault{
-				Path:         fullPath,
-				DefaultValue: respValue,
-				Type:         getValueType(respValue),
-			}
-
-			// Check if it's an empty marker block
-			if m, ok := respValue.(map[string]interface{}); ok && len(m) == 0 {
-				fd.IsMarkerBlock = true
-			}
-
-			defaults[fullPath] = fd
-		} else {
-			// Both have the key - recursively compare if both are maps
-			if reqMap, reqIsMap := reqValue.(map[string]interface{}); reqIsMap {
-				if respMap, respIsMap := respValue.(map[string]interface{}); respIsMap {
-					// Only recurse if request map was empty (marker block)
-					if len(reqMap) == 0 {
-						// Check if response added any fields
-						for subKey, subValue := range respMap {
-							subPath := fullPath + "." + subKey
-							fd := FieldDefault{
-								Path:         subPath,
-								DefaultValue: subValue,
-								Type:         getValueType(subValue),
-							}
-							defaults[subPath] = fd
-						}
-					} else {
-						compareObjects(reqMap, respMap, fullPath, defaults)
-					}
-				}
-			}
-		}
-	}
-}
-
-func getValueType(v interface{}) string {
-	if v == nil {
-		return "null"
-	}
-	switch reflect.TypeOf(v).Kind() {
-	case reflect.String:
-		return "string"
-	case reflect.Int, reflect.Int64, reflect.Float64:
-		return "number"
-	case reflect.Bool:
-		return "bool"
-	case reflect.Map:
-		return "object"
-	case reflect.Slice, reflect.Array:
-		return "array"
-	default:
-		return "unknown"
-	}
-}
+// Default extraction lives in the testable tools/pkg/suppress package
+// (suppress.ExtractDefaults), which recurses into list elements so defaults nested
+// inside list elements — origin_servers[].labels {}, default_route_pools[].
+// endpoint_subsets {} — are discovered. See issue #1103. This script converts the
+// result into its local FieldDefault at the call site above.
 
 // ============================================================================
 // Database Operations

--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -32,6 +32,7 @@
     "disable_trust_client_ip_headers",
     "disable_waf",
     "dns_volterra_managed",
+    "endpoint_subsets",
     "l7_ddos_protection",
     "no_challenge",
     "round_robin",
@@ -43,6 +44,9 @@
   "Healthcheck": [
     "headers",
     "use_http2"
+  ],
+  "OriginPool": [
+    "labels"
   ],
   "RateLimiterPolicy": [
     "any_asn",

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -357,6 +357,50 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault(t *testing.T) 
 	}
 }
 
+// #1103: plain optional empty-marker blocks the API echoes on every list element
+// (origin_pool origin_servers[].labels {}, http_loadbalancer
+// default_route_pools[].endpoint_subsets {}) must guard their response-populate with
+// !isImport, exactly like oneof base markers — otherwise a minimal config that omits
+// them drifts every plan after import. This proves the seed entries flow through to the
+// generated flatten closure for these two leaves.
+func TestRenderUnmarshalSingleChild_ImportSuppressesEmptyMarkerListElement_Issue1103(t *testing.T) {
+	mk := func(go_, tfsdk string) openapi.TerraformAttribute {
+		return openapi.TerraformAttribute{GoName: go_, TfsdkTag: tfsdk, JsonName: tfsdk, IsBlock: true, NestedBlockType: "single"}
+	}
+	cases := []struct {
+		rc, goName, tfsdk string
+	}{
+		{"OriginPool", "Labels", "labels"},
+		{"HTTPLoadBalancer", "EndpointSubsets", "endpoint_subsets"},
+	}
+	for _, c := range cases {
+		var sb strings.Builder
+		// Render as it appears inside a list element (positional state accessor).
+		renderUnmarshalSingleChild(&sb, c.rc, "", mk(c.goName, c.tfsdk), "itemMap", "existingItems[idx]", "len(existingItems) > idx", "list", "\t")
+		got := sb.String()
+		if !strings.Contains(got, "if !isImport {") {
+			t.Errorf("%s.%s must guard response-populate with !isImport (empty-marker import drift #1103); got:\n%s", c.rc, c.tfsdk, got)
+		}
+	}
+}
+
+// #1103 non-collision: seeding OriginPool.labels suppresses ONLY the origin_servers[]
+// empty-marker block. The top-level metadata.labels is a types.Map rendered by a
+// different path that never consults isImportDefaultSuppressed, so a map-typed "labels"
+// child must NOT acquire an empty-marker import-suppression guard.
+func TestRenderUnmarshalChild_MetadataLabelsMapNotSuppressed_Issue1103(t *testing.T) {
+	var sb strings.Builder
+	mapAttr := openapi.TerraformAttribute{GoName: "Labels", TfsdkTag: "labels", JsonName: "labels", Type: "map", ElementType: "string"}
+	renderUnmarshalChild(&sb, "OriginPool", "", mapAttr, "metaMap", "", "", "single", "\t")
+	got := sb.String()
+	if strings.Contains(got, "EmptyModel{}") {
+		t.Errorf("metadata.labels (types.Map) must not render as an empty-marker block; got:\n%s", got)
+	}
+	if strings.Contains(got, "if !isImport {") {
+		t.Errorf("metadata.labels (types.Map) must not acquire an empty-marker import-suppression guard; got:\n%s", got)
+	}
+}
+
 // A suppressed server-computed LIST block nested inside another block (e.g.
 // app_firewall detection_settings.violations_view — the server materializes the
 // full violation catalog whenever detection_settings is set) must not be populated

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -10,14 +10,22 @@ import (
 	"sync"
 )
 
-// Import-default suppression: per resource (title-case model prefix), the oneof
-// members the F5 XC API ALWAYS returns as the server default for their group. On
-// `terraform import` there is no prior config to preserve, so the flatten would
-// otherwise populate every such default member and the next plan would show
-// spurious drift. Suppressing the DEFAULT member on import is semantically safe:
-// omitting it means the server re-applies the same default. Non-default and
-// user-intent markers (e.g. app_firewall, advertise_on_public_default_vip) are
-// NOT listed and still import normally.
+// Import-default suppression: per resource (title-case model prefix), the empty
+// marker blocks the F5 XC API ALWAYS returns as a server default. Two classes:
+//  1. oneof base members the API echoes for their group (e.g. disable_waf,
+//     any_client, round_robin);
+//  2. plain optional message blocks the API materializes as present-but-empty on
+//     every element — including inside list elements — even though they carry no
+//     meaning empty (e.g. origin_servers[].labels {}, default_route_pools[].
+//     endpoint_subsets {}; see #1103).
+//
+// On `terraform import` there is no prior config to preserve, so the flatten would
+// otherwise populate every such marker and the next plan would show spurious drift.
+// Suppressing the marker on import is semantically safe: omitting it means the
+// server re-applies the same default. Non-default and user-intent markers (e.g.
+// app_firewall, advertise_on_public_default_vip) are NOT listed and still import
+// normally. Matched by leaf name at any depth (see isImportDefaultSuppressed), so
+// one entry per resource covers every nesting/list depth it appears at.
 //
 // Data lives in tools/import-default-suppressions.json (auto-populated by
 // tools/discover-defaults.go against a live tenant). The seed below is the
@@ -70,9 +78,25 @@ var importDefaultSuppressionsSeed = map[string][]string{
 		// xcsh_api_testing (APITesting, below). Suppress so a concrete-arm credential
 		// (api_key/basic_auth/bearer_token) is round-trip-import clean. Verified live.
 		"standard",
+		// #1103: endpoint_subsets {} is a plain optional empty-marker block (NOT a oneof
+		// member) that the API echoes on every default_route_pools[] / routes[].pools[]
+		// element. The module omits it (empty carries no meaning), so it must be
+		// suppressed on import or the minimal config drifts every plan (- endpoint_subsets
+		// {}), cascading into computed tenant re-planning on pool/app_firewall/api refs.
+		// Missed until now because the auto-derive differ was blind to list-element
+		// defaults (fixed in tools/pkg/suppress/diff.go).
+		"endpoint_subsets",
 	},
 	"APITesting": {
 		"standard",
+	},
+	// #1103: labels {} is a plain optional empty-marker block the API echoes on every
+	// origin_servers[] element (a label selector the schema models as empty-only). The
+	// module omits it, so suppress on import to keep origin_pool round-trip clean.
+	// Does NOT affect the top-level metadata.labels types.Map (a different read path
+	// that never consults isImportDefaultSuppressed).
+	"OriginPool": {
+		"labels",
 	},
 	// Coverage Batch B (#51): the server materializes the base member of each
 	// client-matcher oneof on a rate_limiter_policy rule that omits that matcher

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -105,6 +105,25 @@ func TestImportSuppressions_AppFirewallViolationsView(t *testing.T) {
 	}
 }
 
+// #1103 (recurrence): empty-marker nested blocks the F5 XC API always echoes on
+// every list element — origin_pool origin_servers[].labels {} and
+// http_loadbalancer default_route_pools[].endpoint_subsets {} (also routes[].pools[],
+// etc.). These are NOT oneof members but plain optional message blocks the server
+// materializes as present-but-empty. On import there is no prior state to preserve, so
+// without suppression the flatten populates the marker and the next plan wants to remove
+// it (present-in-read vs absent-in-config) = perpetual drift, cascading into computed
+// tenant re-planning on reference blocks. One entry per resource covers all depths
+// (matched by leaf name). They slipped through because the auto-derive differ was blind
+// to defaults nested inside list elements (fixed in tools/pkg/suppress/diff.go).
+func TestImportSuppressions_EmptyMarkerListElementBlocks_Issue1103(t *testing.T) {
+	if !isImportDefaultSuppressed("OriginPool", "labels") {
+		t.Error("OriginPool.labels must be a suppressed server-default (origin_servers[].labels {} import round-trip drift, #1103)")
+	}
+	if !isImportDefaultSuppressed("HTTPLoadBalancer", "endpoint_subsets") {
+		t.Error("HTTPLoadBalancer.endpoint_subsets must be a suppressed server-default (default_route_pools[].endpoint_subsets {} import round-trip drift, #1103)")
+	}
+}
+
 // Coverage Batch B (#51): a rate_limiter_policy rule that omits its country client
 // matcher gets any_country {} materialized by the server (verified live on
 // f5-sales-demo webapp-api-protection: a rule with asn_list but no country came

--- a/tools/pkg/suppress/diff.go
+++ b/tools/pkg/suppress/diff.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package suppress
+
+import "reflect"
+
+// ExtractDefaults compares a create request against the API response and returns
+// the server-applied defaults keyed by their dotted spec path. A field present in
+// the response but absent from the request is a server default; an empty {} block
+// is a marker block (IsMarkerBlock). Both request and response are the full
+// object maps ({"spec": {...}, ...}); only the spec subtree is compared.
+//
+// It recurses into nested maps AND list elements. The list-element recursion is
+// what lets it discover defaults nested inside list elements — e.g.
+// origin_servers[].labels {} and default_route_pools[].endpoint_subsets {} — which
+// the previous map-only walker silently skipped, the root cause of issue #1103.
+func ExtractDefaults(request, response map[string]interface{}) map[string]FieldDefault {
+	defaults := make(map[string]FieldDefault)
+
+	reqSpec, reqOk := request["spec"].(map[string]interface{})
+	respSpec, respOk := response["spec"].(map[string]interface{})
+	if !reqOk || !respOk {
+		return defaults
+	}
+
+	compareObjects(reqSpec, respSpec, "spec", defaults)
+	return defaults
+}
+
+// compareObjects records every response key that was absent from the request (a
+// server default) and recurses into nested maps that both sides share.
+func compareObjects(request, response map[string]interface{}, path string, defaults map[string]FieldDefault) {
+	for key, respValue := range response {
+		fullPath := path + "." + key
+
+		reqValue, existsInReq := request[key]
+		if !existsInReq {
+			// Absent from the request → a server default.
+			recordDefault(fullPath, respValue, defaults)
+			continue
+		}
+
+		// Present in both. Recurse into maps AND lists so defaults nested at any depth
+		// are discovered.
+		switch rv := reqValue.(type) {
+		case map[string]interface{}:
+			respMap, ok := respValue.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if len(rv) == 0 {
+				// Request sent an empty marker block; record whatever the response added.
+				for subKey, subValue := range respMap {
+					recordDefault(fullPath+"."+subKey, subValue, defaults)
+				}
+			} else {
+				compareObjects(rv, respMap, fullPath, defaults)
+			}
+		case []interface{}:
+			// #1103: recurse element-wise into list values. The API echoes empty-marker
+			// sub-blocks (labels {}, endpoint_subsets {}) on every element of lists like
+			// origin_servers / default_route_pools; without this branch those defaults
+			// were invisible to discovery. The path carries no [i] index, so every
+			// element collapses onto the same dotted path (deduped by leaf downstream).
+			respList, ok := respValue.([]interface{})
+			if !ok {
+				continue
+			}
+			compareLists(rv, respList, fullPath, defaults)
+		}
+	}
+}
+
+// compareLists pairs response elements with their request counterpart by index and
+// recurses into each element map. Response elements beyond the request's length (or
+// whose request counterpart is not a map) are compared against an empty request, so
+// every field they carry registers as a server default.
+func compareLists(request, response []interface{}, path string, defaults map[string]FieldDefault) {
+	for i, respElem := range response {
+		respMap, ok := respElem.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		reqMap := map[string]interface{}{}
+		if i < len(request) {
+			if m, ok := request[i].(map[string]interface{}); ok {
+				reqMap = m
+			}
+		}
+		compareObjects(reqMap, respMap, path, defaults)
+	}
+}
+
+// recordDefault stores one discovered default, flagging empty {} objects as marker
+// blocks (the shape origin_servers[].labels / default_route_pools[].endpoint_subsets
+// take, and that isServerDefaultMember suppresses on import).
+func recordDefault(fullPath string, respValue interface{}, defaults map[string]FieldDefault) {
+	fd := FieldDefault{
+		Path:         fullPath,
+		DefaultValue: respValue,
+		Type:         getValueType(respValue),
+	}
+	if m, ok := respValue.(map[string]interface{}); ok && len(m) == 0 {
+		fd.IsMarkerBlock = true
+	}
+	defaults[fullPath] = fd
+}
+
+// getValueType classifies a JSON-decoded value for the defaults record.
+func getValueType(v interface{}) string {
+	if v == nil {
+		return "null"
+	}
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Int, reflect.Int64, reflect.Float64:
+		return "number"
+	case reflect.Bool:
+		return "bool"
+	case reflect.Map:
+		return "object"
+	case reflect.Slice, reflect.Array:
+		return "array"
+	default:
+		return "unknown"
+	}
+}

--- a/tools/pkg/suppress/diff_test.go
+++ b/tools/pkg/suppress/diff_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package suppress
+
+import "testing"
+
+// hasMarker reports whether ExtractDefaults found a marker-block default whose leaf
+// (final dotted segment) equals name.
+func hasMarker(defaults map[string]FieldDefault, name string) bool {
+	for _, fd := range defaults {
+		if leaf(fd.Path) == name && fd.IsMarkerBlock {
+			return true
+		}
+	}
+	return false
+}
+
+// #1103: the F5 XC API echoes labels {} on every origin_servers[] element. The
+// origin_servers key IS in the request, so the default lives one level down inside a
+// LIST element — exactly what the map-only walker skipped. The differ must recurse
+// into list elements and record spec.origin_servers.labels as a marker block.
+func TestExtractDefaults_OriginServersLabelsMarker_Issue1103(t *testing.T) {
+	request := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"origin_servers": []interface{}{
+				map[string]interface{}{
+					"public_ip": map[string]interface{}{"ip": "20.98.232.135"},
+				},
+			},
+		},
+	}
+	response := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"origin_servers": []interface{}{
+				map[string]interface{}{
+					"public_ip": map[string]interface{}{"ip": "20.98.232.135"},
+					"labels":    map[string]interface{}{},
+				},
+			},
+		},
+	}
+	got := ExtractDefaults(request, response)
+	if !hasMarker(got, "labels") {
+		t.Errorf("expected a marker default with leaf 'labels' (origin_servers[].labels {}); got %#v", got)
+	}
+}
+
+// #1103: default_route_pools[].endpoint_subsets {} — same class, different resource.
+func TestExtractDefaults_EndpointSubsetsMarker_Issue1103(t *testing.T) {
+	request := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"default_route_pools": []interface{}{
+				map[string]interface{}{
+					"pool": map[string]interface{}{"name": "p", "namespace": "ns"},
+				},
+			},
+		},
+	}
+	response := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"default_route_pools": []interface{}{
+				map[string]interface{}{
+					"pool":             map[string]interface{}{"name": "p", "namespace": "ns"},
+					"endpoint_subsets": map[string]interface{}{},
+				},
+			},
+		},
+	}
+	got := ExtractDefaults(request, response)
+	if !hasMarker(got, "endpoint_subsets") {
+		t.Errorf("expected a marker default with leaf 'endpoint_subsets'; got %#v", got)
+	}
+}
+
+// A marker nested inside a map inside a list element must also be found (full
+// recursion, not just one level into list elements).
+func TestExtractDefaults_MarkerNestedInsideListElementMap(t *testing.T) {
+	request := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"routes": []interface{}{
+				map[string]interface{}{
+					"simple_route": map[string]interface{}{
+						"path": map[string]interface{}{"prefix": "/"},
+					},
+				},
+			},
+		},
+	}
+	response := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"routes": []interface{}{
+				map[string]interface{}{
+					"simple_route": map[string]interface{}{
+						"path":             map[string]interface{}{"prefix": "/"},
+						"endpoint_subsets": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+	got := ExtractDefaults(request, response)
+	if !hasMarker(got, "endpoint_subsets") {
+		t.Errorf("expected marker 'endpoint_subsets' nested in routes[].simple_route; got %#v", got)
+	}
+}
+
+// Behavior-preservation: a top-level marker block absent from the request (the
+// original map-only case) is still discovered after the list-recursion change.
+func TestExtractDefaults_TopLevelMarkerStillFound(t *testing.T) {
+	request := map[string]interface{}{"spec": map[string]interface{}{"http": map[string]interface{}{"port": float64(80)}}}
+	response := map[string]interface{}{"spec": map[string]interface{}{
+		"http":        map[string]interface{}{"port": float64(80)},
+		"disable_waf": map[string]interface{}{},
+	}}
+	got := ExtractDefaults(request, response)
+	if !hasMarker(got, "disable_waf") {
+		t.Errorf("expected top-level marker 'disable_waf'; got %#v", got)
+	}
+}


### PR DESCRIPTION
## Problem

Closes #1103. After `terraform import`, a plan shows perpetual in-place drift unless
`origin_pool` `origin_servers { labels {} }` and `http_loadbalancer`
`default_route_pools { endpoint_subsets {} }` are declared verbatim. Omitting them (the
natural minimal config) yields `- labels {}` / `- endpoint_subsets {}` every plan,
cascading into computed `tenant` re-planning on reference blocks (`app_firewall`,
`api_definition`, `code_base_integration`). This is a **recurrence** of the empty-marker
import-drift class solved for top-level markers in #1009/#1018/#1082.

## Root cause (two gaps)

1. **`labels`/`endpoint_subsets` were never suppressed on import.** On import there is no
   prior state to preserve, so the only thing that stops the API's echoed `{}` from being
   materialized is `isImportDefaultSuppressed(rc, jsonName)` (consumed in
   `render.go` empty-marker branch). Neither leaf was in the seed or the derived JSON.
2. **The auto-derive differ was blind to list elements.** `compareObjects` recursed only
   into `map` values — it had no branch for `[]interface{}` — so every default nested
   inside a list element (`origin_servers[]`, `default_route_pools[]`) was invisible to
   discovery and could never be auto-derived. And the differ lived in the `//go:build
   ignore` `discover-defaults.go` script, so it had **no test harness** — the blind spot
   was undetectable. We'd been relying on hand-seeding, which is incomplete by nature.

## Fix

**Layer A — deterministic suppression (immediate).** Add `labels` (OriginPool) and
`endpoint_subsets` (HTTPLoadBalancer) to the import-default-suppression seed
(`import_suppressions.go`) and JSON. Matched by leaf name at any depth, so one entry per
resource covers every nesting/list depth (`default_route_pools[]`, `routes[].pools[]`, …).
Broadened the mechanism doc comment to cover this second class (non-oneof server-echoed
empty markers).

**Layer B — close the discovery blind spot (root of the recurrence).** Extracted the
differ (`ExtractDefaults`/`compareObjects`/`getValueType`) out of the build-ignored script
into the testable `tools/pkg/suppress` package (beside `Derive`/`Merge`), added
element-wise **list recursion** (`compareLists`), and thinned `discover-defaults.go` to
call it. Re-running discovery now empirically finds this whole class — including future
list-nested markers — instead of waiting for a human to hand-seed each one.

## Tests (all offline, CI-gated)

- `import_suppressions_test.go`: `OriginPool.labels` and `HTTPLoadBalancer.endpoint_subsets`
  are suppressed.
- `codegen_test.go`: the generated single-child closure emits the `if !isImport {` guard for
  both leaves; **non-collision** test that the top-level `metadata.labels` `types.Map` read
  path is unaffected.
- `suppress/diff_test.go`: `origin_servers[].labels {}` and `default_route_pools[].endpoint_subsets {}`
  fixtures now yield marker defaults; a marker nested in a list-element map is found (full
  recursion); the original top-level marker path is preserved.

Verified locally: after `make generate`, the guard is present in all origin_pool `Labels`
closures and http_lb `EndpointSubsets` closures (default_route_pools / pools / routes).
Generated code lands via the on-merge auto-regenerate PR (not committed here).