### PR TITLE
Import suppression root-only scope: nested declared disable_waf round-trips (#1145)

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -331,12 +331,14 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault(t *testing.T) 
 		return openapi.TerraformAttribute{GoName: go_, TfsdkTag: tfsdk, JsonName: tfsdk, IsBlock: true, NestedBlockType: "single"}
 	}
 
-	// Suppressed default marker (disable_waf) -> guarded by !isImport.
+	// Suppressed any-depth default marker (common_buffering, a route advanced_options
+	// oneof-base default) -> guarded by !isImport. (disable_waf is root-only scoped;
+	// see TestRenderUnmarshalSingleChild_RootOnlySuppression_Issue1145.)
 	var sb strings.Builder
-	renderUnmarshalSingleChild(&sb, "HTTPLoadBalancer", "", mk("DisableWaf", "disable_waf"), "apiResource.Spec", "data", "true", "single", "\t")
+	renderUnmarshalSingleChild(&sb, "HTTPLoadBalancer", "", mk("CommonBuffering", "common_buffering"), "apiResource.Spec", "data", "true", "single", "\t")
 	got := sb.String()
 	if !strings.Contains(got, "if !isImport {") {
-		t.Errorf("suppressed member disable_waf must guard response-populate with !isImport; got:\n%s", got)
+		t.Errorf("suppressed member common_buffering must guard response-populate with !isImport; got:\n%s", got)
 	}
 
 	// Non-suppressed user-intent marker (advertise_on_public_default_vip) -> no import guard on the populate.
@@ -354,6 +356,57 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault(t *testing.T) 
 	}
 	if isImportDefaultSuppressed("HTTPLoadBalancer", "advertise_on_public_default_vip") {
 		t.Error("advertise_on_public_default_vip is user intent and must NOT be suppressed")
+	}
+}
+
+// #1145: a leaf that is a server-default at the resource ROOT (suppressed there so a bare
+// LB imports clean) but a user-DECLARED oneof arm when nested must be suppressed ONLY at the
+// root. http_loadbalancer disable_waf is the case: at the LB root it is the WAF oneof default;
+// inside routes[].{simple_route}.advanced_options it is a per-route "disable WAF for this
+// route" choice. Because suppression matches by leaf name at any depth, the nested declared
+// disable_waf was stripped on import and drifted (+ disable_waf {}) — forcing custom-routes
+// coverage to drop route-level waf_mode=disable (CR-3). Root-only scope fixes it: the nested
+// renderer (renderUnmarshalSingleChild, which also renders single blocks inside list elements
+// like routes[]) must NOT guard a root-only leaf, so the declared nested marker reads back and
+// round-trips. renderUnmarshalTopLevelSingle (root) still suppresses it. A genuinely any-depth
+// marker (common_buffering, a route advanced_options oneof-base default) stays guarded nested.
+func TestRenderUnmarshalSingleChild_RootOnlySuppression_Issue1145(t *testing.T) {
+	mk := func(go_, tfsdk string) openapi.TerraformAttribute {
+		return openapi.TerraformAttribute{GoName: go_, TfsdkTag: tfsdk, JsonName: tfsdk, IsBlock: true, NestedBlockType: "single"}
+	}
+
+	// Root-only leaf nested inside a route (container="list") -> NOT guarded: the declared
+	// per-route disable_waf must read back from the API so it round-trips on import.
+	var sb strings.Builder
+	renderUnmarshalSingleChild(&sb, "HTTPLoadBalancer", "RoutesSimpleRouteAdvancedOptions", mk("DisableWaf", "disable_waf"), "advMap", "existingItems[idx]", "len(existingItems) > idx", "list", "\t")
+	if strings.Contains(sb.String(), "if !isImport {") {
+		t.Errorf("root-only leaf disable_waf must NOT be import-suppressed when nested; got:\n%s", sb.String())
+	}
+
+	// Genuinely any-depth suppressed marker (common_buffering) -> STILL guarded nested.
+	var sb2 strings.Builder
+	renderUnmarshalSingleChild(&sb2, "HTTPLoadBalancer", "RoutesSimpleRouteAdvancedOptions", mk("CommonBuffering", "common_buffering"), "advMap", "existingItems[idx]", "len(existingItems) > idx", "list", "\t")
+	if !strings.Contains(sb2.String(), "if !isImport {") {
+		t.Errorf("any-depth marker common_buffering must remain import-suppressed when nested; got:\n%s", sb2.String())
+	}
+
+	// The root suppression is unchanged: at the LB root, disable_waf is an empty-marker
+	// server default and renderUnmarshalTopLevelSingle emits NO populate for it.
+	var sb3 strings.Builder
+	renderUnmarshalTopLevelSingle(&sb3, "HTTPLoadBalancer", mk("DisableWaf", "disable_waf"), "\t")
+	if strings.Contains(sb3.String(), "EmptyModel{}") {
+		t.Errorf("root disable_waf must stay suppressed (no populate) at the resource root; got:\n%s", sb3.String())
+	}
+
+	// Helper contract: disable_waf is root-only; common_buffering / round_robin are not.
+	if !isSuppressionRootOnly("HTTPLoadBalancer", "disable_waf") {
+		t.Error("disable_waf must be root-only-scoped for HTTPLoadBalancer")
+	}
+	if isSuppressionRootOnly("HTTPLoadBalancer", "common_buffering") {
+		t.Error("common_buffering is suppressed at any depth and must NOT be root-only-scoped")
+	}
+	if isSuppressionRootOnly("HTTPLoadBalancer", "round_robin") {
+		t.Error("round_robin is suppressed at any depth and must NOT be root-only-scoped")
 	}
 }
 

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -248,3 +248,31 @@ func isImportDefaultSuppressed(resourceTitleCase, jsonName string) bool {
 	}
 	return members[jsonName]
 }
+
+// suppressionRootOnly scopes a suppressed leaf to the resource ROOT only. A few leaves are a
+// server-default oneof member at the top level (must suppress so a bare resource imports clean)
+// AND a legitimately user-DECLARED oneof arm when nested. Because isImportDefaultSuppressed
+// matches by leaf name at any depth, suppressing such a leaf everywhere strips the nested
+// declared value on import, drifting the next plan.
+//
+// http_loadbalancer disable_waf is the case (#1145): the LB-level WAF oneof default vs. the
+// per-route routes[].{simple_route}.advanced_options "disable WAF for this route" choice. Root
+// single blocks render via renderUnmarshalTopLevelSingle (which keeps suppressing these leaves);
+// nested single blocks — including single blocks inside list elements like routes[] — render via
+// renderUnmarshalSingleChild, which skips suppression for a root-only leaf so the declared nested
+// marker reads back and round-trips. Keep this list tight: only a leaf a live round-trip proves
+// is a DECLARED arm when nested (never a server-default-on-omit there) belongs here.
+var suppressionRootOnly = map[string][]string{
+	"HTTPLoadBalancer": {"disable_waf"},
+}
+
+// isSuppressionRootOnly reports whether the given suppressed leaf must be suppressed only at the
+// resource root (and therefore read back — not suppressed — when nested).
+func isSuppressionRootOnly(resourceTitleCase, jsonName string) bool {
+	for _, leaf := range suppressionRootOnly[resourceTitleCase] {
+		if leaf == jsonName {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -767,7 +767,10 @@ func renderUnmarshalSingleChild(sb *strings.Builder, rc, childPath string, attr 
 		// them causes spurious "was absent, now present" drift on the next plan.
 		// Guard the response-populate with !isImport for those members; omitting a
 		// default member means the server re-applies the same default (safe).
-		suppress := isImportDefaultSuppressed(rc, jsonName)
+		// Root-only leaves (#1145, e.g. disable_waf) are a server default at the resource
+		// root but a DECLARED oneof arm here (nested / inside a list element), so they must
+		// read back and round-trip — skip suppression for them at this nested site.
+		suppress := isImportDefaultSuppressed(rc, jsonName) && !isSuppressionRootOnly(rc, jsonName)
 		popIndent := indent
 		if suppress {
 			sb.WriteString(fmt.Sprintf("%s\tif !isImport {\n", indent))


### PR DESCRIPTION
## Problem

Import-default suppression (`isImportDefaultSuppressed`) matches by leaf name at ANY depth.
Correct for markers the server materializes as a default at every occurrence, but wrong for a
leaf that is BOTH a top-level server default AND a legitimately DECLARED oneof arm when nested —
`http_loadbalancer` **`disable_waf`**: the LB-level WAF oneof default (suppressed so a bare LB
imports clean) vs. the per-route `routes[].{simple_route}.advanced_options` "disable WAF for this
route" choice.

Because suppression is leaf-name-only, a route that declares `disable_waf {}` has it stripped on
import → the next plan drifts (`+ disable_waf {}`). This forced the custom-routes coverage to drop
route-level `waf_mode = disable` (webapp CR-3).

## Fix

Add a `suppressionRootOnly` scope set (`HTTPLoadBalancer` → `disable_waf`): leaves suppressed
ONLY at the resource root.

- Root single blocks render via `renderUnmarshalTopLevelSingle` — unchanged, still suppress.
- Nested single blocks — including single blocks inside list elements like `routes[]` — render
  via `renderUnmarshalSingleChild`, which now skips suppression for a root-only leaf, so a nested
  declared `disable_waf {}` reads back and round-trips clean.

`renderUnmarshalListChild` is untouched: no root-only leaf is itself a list, so path-scoping it
would be dead code.

## Tests (TDD)

- New `TestRenderUnmarshalSingleChild_RootOnlySuppression_Issue1145`: nested `disable_waf` NOT
  guarded; nested `common_buffering` (any-depth marker) STILL guarded; root `disable_waf` still
  emits no populate; helper contract for `isSuppressionRootOnly`.
- Updated `TestRenderUnmarshalSingleChild_ImportSuppressesServerDefault` to use `common_buffering`
  as its any-depth suppressed example (disable_waf is now root-only).
- Confirmed red without the fix (nested disable_waf was suppressed), green with it.
  `go test ./tools/...` passes; gofmt/vet clean.

## Verification (post-release)

Consumer route with `waf_mode=disable` round-trips clean on the f5-sales-demo tenant (webapp CR
re-enable), after this ships via the auto-regenerate PR.

Closes #1145