### PR TITLE
fix: read meaningful-zero int64 (signature_id) back faithfully (#1129)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -1027,3 +1027,33 @@ func TestRenderMarshalBlock_NestedSameNameNoShadow(t *testing.T) {
 		names[m[1]] = true
 	}
 }
+
+// #1129: meaningful-zero int64 leaves (signature_id, where 0 = "all signatures") must read a
+// returned 0 back faithfully — the generated read must DROP the `v != 0` guard for them, while
+// every other int64 field keeps it (0 = unset). Regression test for both the allowlisted leaf
+// and a control leaf.
+func TestRenderUnmarshalScalarChild_MeaningfulZeroInt64_Issue1129(t *testing.T) {
+	// signature_id on HTTPLoadBalancer (a list-element leaf) drops the v != 0 guard.
+	var sig strings.Builder
+	sigAttr := openapi.TerraformAttribute{
+		GoName: "SignatureID", TfsdkTag: "signature_id", JsonName: "signature_id", Type: "int64", Optional: true,
+	}
+	renderUnmarshalScalarChild(&sig, "HTTPLoadBalancer", sigAttr, "m", "", "", "list", "\t")
+	got := sig.String()
+	if !strings.Contains(got, `if v, ok := m["signature_id"].(float64); ok {`) {
+		t.Errorf("signature_id read must drop the `v != 0` guard (#1129); got:\n%s", got)
+	}
+	if strings.Contains(got, "ok && v != 0") {
+		t.Errorf("signature_id read must NOT keep the `v != 0` guard (#1129); got:\n%s", got)
+	}
+
+	// A control int64 leaf keeps the v != 0 guard (0 = unset for the common case).
+	var ctl strings.Builder
+	ctlAttr := openapi.TerraformAttribute{
+		GoName: "Timeout", TfsdkTag: "timeout", JsonName: "timeout", Type: "int64", Optional: true,
+	}
+	renderUnmarshalScalarChild(&ctl, "HTTPLoadBalancer", ctlAttr, "m", "", "", "list", "\t")
+	if !strings.Contains(ctl.String(), "ok && v != 0") {
+		t.Errorf("non-meaningful-zero int64 (timeout) must keep the `v != 0` guard; got:\n%s", ctl.String())
+	}
+}

--- a/tools/pkg/codegen/meaningful_zero.go
+++ b/tools/pkg/codegen/meaningful_zero.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package codegen
+
+// Meaningful-zero int64 leaves: fields whose value 0 is a real, user-intended value the API
+// stores and returns — NOT the "unset / server default" sentinel that most int64 fields use.
+//
+// The generated int64 read guard is `if v, ok := m[k].(float64); ok && v != 0` — the `v != 0`
+// clause treats a returned 0 as absent and leaves the attribute null. That is correct for the
+// common case (the API omits or zero-fills a field it considers unset), but wrong for fields
+// where 0 carries meaning: the API returns 0, the read drops it, and a config that set 0 drifts
+// ("was 0, now null" on apply / round-trip import). See #1129: waf_exclusion
+// exclude_signature_contexts[].signature_id, where 0 means "exclude ALL signatures for the
+// context" (per the schema) and is a legitimate value in the range {0} ∪ [200000001,299999999].
+//
+// Listed here per resource (title-case model prefix) by leaf json name, matched at any depth
+// (mirrors isImportDefaultSuppressed). For these, renderUnmarshalScalarChild drops the `v != 0`
+// clause so a returned 0 is read back faithfully. Keep this list tight: only add a leaf a live
+// round-trip proves the API returns 0 for as a meaningful value.
+var meaningfulZeroInt64Seed = map[string][]string{
+	// #1129: signature_id 0 = "all signatures excluded for the context". Appears on the LB
+	// inline waf_exclusion and the standalone xcsh_waf_exclusion_policy; matched by leaf name at
+	// any depth, so one entry per resource covers every nesting.
+	"HTTPLoadBalancer":   {"signature_id"},
+	"WAFExclusionPolicy": {"signature_id"},
+}
+
+// isMeaningfulZeroInt64 reports whether the given int64 leaf of the given resource must be read
+// back even when the API returns 0 (i.e. the `v != 0` guard must be dropped).
+func isMeaningfulZeroInt64(resourceTitleCase, jsonName string) bool {
+	for _, leaf := range meaningfulZeroInt64Seed[resourceTitleCase] {
+		if leaf == jsonName {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -635,7 +635,13 @@ func renderUnmarshalScalarChild(sb *strings.Builder, rc string, attr openapi.Ter
 			sb.WriteString(fmt.Sprintf("%s\t\treturn %s.%s\n", indent, stateBase, fieldName))
 			sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		}
-		sb.WriteString(fmt.Sprintf("%s\tif v, ok := %s[\"%s\"].(float64); ok && v != 0 {\n", indent, srcMap, jsonName))
+		// Most int64 fields treat a returned 0 as "unset" (v != 0 guard); meaningful-zero
+		// leaves (e.g. signature_id, where 0 = "all") must read 0 back faithfully (#1129).
+		if isMeaningfulZeroInt64(rc, jsonName) {
+			sb.WriteString(fmt.Sprintf("%s\tif v, ok := %s[\"%s\"].(float64); ok {\n", indent, srcMap, jsonName))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s\tif v, ok := %s[\"%s\"].(float64); ok && v != 0 {\n", indent, srcMap, jsonName))
+		}
 		sb.WriteString(fmt.Sprintf("%s\t\treturn types.Int64Value(int64(v))\n", indent))
 		sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 		sb.WriteString(fmt.Sprintf("%s\treturn types.Int64Null()\n", indent))


### PR DESCRIPTION
## Problem

The generated int64 read guard `if v, ok := m[k].(float64); ok && v != 0` treats a returned `0`
as unset. For `waf_exclusion.exclude_signature_contexts[].signature_id`, `0` means "exclude ALL
signatures for the context" (per the schema). The API returns 0, the read dropped it, and a
config that set `signature_id = 0` failed apply with "Provider produced inconsistent result …
was cty.NumberIntVal(0), but now null", then drifted every round-trip. (Non-zero signature IDs
were unaffected — that's why the webapp waf_exclusion matrices used real IDs.)

## Fix

Add a meaningful-zero int64 allowlist (`tools/pkg/codegen/meaningful_zero.go`, seeded
`HTTPLoadBalancer` + `WAFExclusionPolicy` → `signature_id`; matched by leaf name at any depth,
mirroring `isImportDefaultSuppressed`). `renderUnmarshalScalarChild` drops the `v != 0` clause
for those leaves so a returned 0 reads back faithfully; every other int64 keeps the guard
(0 = unset). Unit test covers the allowlisted leaf and a control.

## Verification

`go test ./tools/...` green. After release, the webapp waf_exclusion coverage that currently
avoids `signature_id = 0` (LPC-4a/4b) will be re-enabled and live-verified.

Closes #1129