### PR TITLE
fix: suppress origin_pool advanced_options server-default markers on import

### DIFF
--- a/tools/import-default-suppressions.json
+++ b/tools/import-default-suppressions.json
@@ -48,7 +48,13 @@
     "use_http2"
   ],
   "OriginPool": [
-    "labels"
+    "auto_http_config",
+    "default_circuit_breaker",
+    "disable_outlier_detection",
+    "disable_subsets",
+    "labels",
+    "no_panic_threshold",
+    "no_request_limit_per_connection"
   ],
   "RateLimiterPolicy": [
     "any_asn",

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -105,6 +105,19 @@ var importDefaultSuppressionsSeed = map[string][]string{
 	// that never consults isImportDefaultSuppressed).
 	"OriginPool": {
 		"labels",
+		// LPC-5b (#1130): advanced_options oneof base members the API materializes whenever
+		// advanced_options is set — the circuit_breaker / outlier_detection / subsets /
+		// panic_threshold / request-limit "default/disable/no" choices plus auto_http_config.
+		// A minimal advanced_options config (e.g. just connection_timeout/http_idle_timeout)
+		// omits them, so import populates them and the next plan drifts (- each marker). Same
+		// class as endpoint_subsets (#1103) / more_option (#1125). Verified live
+		// (f5-sales-demo webapp-api-protection LPC-5b origin_pool matrix).
+		"auto_http_config",
+		"default_circuit_breaker",
+		"disable_outlier_detection",
+		"disable_subsets",
+		"no_panic_threshold",
+		"no_request_limit_per_connection",
 	},
 	// Coverage Batch B (#51): the server materializes the base member of each
 	// client-matcher oneof on a rate_limiter_policy rule that omits that matcher

--- a/tools/pkg/codegen/import_suppressions_test.go
+++ b/tools/pkg/codegen/import_suppressions_test.go
@@ -124,6 +124,24 @@ func TestImportSuppressions_EmptyMarkerListElementBlocks_Issue1103(t *testing.T)
 	}
 }
 
+// LPC-5b (#1130): advanced_options oneof base members the API materializes whenever
+// advanced_options is set. A minimal advanced_options config omits them, so import drifts
+// (- each marker) unless suppressed. Verified live (webapp-api-protection LPC-5b).
+func TestImportSuppressions_OriginPoolAdvancedOptionsDefaults(t *testing.T) {
+	for _, leaf := range []string{
+		"auto_http_config",
+		"default_circuit_breaker",
+		"disable_outlier_detection",
+		"disable_subsets",
+		"no_panic_threshold",
+		"no_request_limit_per_connection",
+	} {
+		if !isImportDefaultSuppressed("OriginPool", leaf) {
+			t.Errorf("OriginPool.%s must be a suppressed advanced_options server-default (#1130)", leaf)
+		}
+	}
+}
+
 // SPol-1 (service_policy coverage): suppress ONLY the oneof base members the F5 XC API
 // echoes when their parent is OMITTED — verified live by GETting a created service_policy
 // on f5-sales-demo: a rule with no client/asn/ip matcher still returns any_client{}/


### PR DESCRIPTION
## Problem

Importing `xcsh_origin_pool` with `advanced_options` set drifts on the next plan: the F5 XC API
materializes six server-default empty-marker sub-blocks that a minimal advanced_options config
omits, so `terraform import` populates them and the plan shows spurious removals:

```
~ advanced_options {
    - auto_http_config {}
    - default_circuit_breaker {}
    - disable_outlier_detection {}
    - disable_subsets {}
    - no_panic_threshold {}
    - no_request_limit_per_connection {}
```

These are the oneof base members the server adds whenever advanced_options is present
(circuit_breaker/outlier_detection/subsets/panic_threshold/request-limit choices + auto_http_config).
Same class as endpoint_subsets (#1103) and the more_option markers (#1125).

## Fix

Add the six leaf names to the `OriginPool` entry in the import-default-suppression seed
(`tools/pkg/codegen/import_suppressions.go`) + `tools/import-default-suppressions.json`, with a
unit test asserting each is suppressed. Matched by leaf name at any depth, so one entry covers
the advanced_options nesting.

## Verification

`go test ./tools/...`; consumer whole-pool import round-trip clean on a config that sets
advanced_options timeouts (verified against f5-sales-demo webapp-api-protection LPC-5b).

Closes #1130