### PR TITLE
fix: force-replace create/delete-only CSD domain resources (no PUT endpoint)

### DIFF
--- a/tools/import-id-fields.json
+++ b/tools/import-id-fields.json
@@ -1,4 +1,6 @@
 {
   "_comment": "Resources whose create-only spec fields are NOT readable from the API (e.g. GET-by-name returns 501) and therefore cannot be recovered on import from state alone. For these, the import ID carries the field value(s) as trailing '/'-separated segments after namespace/name, so a round-trip import is drift-free. Keyed by resource TitleCase; loaded by tools/pkg/openapi/import_id_fields.go and emitted into ImportState by the codegen. Example import: `terraform import xcsh_protected_domain.x <namespace>/<name>/<protected_domain>`.",
-  "ProtectedDomain": ["protected_domain"]
+  "ProtectedDomain": ["protected_domain"],
+  "MitigatedDomain": ["mitigated_domain"],
+  "AllowedDomain": ["allowed_domain"]
 }

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -25,6 +25,21 @@ type ExtractConfig struct {
 
 // ExtractResourceSchema extracts a Terraform resource schema from an OpenAPI spec.
 // extractAPIPath is passed as a callback because it remains in the monolith.
+// ForceReplaceForCreateDeleteOnly marks every user-settable, non-computed attribute as
+// RequiresReplace. Create/delete-only F5 XC resources (those declared in import-id-fields.json —
+// e.g. the CSD shape/csd domain objects) support only create/list/delete: there is no PUT/update
+// endpoint and no by-name GET. An in-place update therefore 404s ("API Group could not be
+// determined for Method: PUT"), so any field change must force delete+create instead of a phantom
+// update. Computed-only attributes (e.g. id) are left untouched.
+func ForceReplaceForCreateDeleteOnly(attrs []openapi.TerraformAttribute) {
+	for i := range attrs {
+		a := &attrs[i]
+		if (a.Required || a.Optional) && !a.Computed && a.PlanModifier != "RequiresReplace" {
+			a.PlanModifier = "RequiresReplace"
+		}
+	}
+}
+
 func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPath func(spec *openapi.Spec, resourceName string) (string, string, bool)) (*openapi.ResourceTemplate, error) {
 	// Find CreateSpecType schema
 	var createSpec openapi.Schema
@@ -239,6 +254,14 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	}
 
 	attributes = sortedAttrs
+
+	// Create/delete-only resources (declared in import-id-fields.json, because their create-only
+	// spec fields are not readable via the 501 by-name GET) also lack a PUT/update endpoint on the
+	// F5 XC API. Force every settable field to RequiresReplace so terraform reconciles via
+	// delete+create instead of a phantom in-place update that 404s.
+	if len(openapi.LoadImportIDFields(naming.ToResourceTypeName(resourceName))) > 0 {
+		ForceReplaceForCreateDeleteOnly(attributes)
+	}
 
 	// Apply x-f5xc-minimum-configuration to improve Required field accuracy
 	minConfigFields := ParseMinConfigRequiredFields(createSpec.XF5XCMinimumConfiguration)

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -342,3 +342,34 @@ func TestExtractResourceSchema_AutoDerivesPreflightFromRequires(t *testing.T) {
 		t.Error("WhenGoField must be resolved to the Go model field, got empty")
 	}
 }
+
+// TestForceReplaceForCreateDeleteOnly verifies that create/delete-only resources (no PUT/update
+// endpoint on the F5 XC API) get RequiresReplace on every user-settable field, so any change
+// forces delete+create instead of a phantom in-place update that 404s.
+func TestForceReplaceForCreateDeleteOnly(t *testing.T) {
+	attrs := []openapi.TerraformAttribute{
+		{Name: "name", TfsdkTag: "name", Required: true, PlanModifier: "RequiresReplace"},
+		{Name: "namespace", TfsdkTag: "namespace", Required: true, PlanModifier: "RequiresReplace"},
+		{Name: "mitigated_domain", TfsdkTag: "mitigated_domain", Type: "string", Required: true},
+		{Name: "description", TfsdkTag: "description", Type: "string", Optional: true},
+		{Name: "disable", TfsdkTag: "disable", Type: "bool", Optional: true},
+		{Name: "labels", TfsdkTag: "labels", Type: "map", Optional: true},
+		{Name: "annotations", TfsdkTag: "annotations", Type: "map", Optional: true},
+		{Name: "id", TfsdkTag: "id", Type: "string", Computed: true, PlanModifier: "UseStateForUnknown"},
+	}
+	ForceReplaceForCreateDeleteOnly(attrs)
+
+	for _, tag := range []string{"mitigated_domain", "description", "disable", "labels", "annotations", "name", "namespace"} {
+		a := findAttr(attrs, tag)
+		if a == nil {
+			t.Fatalf("attr %q missing", tag)
+		}
+		if a.PlanModifier != "RequiresReplace" {
+			t.Errorf("attr %q: PlanModifier = %q, want RequiresReplace", tag, a.PlanModifier)
+		}
+	}
+	// Computed id must NOT be forced to replace.
+	if id := findAttr(attrs, "id"); id == nil || id.PlanModifier != "UseStateForUnknown" {
+		t.Errorf("computed id must keep UseStateForUnknown, got %v", id)
+	}
+}


### PR DESCRIPTION
## Problem

CSD domain resources (`xcsh_mitigated_domain`, `xcsh_allowed_domain`, `xcsh_protected_domain`) are create/delete-only on the F5 XC API — raw-probe verified across all three:

| Verb | Result |
| --- | --- |
| POST / GET list / DELETE by-name | 200 |
| GET by-name | **501 not implemented** |
| PUT (update) | **404 API Group could not be determined for Method: PUT** |

The generator emits a standard `Update` (PUT), so any field change — including the post-import reconcile — fails: `Unable to update MitigatedDomain: [NOT_FOUND]`. This breaks the build-via-API → `terraform import` → manage-as-code workflow.

("Spec has no PUT" is not a usable signal — `http_loadbalancer` et al. also omit spec-PUT but the server supports update. The set must be explicit.)

## Fix (source-only; generated code lands via auto-regenerate)

- Reuse `tools/import-id-fields.json` as the registry of create/delete-only resources. `ForceReplaceForCreateDeleteOnly` (in `tools/pkg/schema/extract.go`) marks every settable attribute `RequiresReplace` for those resources → changes reconcile via delete+create (both endpoints exist), never the phantom PUT.
- Add `MitigatedDomain` + `AllowedDomain` to the registry (extended import ID `namespace/name/<domain>`; `ProtectedDomain` already present).

## Verification

- Unit test `TestForceReplaceForCreateDeleteOnly`; `go test ./tools/...` green.
- Local build (main + the 3 regenerated CSD resources) against the live tenant:
  - `terraform import <ns>/<name>/<domain>` → **Import successful**.
  - Apply reconcile → **delete+create succeeds** (the old path errored `NOT_FOUND` here) → re-plan **0-change**.
  - protected_domain (minimal config) imports at **0-change** directly.

Closes #1189
🤖 Generated with [Claude Code](https://claude.com/claude-code)