### PR TITLE
fix(dns_zone): filter F5XC system-managed x-ves-io-managed rr_set_group (closes #1167)

### DIFF
--- a/internal/provider/dns_zone_helpers_test.go
+++ b/internal/provider/dns_zone_helpers_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package provider
+
+import "testing"
+
+// group is a tiny helper to build an rr_set_group element as the flatten sees it
+// (a map[string]interface{} decoded from the API response).
+func rrSetGroup(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{"name": name},
+	}
+}
+
+func TestIsSystemManagedRrSetGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		item map[string]interface{}
+		want bool
+	}{
+		{
+			name: "reserved system group",
+			item: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":        "x-ves-io-managed",
+					"description": "Special RRSetGroup managed by F5XC",
+				},
+			},
+			want: true,
+		},
+		{name: "user group", item: rrSetGroup("demo-records"), want: false},
+		{name: "no metadata", item: map[string]interface{}{}, want: false},
+		{
+			name: "metadata missing name",
+			item: map[string]interface{}{"metadata": map[string]interface{}{}},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSystemManagedRrSetGroup(tc.item); got != tc.want {
+				t.Fatalf("isSystemManagedRrSetGroup(%v) = %v, want %v", tc.item, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterSystemManagedRrSetGroups(t *testing.T) {
+	sys := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "x-ves-io-managed"},
+	}
+
+	t.Run("drops the system group, keeps the user group", func(t *testing.T) {
+		in := []interface{}{rrSetGroup("demo-records"), sys}
+		got := filterSystemManagedRrSetGroups(in)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1 (%v)", len(got), got)
+		}
+		md := got[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		if md["name"] != "demo-records" {
+			t.Fatalf("kept %q, want demo-records", md["name"])
+		}
+	})
+
+	t.Run("preserves user group order when system group is first", func(t *testing.T) {
+		in := []interface{}{sys, rrSetGroup("demo-records")}
+		got := filterSystemManagedRrSetGroups(in)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		md := got[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		if md["name"] != "demo-records" {
+			t.Fatalf("index 0 = %q, want demo-records", md["name"])
+		}
+	})
+
+	t.Run("no system group leaves the list unchanged", func(t *testing.T) {
+		in := []interface{}{rrSetGroup("demo-records"), rrSetGroup("more-records")}
+		got := filterSystemManagedRrSetGroups(in)
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("empty input yields empty output", func(t *testing.T) {
+		if got := filterSystemManagedRrSetGroups(nil); len(got) != 0 {
+			t.Fatalf("len = %d, want 0", len(got))
+		}
+	})
+}

--- a/internal/provider/provider_helpers.go
+++ b/internal/provider/provider_helpers.go
@@ -42,3 +42,40 @@ func filterSystemLabels(labels map[string]string) map[string]string {
 	}
 	return filtered
 }
+
+// systemManagedRrSetGroupName is the reserved name F5 XC gives the rr_set_group it
+// auto-creates in a DNS zone to hold records owned by load balancers (created when
+// a primary block sets allow_http_lb_managed_records = true). The group is
+// platform-owned: any attempt to modify or delete it via the config API returns
+// 403 FORBIDDEN.
+const systemManagedRrSetGroupName = "x-ves-io-managed"
+
+// isSystemManagedRrSetGroup reports whether an rr_set_group element read from the
+// API (as decoded into a map) is the reserved F5 XC system-managed group. The
+// reserved name is the authoritative signal.
+func isSystemManagedRrSetGroup(item map[string]interface{}) bool {
+	md, ok := item["metadata"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	name, _ := md["name"].(string)
+	return name == systemManagedRrSetGroupName
+}
+
+// filterSystemManagedRrSetGroups returns rawList with the F5 XC system-managed
+// rr_set_group ("x-ves-io-managed") removed. Terraform must not surface that group
+// as user-managed state: a config that does not declare it would otherwise plan a
+// delete the API forbids (403). Filtering the raw API list up front (before the
+// flatten loop) keeps prior-state positional threading aligned, since the user
+// never declares the system group. Returns a new slice; the input is not mutated.
+// nolint:unused // Used by generated DNS zone Read/Create/Update methods
+func filterSystemManagedRrSetGroups(rawList []interface{}) []interface{} {
+	filtered := make([]interface{}, 0, len(rawList))
+	for _, item := range rawList {
+		if m, ok := item.(map[string]interface{}); ok && isSystemManagedRrSetGroup(m) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -256,6 +256,20 @@ func isImportDefaultSuppressed(resourceTitleCase, jsonName string) bool {
 	return members[jsonName]
 }
 
+// isSystemManagedFilteredList reports whether the given list member of the given
+// resource holds F5 XC system-managed elements that must be dropped from Terraform
+// state on EVERY refresh path (Read/Create/Update, not just import), so a config
+// that does not declare them does not plan a forbidden delete.
+//
+// DNSZone rr_set_group is the case: when a primary block sets
+// allow_http_lb_managed_records = true, F5 XC auto-creates a reserved
+// "x-ves-io-managed" rr_set_group holding load-balancer-owned records. The caller
+// may not modify or delete it (403 FORBIDDEN), so the generated flatten filters it
+// via filterSystemManagedRrSetGroups (internal/provider/provider_helpers.go).
+func isSystemManagedFilteredList(resourceTitleCase, jsonName string) bool {
+	return resourceTitleCase == "DNSZone" && jsonName == "rr_set_group"
+}
+
 // suppressionRootOnly scopes a suppressed leaf to the resource ROOT only. A few leaves are a
 // server-default oneof member at the top level (must suppress so a bare resource imports clean)
 // AND a legitimately user-DECLARED oneof arm when nested. Because isImportDefaultSuppressed

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -894,6 +894,14 @@ func renderUnmarshalListChild(sb *strings.Builder, rc, childPath string, attr op
 		sb.WriteString(fmt.Sprintf("%s\t}\n", indent))
 	}
 	sb.WriteString(fmt.Sprintf("%s\tif rawList, ok := %s[\"%s\"].([]interface{}); ok && len(rawList) > 0 {\n", indent, srcMap, jsonName))
+	// Drop F5 XC system-managed elements (e.g. the DNS zone "x-ves-io-managed"
+	// rr_set_group) from the raw API list before flattening, so a config that does
+	// not declare them does not plan a forbidden delete. Filtering up front keeps
+	// prior-state positional threading aligned. See isSystemManagedFilteredList and
+	// filterSystemManagedRrSetGroups (internal/provider/provider_helpers.go).
+	if isSystemManagedFilteredList(rc, jsonName) {
+		sb.WriteString(fmt.Sprintf("%s\t\trawList = filterSystemManagedRrSetGroups(rawList)\n", indent))
+	}
 	sb.WriteString(fmt.Sprintf("%s\t\tvar %s []%s\n", indent, resultVar, elemModel))
 	if len(attr.NestedAttributes) == 0 {
 		sb.WriteString(fmt.Sprintf("%s\t\tfor range rawList {\n", indent))


### PR DESCRIPTION
## Problem

`xcsh_dns_zone` with `primary.allow_http_lb_managed_records = true` makes F5 XC
auto-create a reserved system-managed `rr_set_group` named **`x-ves-io-managed`**
(load-balancer-owned records, e.g. www/api). The generated flatten appended every
`rr_set_group` from the API into Terraform state, so a config declaring only its own
group planned to DELETE the system group, and apply failed:

```
Unable to update DNSZone: [FORBIDDEN] Access denied - insufficient permissions
(resource: /api/config/dns/namespaces/system/dns_zones/<zone>) (operation: PUT) (status: 403)
```

Observed live: f5-sales-demo/dns apply-on-main run 29741124417 (tracked in dns#549).

## Fix (generator-level; CLAUDE.md Rule 1 — generated files are not committed)

Mirrors the existing `filterSystemLabels` precedent:

- **`internal/provider/provider_helpers.go`** (hand-maintained): `filterSystemManagedRrSetGroups`
  / `isSystemManagedRrSetGroup`, keyed on the reserved name `x-ves-io-managed`.
- **`tools/pkg/codegen`**: `isSystemManagedFilteredList(rc,jsonName)` gate (beside
  `isImportDefaultSuppressed`) + `renderUnmarshalListChild` emits
  `rawList = filterSystemManagedRrSetGroups(rawList)` for the DNSZone `rr_set_group`
  list — up front so prior-state positional threading stays aligned, on **all** refresh
  paths (Read/Create/Update), not gated on import.

Post-merge `on-merge.yml` (STEP 3, triggered by the `tools/` change) regenerates the
provider and opens the auto-regenerate PR carrying the filter into the generated code.

## Verification

- **TDD** unit test `internal/provider/dns_zone_helpers_test.go` (red → green): drops
  the system group, preserves user-group order when it appears first, leaves
  system-free lists unchanged.
- `go test ./tools/pkg/codegen/...` green (generator).
- `make generate` locally emits the filter in **all three** paths
  (`dns_zone_resource.go` Create@5551 / Read@7906 / Update@11453); `go build ./...` +
  `go test -race ./internal/...` all green with the regenerated code.

## Follow-ups
- Hermetic mock e2e (empty-plan on a zone containing `x-ves-io-managed`) — added after
  regeneration lands, when the committed generated code carries the filter.
- Bump `f5-sales-demo/dns` provider floor to the released version + verify apply green (dns#549).

Closes #1167