### PR TITLE
Expose token system_metadata.uid as a computed uid attribute

### DIFF
--- a/tools/expose-uid.json
+++ b/tools/expose-uid.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Resources whose server-generated system_metadata.uid must be surfaced as a Computed, read-only `uid` Terraform attribute. Keyed by resource TitleCase. The generator only emits uid when BOTH this file opts the resource in AND its response schema (e.g. <resource>GetResponse) actually carries system_metadata.uid, so the mechanism is schema-driven yet surgically scoped. Loaded by tools/pkg/openapi/expose_uid.go; the schema guard lives in schema.ResponseHasSystemMetadataUID. Token opts in because a Customer Edge registers with the token VALUE, which is system_metadata.uid (the object's own `id`/name is not the token value). See docs-control issue #1224.",
+  "Token": true
+}

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -3,6 +3,8 @@
 package codegen
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -1108,5 +1110,52 @@ func TestRenderUnmarshalScalarChild_MeaningfulZeroInt64_Issue1129(t *testing.T) 
 	renderUnmarshalScalarChild(&ctl, "HTTPLoadBalancer", ctlAttr, "m", "", "", "list", "\t")
 	if !strings.Contains(ctl.String(), "ok && v != 0") {
 		t.Errorf("non-meaningful-zero int64 (timeout) must keep the `v != 0` guard; got:\n%s", ctl.String())
+	}
+}
+
+// TestGenerateClientTypes_ExposeUID verifies that when a resource opts in to
+// ExposeUID, the generated client type carries a SystemMetadata field and a
+// per-resource *SystemMetadata type with a uid; and that a resource without
+// ExposeUID is unchanged (no SystemMetadata anywhere).
+func TestGenerateClientTypes_ExposeUID(t *testing.T) {
+	base := &openapi.ResourceTemplate{
+		Name:               "token",
+		TitleCase:          "Token",
+		APIPath:            "/api/register/namespaces/%s/tokens",
+		APIPathItem:        "/api/register/namespaces/%s/tokens/%s",
+		HasNamespaceInPath: true,
+	}
+
+	render := func(exposeUID bool) string {
+		r := *base
+		r.ExposeUID = exposeUID
+		dir := t.TempDir()
+		if err := GenerateClientTypes(&r, dir); err != nil {
+			t.Fatalf("GenerateClientTypes error: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "token_types.go"))
+		if err != nil {
+			t.Fatalf("reading generated file: %v", err)
+		}
+		return string(data)
+	}
+
+	with := render(true)
+	// Substrings chosen to survive gofmt column alignment of struct fields.
+	for _, want := range []string{
+		"SystemMetadata *TokenSystemMetadata",
+		"json:\"system_metadata,omitempty\"",
+		"type TokenSystemMetadata struct",
+		"UID string",
+		"json:\"uid,omitempty\"",
+	} {
+		if !strings.Contains(with, want) {
+			t.Errorf("ExposeUID=true output missing %q; got:\n%s", want, with)
+		}
+	}
+
+	without := render(false)
+	if strings.Contains(without, "SystemMetadata") {
+		t.Errorf("ExposeUID=false output must not mention SystemMetadata; got:\n%s", without)
 	}
 }

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -335,6 +335,14 @@ func (r *{{.TitleCase}}Resource) Create(ctx context.Context, req resource.Create
 	// For resources without namespace in API path, namespace is computed from API response
 	data.Namespace = types.StringValue(apiResource.Metadata.Namespace)
 {{- end}}
+{{- if .ExposeUID}}
+	// Surface the server-generated system_metadata.uid as the read-only uid attribute.
+	if apiResource.SystemMetadata != nil {
+		data.Uid = types.StringValue(apiResource.SystemMetadata.UID)
+	} else {
+		data.Uid = types.StringNull()
+	}
+{{- end}}
 
 	// Unmarshal spec fields from API response to Terraform state
 	// This ensures computed nested fields (like tenant in Object Reference blocks) have known values
@@ -393,6 +401,14 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 	data.ID = types.StringValue(apiResource.Metadata.Name)
 	data.Name = types.StringValue(apiResource.Metadata.Name)
 	data.Namespace = types.StringValue(apiResource.Metadata.Namespace)
+{{- if .ExposeUID}}
+	// Surface the server-generated system_metadata.uid as the read-only uid attribute.
+	if apiResource.SystemMetadata != nil {
+		data.Uid = types.StringValue(apiResource.SystemMetadata.UID)
+	} else {
+		data.Uid = types.StringNull()
+	}
+{{- end}}
 
 	// Read description from metadata
 	if apiResource.Metadata.Description != "" {
@@ -517,6 +533,14 @@ func (r *{{.TitleCase}}Resource) Update(ctx context.Context, req resource.Update
 
 	// Unmarshal spec fields from fetched resource to Terraform state
 	apiResource = fetched // Use GET response which includes all computed fields
+{{- if .ExposeUID}}
+	// Surface the server-generated system_metadata.uid as the read-only uid attribute.
+	if apiResource.SystemMetadata != nil {
+		data.Uid = types.StringValue(apiResource.SystemMetadata.UID)
+	} else {
+		data.Uid = types.StringNull()
+	}
+{{- end}}
 	isImport := false // Update is never an import
 	_ = isImport // May be unused if resource has no blocks needing import detection
 {{renderSpecUnmarshalCode .Attributes "\t" .TitleCase}}
@@ -672,7 +696,19 @@ import (
 type {{.TitleCase}} struct {
 	Metadata Metadata               ` + "`" + `json:"metadata"` + "`" + `
 	Spec     map[string]interface{} ` + "`" + `json:"spec"` + "`" + `
+{{- if .ExposeUID}}
+	SystemMetadata *{{.TitleCase}}SystemMetadata ` + "`" + `json:"system_metadata,omitempty"` + "`" + `
+{{- end}}
 }
+{{- if .ExposeUID}}
+
+// {{.TitleCase}}SystemMetadata carries server-generated object metadata returned in
+// {{.TitleCase}} API responses. Only uid is surfaced: it is the value a consumer needs
+// (e.g. the token value a Customer Edge registers with).
+type {{.TitleCase}}SystemMetadata struct {
+	UID string ` + "`" + `json:"uid,omitempty"` + "`" + `
+}
+{{- end}}
 
 // Create{{.TitleCase}} creates a new {{.TitleCase}}
 func (c *Client) Create{{.TitleCase}}(ctx context.Context, resource *{{.TitleCase}}) (*{{.TitleCase}}, error) {
@@ -761,6 +797,9 @@ type {{.TitleCase}}DataSourceModel struct {
 	Description types.String ` + "`" + `tfsdk:"description"` + "`" + `
 	Labels      types.Map    ` + "`" + `tfsdk:"labels"` + "`" + `
 	Annotations types.Map    ` + "`" + `tfsdk:"annotations"` + "`" + `
+{{- if .ExposeUID}}
+	Uid         types.String ` + "`" + `tfsdk:"uid"` + "`" + `
+{{- end}}
 }
 
 func (d *{{.TitleCase}}DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -797,6 +836,12 @@ func (d *{{.TitleCase}}DataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:            true,
 				ElementType:         types.StringType,
 			},
+{{- if .ExposeUID}}
+			"uid": schema.StringAttribute{
+				MarkdownDescription: "Server-generated unique identifier (system_metadata.uid).",
+				Computed:            true,
+			},
+{{- end}}
 		},
 	}
 }
@@ -827,6 +872,13 @@ func (d *{{.TitleCase}}DataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	data.ID = types.StringValue(resource.Metadata.Name)
+{{- if .ExposeUID}}
+	if resource.SystemMetadata != nil {
+		data.Uid = types.StringValue(resource.SystemMetadata.UID)
+	} else {
+		data.Uid = types.StringNull()
+	}
+{{- end}}
 	data.Name = types.StringValue(resource.Metadata.Name)
 	data.Namespace = types.StringValue(resource.Metadata.Namespace)
 	if resource.Metadata.Description != "" {

--- a/tools/pkg/openapi/expose_uid.go
+++ b/tools/pkg/openapi/expose_uid.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// Most F5 XC objects carry a server-generated system_metadata.uid, but the
+// generator surfaces it as a Terraform attribute only for the handful of
+// resources where that uid is the value a consumer actually needs (e.g. a CE
+// registration token: the token VALUE is system_metadata.uid, not the object's
+// name). tools/expose-uid.json (keyed by resource TitleCase) opts those
+// resources in; the codegen additionally verifies the response schema really
+// carries system_metadata.uid (schema.ResponseHasSystemMetadataUID) before
+// emitting anything, so the opt-in list stays schema-driven and surgically
+// scoped. See RequirementPreflight / LoadImportIDFields for the sibling
+// data-driven codegen patterns.
+
+var (
+	exposeUIDOnce sync.Once
+	exposeUIDMap  map[string]bool
+)
+
+func loadExposeUID() {
+	exposeUIDMap = map[string]bool{}
+	if _, file, _, ok := runtime.Caller(0); ok {
+		jsonPath := filepath.Join(filepath.Dir(file), "..", "..", "expose-uid.json")
+		if data, err := os.ReadFile(jsonPath); err == nil {
+			exposeUIDMap = parseExposeUIDJSON(data)
+		}
+	}
+}
+
+// parseExposeUIDJSON decodes the data file into resource -> bool, skipping the
+// string "_comment" documentation key.
+func parseExposeUIDJSON(data []byte) map[string]bool {
+	out := map[string]bool{}
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return out
+	}
+	for resource, rawVal := range raw {
+		if resource == "_comment" {
+			continue
+		}
+		var enabled bool
+		if json.Unmarshal(rawVal, &enabled) == nil {
+			out[resource] = enabled
+		}
+	}
+	return out
+}
+
+// LoadExposeUID reports whether the resource (by TitleCase) is opted in to
+// surfacing system_metadata.uid as a Computed `uid` attribute.
+func LoadExposeUID(resourceTitleCase string) bool {
+	exposeUIDOnce.Do(loadExposeUID)
+	return exposeUIDMap[resourceTitleCase]
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -200,6 +200,15 @@ type ResourceTemplate struct {
 	// so their values ride in the import ID as trailing segments after namespace/name.
 	// Loaded from tools/import-id-fields.json keyed by TitleCase; see import_id_fields.go.
 	ImportIDExtraFields []string
+
+	// ExposeUID makes the generator surface the object's server-generated
+	// system_metadata.uid as a Computed, read-only `uid` attribute, carry it on the
+	// client struct (SystemMetadata), and populate it from the Create/Get response.
+	// It is opt-in per resource (tools/expose-uid.json, keyed by TitleCase) AND
+	// gated on the response schema actually carrying system_metadata.uid, so it
+	// stays surgically scoped and never emits a uid a resource cannot return.
+	// See tools/pkg/openapi/expose_uid.go and schema.ResponseHasSystemMetadataUID.
+	ExposeUID bool
 }
 
 // RequirementPreflight is one apply-time prerequisite the provider verifies

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -215,6 +215,25 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 			Description: "Unique identifier for the resource.", Computed: true, PlanModifier: "UseStateForUnknown"},
 	}
 
+	// Surface the object's server-generated system_metadata.uid as a Computed,
+	// read-only `uid` attribute — but only when the resource is opted in
+	// (tools/expose-uid.json) AND its response schema actually carries
+	// system_metadata.uid. This keeps the mechanism schema-driven yet surgically
+	// scoped: `id` is the object name, whereas `uid` is the value a consumer such
+	// as a CE registration flow needs. It is not a spec field, so it is excluded
+	// from spec marshal/unmarshal and populated directly from the API response.
+	exposeUID := openapi.LoadExposeUID(naming.ToResourceTypeName(resourceName)) &&
+		ResponseHasSystemMetadataUID(spec, resourceName)
+	if exposeUID {
+		computedAttrs = append(computedAttrs, openapi.TerraformAttribute{
+			Name: "uid", GoName: "Uid", TfsdkTag: "uid", Type: "string",
+			Description:  "Server-generated unique identifier (`system_metadata.uid`). Read-only; assigned by F5 Distributed Cloud on creation.",
+			Computed:     true,
+			PlanModifier: "UseStateForUnknown",
+			IsSpecField:  false,
+		})
+	}
+
 	// Combine: ID components first, then other required, then optional (incl. standard), then computed
 	var sortedAttrs []openapi.TerraformAttribute
 	sortedAttrs = append(sortedAttrs, idComponentAttrs...)
@@ -339,6 +358,7 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 		TitleCase:               titleCase,
 		Preflights:              preflights,
 		ImportIDExtraFields:     openapi.LoadImportIDFields(titleCase),
+		ExposeUID:               exposeUID,
 		APIPath:                 apiPath,
 		APIPathPlural:           resourceName + "s",
 		APIPathItem:             apiPathItem,
@@ -494,6 +514,50 @@ func ExtractReadOnlyResourceSchema(spec *openapi.Spec, resourceName string, extr
 		Attributes:         allAttrs,
 		IsReadOnly:         true,
 	}, nil
+}
+
+// ResponseHasSystemMetadataUID reports whether the resource's API response
+// envelope carries a system_metadata object with a uid property. F5 XC response
+// schemas wrap system_metadata as an allOf-$ref to a shared system-metadata type
+// (e.g. schemaSystemObjectGetMetaType) whose properties include uid. This is the
+// schema guard behind ExposeUID: the generator only surfaces uid when the object
+// can actually return it. Checks the Get and Create response envelopes and the
+// object schema, resolving refs via ResolveRef (spec components then SchemaCache).
+func ResponseHasSystemMetadataUID(spec *openapi.Spec, resourceName string) bool {
+	candidates := []string{
+		resourceName + "GetResponse",
+		"schema" + resourceName + "GetResponse",
+		resourceName + "CreateResponse",
+		"schema" + resourceName + "CreateResponse",
+		resourceName + "Object",
+	}
+	for _, name := range candidates {
+		envelope, ok := spec.Components.Schemas[name]
+		if !ok {
+			continue
+		}
+		sm, ok := envelope.Properties["system_metadata"]
+		if !ok {
+			continue
+		}
+		// system_metadata is typically an allOf-wrapped $ref; unwrap it.
+		if sm.Ref == "" && len(sm.AllOf) > 0 {
+			for _, item := range sm.AllOf {
+				if item.Ref != "" {
+					sm.Ref = item.Ref
+					break
+				}
+			}
+		}
+		target := sm
+		if sm.Ref != "" {
+			target = ResolveRef(sm.Ref, spec)
+		}
+		if _, ok := target.Properties["uid"]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtractOneOfGroups extracts x-ves-oneof-field annotations from the raw schema JSON.

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -143,6 +143,103 @@ func TestExtractResourceSchema_UnverifiedSingleAllowedStaysRequired(t *testing.T
 	}
 }
 
+// tokenLikeSpec builds a spec shaped like the F5 XC token domain: an (empty)
+// CreateSpecType plus a GetResponse envelope whose system_metadata is an
+// allOf-$ref to a shared system-metadata type carrying uid.
+func tokenLikeSpec(resourceName string, withSystemMetadataUID bool) (*openapi.Spec, func(*openapi.Spec, string) (string, string, bool)) {
+	schemas := map[string]openapi.Schema{
+		resourceName + "CreateSpecType": {
+			Type:       "object",
+			Properties: map[string]openapi.Schema{},
+		},
+		"schemaSystemObjectGetMetaType": {
+			Type: "object",
+			Properties: map[string]openapi.Schema{
+				"uid":    {Type: "string"},
+				"tenant": {Type: "string"},
+			},
+		},
+	}
+	getResp := openapi.Schema{Type: "object", Properties: map[string]openapi.Schema{
+		"metadata": {Type: "object"},
+		"spec":     {Type: "object"},
+	}}
+	if withSystemMetadataUID {
+		getResp.Properties["system_metadata"] = openapi.Schema{
+			AllOf: []openapi.Schema{{Ref: "#/components/schemas/schemaSystemObjectGetMetaType"}},
+		}
+	}
+	schemas[resourceName+"GetResponse"] = getResp
+	spec := &openapi.Spec{Components: openapi.Components{Schemas: schemas}}
+	extractAPIPath := func(_ *openapi.Spec, _ string) (string, string, bool) {
+		return "/api/register/namespaces/%s/" + resourceName + "s",
+			"/api/register/namespaces/%s/" + resourceName + "s/%s", true
+	}
+	return spec, extractAPIPath
+}
+
+// ResponseHasSystemMetadataUID resolves the allOf-wrapped system_metadata ref and
+// reports whether it carries uid.
+func TestResponseHasSystemMetadataUID(t *testing.T) {
+	specYes, _ := tokenLikeSpec("token", true)
+	if !ResponseHasSystemMetadataUID(specYes, "token") {
+		t.Error("expected true when GetResponse.system_metadata carries uid")
+	}
+	specNo, _ := tokenLikeSpec("token", false)
+	if ResponseHasSystemMetadataUID(specNo, "token") {
+		t.Error("expected false when the response envelope has no system_metadata")
+	}
+}
+
+// The token resource (opted in via tools/expose-uid.json AND schema-verified)
+// gains a Computed, read-only `uid` attribute and ExposeUID=true; the uid is not
+// a spec field. A resource NOT opted in is unchanged (no uid, ExposeUID=false).
+func TestExtractResourceSchema_ExposesUIDForToken(t *testing.T) {
+	namespace.ClearProfiles()
+	defer namespace.ClearProfiles()
+
+	spec, extractAPIPath := tokenLikeSpec("token", true)
+	result, err := ExtractResourceSchema(spec, "token", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.ExposeUID {
+		t.Error("ResourceTemplate.ExposeUID should be true for token")
+	}
+	uid := findAttr(result.Attributes, "uid")
+	if uid == nil {
+		t.Fatal("uid attribute missing")
+	}
+	if !uid.Computed || uid.Required || uid.Optional {
+		t.Errorf("uid must be Computed-only, got Computed=%v Required=%v Optional=%v", uid.Computed, uid.Required, uid.Optional)
+	}
+	if uid.IsSpecField {
+		t.Error("uid must not be a spec field (excluded from spec marshal/unmarshal)")
+	}
+	if uid.GoName != "Uid" || uid.Type != "string" {
+		t.Errorf("uid GoName/Type = %q/%q, want Uid/string", uid.GoName, uid.Type)
+	}
+}
+
+// A resource that is NOT opted in gets no uid attribute even if its response
+// schema carries system_metadata.uid — scoping is opt-in, not schema-wide.
+func TestExtractResourceSchema_NoUIDWhenNotOptedIn(t *testing.T) {
+	namespace.ClearProfiles()
+	defer namespace.ClearProfiles()
+
+	spec, extractAPIPath := tokenLikeSpec("not_opted_in_res", true)
+	result, err := ExtractResourceSchema(spec, "not_opted_in_res", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExposeUID {
+		t.Error("ExposeUID must be false for a resource not in expose-uid.json")
+	}
+	if findAttr(result.Attributes, "uid") != nil {
+		t.Error("non-opted-in resource must not gain a uid attribute")
+	}
+}
+
 func TestExtractOneOfGroups_Empty(t *testing.T) {
 	spec := &openapi.Spec{}
 	result := ExtractOneOfGroups(spec, "NonExistent")


### PR DESCRIPTION
Closes #1224

## Root cause

`xcsh_token` exposes only `name`/`namespace`/`labels`/`description`/`id`, where `id = metadata.name`. The value a Customer Edge needs to register is the token's `system_metadata.uid`. The token API responses carry it (`tokenGetResponse`/`tokenCreateResponse` have a `system_metadata` field resolving to `schemaSystemObjectGetMetaType`, which has `uid`), but the generator dropped it: the client `Token` struct was `{Metadata, Spec}` only, so `system_metadata` was silently discarded on unmarshal and never reached Terraform state.

## The generator change

A scoped, schema-driven mechanism to surface an object's own `system_metadata.uid` as a **Computed, read-only `uid`** attribute:

- `openapi.ResourceTemplate.ExposeUID` + new `tools/expose-uid.json` (keyed by TitleCase, mirrors the existing `import-id-fields.json` / `preflight-requirements.json` config pattern) opts a resource in — seeded with **only `Token`**.
- `schema.ResponseHasSystemMetadataUID` resolves the allOf-wrapped `system_metadata` `$ref` and verifies the response envelope actually carries `uid`, so an opt-in never emits a `uid` the resource cannot return.
- `ExtractResourceSchema` appends a Computed `uid` attribute (`IsSpecField:false`, so excluded from spec marshal/unmarshal) only when both hold.
- Templates: the client `Token` gains `SystemMetadata *TokenSystemMetadata{ UID }`; the resource `Create`/`Read`/`Update` and the data source populate `data.Uid` from the API response.

## Why scoped, not schema-wide

Nearly every F5 XC object carries `system_metadata.uid` (192 of 202 `*GetResponse` envelopes), so a raw schema predicate would rewrite ~all resources. The opt-in list restricts the blast radius to `token` alone while keeping the emission schema-verified.

## Surgical-scope proof

Baseline generator vs this change, both run against `docs/specifications/api` into temp dirs, `diff -rq`:

```
Files .../client/token_types.go differ
Files .../provider/token_data_source.go differ
Files .../provider/token_resource.go differ
```

Only the three token files change; no other resource's generated output moves. The generated code was compile-checked in-tree (`go build ./internal/...` clean) then reverted (generated files land via on-merge auto-regen).

Generated `uid` attribute (from the dry-run output):

```go
"uid": schema.StringAttribute{
    MarkdownDescription: "Server-generated unique identifier (`system_metadata.uid`). Read-only; assigned by F5 Distributed Cloud on creation.",
    Computed:            true,
    PlanModifiers: []planmodifier.String{
        stringplanmodifier.UseStateForUnknown(),
    },
},
```

## Gate outputs

- `gofmt -l` on changed files: clean
- `go vet ./tools/...`: clean
- `go test ./tools/...`: all pass (new schema + codegen tests; no regressions)

## TDD

Red first (undefined `ResponseHasSystemMetadataUID` / `ExposeUID`), then green. Schema tests assert `ResponseHasSystemMetadataUID` true/false and that token gains a Computed non-spec `uid` while a non-opted-in resource is unchanged; a codegen test asserts the client type carries `SystemMetadata` when opted in and is untouched otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)