### PR TITLE
fix(sync): validate only index-listed specs, not auxiliary data files

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -250,18 +250,28 @@ jobs:
             SPEC_COUNT=$(jq '.specifications | length' "${{ env.SPEC_DIR }}/index.json")
             echo "✅ index.json valid with $SPEC_COUNT domain specifications"
 
-            # Verify each domain file exists and has basic OpenAPI structure
+            # Verify each OpenAPI spec listed in index.json exists and has basic
+            # OpenAPI structure. Iterate index.json's specifications[] (the actual
+            # domain specs) rather than every domains/*.json: the enriched bundle
+            # also ships auxiliary data files (e.g. namespace_profiles.json,
+            # validation.json) that are not OpenAPI documents and legitimately lack
+            # an openapi/swagger key. Validating those hard-fails every real release.
             VALID=true
-            for file in "${{ env.SPEC_DIR }}"/domains/*.json; do
-              if [ -f "$file" ]; then
-                if jq -e '.openapi or .swagger' "$file" > /dev/null 2>&1; then
-                  echo "✅ $(basename "$file") has valid OpenAPI structure"
-                else
-                  echo "❌ $(basename "$file") missing openapi/swagger version"
-                  VALID=false
-                fi
+            while IFS= read -r spec_file; do
+              [ -z "$spec_file" ] && continue
+              file="${{ env.SPEC_DIR }}/domains/$(basename "$spec_file")"
+              if [ ! -f "$file" ]; then
+                echo "❌ $spec_file listed in index.json but not found in domains/"
+                VALID=false
+                continue
               fi
-            done
+              if jq -e '.openapi or .swagger' "$file" > /dev/null 2>&1; then
+                echo "✅ $spec_file has valid OpenAPI structure"
+              else
+                echo "❌ $spec_file missing openapi/swagger version"
+                VALID=false
+              fi
+            done < <(jq -r '.specifications[].file' "${{ env.SPEC_DIR }}/index.json")
             if [ "$VALID" = false ]; then
               echo "::error::Some v2 specs failed structure validation"
               exit 1


### PR DESCRIPTION
## Summary

Final blocker for the OpenAPI auto-sync. After #1178, a real sync run stages the marker and reaches validation — but then **fails** at `Validate OpenAPI specs` and never opens a PR.

Closes #1183

## Root cause

The validate step looped over **every** `docs/specifications/api/domains/*.json` and required a top-level `openapi`/`swagger` key. The enriched bundle also ships auxiliary data files that are **not** OpenAPI documents and are **not** in `index.json.specifications[]`:

- `namespace_profiles.json` — namespace → resource mappings
- `validation.json` — constraints / conditional requirements / enum values (the metadata driving resource naming constraints)

Confirmed against **v2.1.183** (current latest): `domains/` has 40 files = 38 real specs + these 2 → 2 spurious "missing openapi/swagger" failures → step exits 1 → no PR.

## Fix

Validate only the specs listed in `index.json.specifications[].file` (38 for v2.1.183). Auxiliary files are skipped. Also flags any index-listed spec missing from `domains/`.

## Verification

- Simulated the corrected loop against local v2.1.183 specs: **38 validated, 0 failures** (vs. 2 failures with the old glob).
- `actionlint` clean; YAML valid.
- After merge: a `workflow_dispatch` of `sync-openapi.yml` at a version ≠ the marker should now reach PR creation (end-to-end auto-sync proof).
