### PR TITLE
fix(generator): recognize /api/register/ CRUD paths (generates xcsh_token + xcsh_registration)

### DIFF
--- a/tools/pkg/openapi/openapi_test.go
+++ b/tools/pkg/openapi/openapi_test.go
@@ -806,3 +806,28 @@ func TestExtractResourcePaths_ShapeServiceCSD(t *testing.T) {
 		}
 	}
 }
+
+// Site registration tokens and registration objects live under /api/register/
+// (not /api/config/), so resource discovery must recognize the register pattern.
+// Without it, xcsh_token and xcsh_registration are never generated (see #1212).
+// The token spec also exposes {metadata.namespace} path variants alongside the
+// {namespace} forms; the {namespace} collection/item paths are what drive CRUD
+// detection, so the resource is discovered even though the dotted variant is not.
+func TestExtractResourcePaths_RegisterService(t *testing.T) {
+	paths := map[string]interface{}{
+		"/api/register/namespaces/{namespace}/tokens":               map[string]interface{}{"post": map[string]interface{}{}, "get": map[string]interface{}{}},
+		"/api/register/namespaces/{namespace}/tokens/{name}":        map[string]interface{}{"get": map[string]interface{}{}, "put": map[string]interface{}{}, "delete": map[string]interface{}{}},
+		"/api/register/namespaces/{metadata.namespace}/tokens":      map[string]interface{}{"post": map[string]interface{}{}},
+		"/api/register/namespaces/{namespace}/registrations":        map[string]interface{}{"post": map[string]interface{}{}, "get": map[string]interface{}{}},
+		"/api/register/namespaces/{namespace}/registrations/{name}": map[string]interface{}{"get": map[string]interface{}{}, "delete": map[string]interface{}{}},
+	}
+	got := map[string]bool{}
+	for _, rp := range extractResourcePathsFromPaths(paths) {
+		got[rp.ResourceName] = true
+	}
+	for _, want := range []string{"token", "registration"} {
+		if !got[want] {
+			t.Errorf("expected register-service resource %q to be discovered; got %v", want, got)
+		}
+	}
+}

--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -223,27 +223,27 @@ func ParseDomainSpec(path string) (*DomainSpec, error) {
 
 // DomainSpecInfo contains parsed information about a domain and its resources.
 type DomainSpecInfo struct {
-	DomainName    string
-	Category      string
-	RequiresTier  string
-	Complexity    string
-	IsPreview     bool
-	Resources     []ExtractedResource
-	SourceFile    string
-	Spec          *DomainSpec
+	DomainName   string
+	Category     string
+	RequiresTier string
+	Complexity   string
+	IsPreview    bool
+	Resources    []ExtractedResource
+	SourceFile   string
+	Spec         *DomainSpec
 }
 
 // ExtractedResource contains information about a single resource extracted from a domain.
 type ExtractedResource struct {
-	Name             string
-	SchemaName       string  // Full schema name in components/schemas
-	Description      string
-	APIPath          string
-	RequiresTier     string
-	Complexity       string
-	Category         string  // Inherited from domain if not specified
-	IsPreview        bool    // Inherited from domain if not specified
-	DomainName       string  // Parent domain
+	Name         string
+	SchemaName   string // Full schema name in components/schemas
+	Description  string
+	APIPath      string
+	RequiresTier string
+	Complexity   string
+	Category     string // Inherited from domain if not specified
+	IsPreview    bool   // Inherited from domain if not specified
+	DomainName   string // Parent domain
 }
 
 // ExtractResourcesFromDomain parses a domain spec and extracts resource information.
@@ -278,10 +278,10 @@ func ExtractResourcesFromDomain(specPath string) (*DomainSpecInfo, error) {
 			SchemaName:   rp.SchemaName,
 			APIPath:      rp.APIPath,
 			DomainName:   domainName,
-			Category:     info.Category,    // Inherit from domain
-			IsPreview:    info.IsPreview,   // Inherit from domain
+			Category:     info.Category,     // Inherit from domain
+			IsPreview:    info.IsPreview,    // Inherit from domain
 			RequiresTier: info.RequiresTier, // Inherit from domain
-			Complexity:   info.Complexity,  // Inherit from domain
+			Complexity:   info.Complexity,   // Inherit from domain
 		}
 
 		// Try to get description from schema if available
@@ -338,6 +338,14 @@ func extractResourcePathsFromPaths(paths map[string]interface{}) []resourcePath 
 	// preserved as the resource's APIPath so the client targets /api/shape/... correctly.
 	shapeServicePathRegex := regexp.MustCompile(`^/api/shape/[a-z_0-9]+/namespaces/\{namespace\}/([a-z_0-9]+s)$`)
 
+	// Register pattern: /api/register/namespaces/{namespace}/{resource_plural}
+	// (e.g. tokens, registrations). Site-registration objects (the CE registration
+	// token and the registration record) live under /api/register/, not /api/config/.
+	// Without this the generator never emits xcsh_token / xcsh_registration. See #1212.
+	// The token spec also exposes {metadata.namespace} variants; the {namespace} form
+	// above is what drives detection, so the dotted variant is simply ignored here.
+	registerPathRegex := regexp.MustCompile(`^/api/register/namespaces/\{namespace\}/([a-z_0-9]+s)$`)
+
 	for path := range paths {
 		var resourcePlural string
 
@@ -352,6 +360,9 @@ func extractResourcePathsFromPaths(paths map[string]interface{}) []resourcePath 
 			resourcePlural = matches[1]
 		} else if matches := shapeServicePathRegex.FindStringSubmatch(path); len(matches) >= 2 {
 			// Shape-service resources (e.g. Client-Side Defense protected_domains)
+			resourcePlural = matches[1]
+		} else if matches := registerPathRegex.FindStringSubmatch(path); len(matches) >= 2 {
+			// Register-service resources (token, registration)
 			resourcePlural = matches[1]
 		} else {
 			continue


### PR DESCRIPTION
Closes #1212. Part of epic #1207.

## Problem

`tools/pkg/openapi/parser.go:extractResourcePathsFromPaths` detected CRUD resources for only four path families — `/api/config/...`, `/api/config/{service}/...`, `/api/web/...`, `/api/shape/{service}/...`. The `token` and `registration` APIs live under **`/api/register/`**, so no resource was extracted from them. That — not domain routing — is why `xcsh_token` and `xcsh_registration` do not exist today (`ls internal/provider | grep -iE '^(token|registration)'` → NONE).

## Fix

Add `registerPathRegex` (`^/api/register/namespaces/\{namespace\}/([a-z_0-9]+s)$`) as a fifth branch, preserving the full `/api/register/...` path as the resource `APIPath` (mirrors the existing shape/service handling). Generator-source only.

## Verification

- **TDD**: `TestExtractResourcePaths_RegisterService` — red before the fix (`got map[]`), green after. Mirrors the existing `TestExtractResourcePaths_ShapeServiceCSD`.
- **End-to-end dry-run** against the current enriched specs (`generate-all-schemas.go --dry-run`):
  - `ce_management` → `✅ registration: 8 attrs, 2 blocks` (schema `schemaregistrationCreateSpecType`)
  - `users` → `✅ token: 7 attrs, 0 blocks` (schema `tokenCreateSpecType`)
- `gofmt` clean; `go vet ./tools/pkg/openapi/` clean; `go test ./tools/...` all pass (no regression to config/web/shape extraction).

## Scope notes

- **Source-only**: the regenerated `token_resource.go` / `registration_resource.go` (+ client types) land via the post-merge `on-merge.yml` auto-regeneration flow — the constitution check blocks manual generated-file commits on feature branches.
- The base `xcsh_registration` this unblocks is a prerequisite for `xcsh_registration_approval` (#1206), whose `/approve` CustomAPI action still needs the separate action-resource codegen. Closes #1205's blocker (`xcsh_token` generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)