### PR TITLE
S1b: emit int64 range validators incl. minimum:0; gate ./tools/... in CI

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -55,8 +55,10 @@ jobs:
       - name: Set result
         id: result
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
         run: |
-          if [ "${{ job.status }}" == "success" ]; then
+          if [ "$JOB_STATUS" == "success" ]; then
             echo "success=true" >> "$GITHUB_OUTPUT"
           else
             echo "success=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -50,7 +50,7 @@ jobs:
         run: scripts/go-retry.sh 3 go build -v .
 
       - name: Test
-        run: scripts/go-retry.sh 2 go test -v -race ./internal/...
+        run: scripts/go-retry.sh 2 go test -v -race ./internal/... ./tools/...
 
       - name: Set result
         id: result

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build:
 # Run tests
 test:
 	@echo "Running tests..."
-	$(GO) test -v -race ./internal/...
+	$(GO) test -v -race ./internal/... ./tools/...
 
 # Run linters
 lint:

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -1159,3 +1159,13 @@ func TestGenerateClientTypes_ExposeUID(t *testing.T) {
 		t.Errorf("ExposeUID=false output must not mention SystemMetadata; got:\n%s", without)
 	}
 }
+
+func TestRenderNestedAttributes_Int64MinZero(t *testing.T) {
+	attrs := []openapi.TerraformAttribute{
+		{GoName: "Priority", TfsdkTag: "priority", Type: "int64", Minimum: 0, HasMinimum: true, Maximum: 255, HasMaximum: true},
+	}
+	got := RenderNestedAttributes(attrs, "\t")
+	if !strings.Contains(got, "int64validator.Between(0, 255)") {
+		t.Errorf("expected int64validator.Between(0, 255), got:\n%s", got)
+	}
+}

--- a/tools/pkg/codegen/render.go
+++ b/tools/pkg/codegen/render.go
@@ -1071,6 +1071,20 @@ func RenderNestedAttributes(attrs []openapi.TerraformAttribute, indent string) s
 			sb.WriteString(fmt.Sprintf("%s\t\t},\n", indent))
 		}
 
+		// int64 range validators. Gated on presence flags (not value > 0) so a
+		// legitimate minimum:0 still emits AtLeast(0)/Between(0, N).
+		if attr.Type == "int64" && (attr.HasMinimum || attr.HasMaximum) {
+			sb.WriteString(fmt.Sprintf("%s\t\tValidators: []validator.Int64{\n", indent))
+			if attr.HasMinimum && attr.HasMaximum {
+				sb.WriteString(fmt.Sprintf("%s\t\t\tint64validator.Between(%d, %d),\n", indent, attr.Minimum, attr.Maximum))
+			} else if attr.HasMaximum {
+				sb.WriteString(fmt.Sprintf("%s\t\t\tint64validator.AtMost(%d),\n", indent, attr.Maximum))
+			} else {
+				sb.WriteString(fmt.Sprintf("%s\t\t\tint64validator.AtLeast(%d),\n", indent, attr.Minimum))
+			}
+			sb.WriteString(fmt.Sprintf("%s\t\t},\n", indent))
+		}
+
 		sb.WriteString(fmt.Sprintf("%s\t},\n", indent))
 	}
 

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -173,11 +173,11 @@ func (r *{{.TitleCase}}Resource) Schema(ctx context.Context, req resource.Schema
 					listvalidator.SizeAtLeast({{.MinItems}}),
 {{- end}}
 				},
-{{- else if and (eq .Type "int64") (or (gt .Minimum 0) (gt .Maximum 0))}}
+{{- else if and (eq .Type "int64") (or .HasMinimum .HasMaximum)}}
 				Validators: []validator.Int64{
-{{- if and (gt .Minimum 0) (gt .Maximum 0)}}
+{{- if and .HasMinimum .HasMaximum}}
 					int64validator.Between({{.Minimum}}, {{.Maximum}}),
-{{- else if gt .Maximum 0}}
+{{- else if .HasMaximum}}
 					int64validator.AtMost({{.Maximum}}),
 {{- else}}
 					int64validator.AtLeast({{.Minimum}}),

--- a/tools/pkg/constraints/constraints.go
+++ b/tools/pkg/constraints/constraints.go
@@ -13,6 +13,11 @@ type Parsed struct {
 	MaxItems  int
 	Minimum   int
 	Maximum   int
+
+	// HasMinimum/HasMaximum record whether the minimum/maximum key was present,
+	// independent of value, so a legitimate minimum:0 (or maximum:0) is detectable.
+	HasMinimum bool
+	HasMaximum bool
 }
 
 // Parse extracts constraint data from x-f5xc-constraints map.
@@ -82,9 +87,11 @@ func Parse(raw map[string]interface{}) *Parsed {
 	// Numeric constraints
 	if v, ok := raw["minimum"].(float64); ok {
 		p.Minimum = int(v)
+		p.HasMinimum = true
 	}
 	if v, ok := raw["maximum"].(float64); ok {
 		p.Maximum = int(v)
+		p.HasMaximum = true
 	}
 
 	return p

--- a/tools/pkg/constraints/constraints_test.go
+++ b/tools/pkg/constraints/constraints_test.go
@@ -269,3 +269,18 @@ func TestParse_ConfidenceInMetadata_NoDeterministic(t *testing.T) {
 		t.Errorf("MaxLength = %d, want 1200", result.MaxLength)
 	}
 }
+
+func TestParse_MinimumZeroIsPresent(t *testing.T) {
+	p := Parse(map[string]interface{}{
+		"minimum": float64(0), "maximum": float64(255), "deterministic": true,
+	})
+	if p == nil {
+		t.Fatal("nil")
+	}
+	if !p.HasMinimum || p.Minimum != 0 {
+		t.Errorf("HasMinimum=%v Minimum=%d, want true/0", p.HasMinimum, p.Minimum)
+	}
+	if !p.HasMaximum || p.Maximum != 255 {
+		t.Errorf("HasMaximum=%v Maximum=%d, want true/255", p.HasMaximum, p.Maximum)
+	}
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -154,6 +154,10 @@ type TerraformAttribute struct {
 	MaxItems              int               // From x-f5xc-constraints.max_items
 	Minimum               int
 	Maximum               int
+	// HasMinimum/HasMaximum record presence of the numeric bound (independent of
+	// value), so an int64 field with minimum:0 still emits a range validator.
+	HasMinimum bool
+	HasMaximum bool
 }
 
 // ResourceTemplate contains data for generating a Terraform resource.

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -267,11 +267,13 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 		if c.MaxItems > 0 {
 			attr.MaxItems = c.MaxItems
 		}
-		if c.Minimum > 0 {
+		if c.HasMinimum {
 			attr.Minimum = c.Minimum
+			attr.HasMinimum = true
 		}
-		if c.Maximum > 0 {
+		if c.HasMaximum {
 			attr.Maximum = c.Maximum
+			attr.HasMaximum = true
 		}
 	}
 

--- a/tools/pkg/schema/scan.go
+++ b/tools/pkg/schema/scan.go
@@ -132,11 +132,11 @@ func CollectConflictAttrs(attributes []openapi.TerraformAttribute) ([]conflicts.
 // Block attributes are excluded because blocks use nested schema types that don't support int64validator.
 func HasInt64RangeValidatorsAny(attributes []openapi.TerraformAttribute) bool {
 	for _, attr := range attributes {
-		if !attr.IsBlock && (attr.Minimum > 0 || attr.Maximum > 0) {
+		if !attr.IsBlock && (attr.HasMinimum || attr.HasMaximum) {
 			return true
 		}
 		for _, nested := range attr.NestedAttributes {
-			if !nested.IsBlock && (nested.Minimum > 0 || nested.Maximum > 0) {
+			if !nested.IsBlock && (nested.HasMinimum || nested.HasMaximum) {
 				return true
 			}
 		}

--- a/tools/pkg/schema/scan_test.go
+++ b/tools/pkg/schema/scan_test.go
@@ -131,10 +131,10 @@ func TestCollectConflictAttrs(t *testing.T) {
 func TestHasInt64RangeValidatorsAny(t *testing.T) {
 	withRange := []openapi.TerraformAttribute{
 		{Name: "no_range"},
-		{Name: "has_range", Minimum: 1, Maximum: 16},
+		{Name: "has_range", Minimum: 1, HasMinimum: true, Maximum: 16, HasMaximum: true},
 	}
 	if !HasInt64RangeValidatorsAny(withRange) {
-		t.Error("HasInt64RangeValidatorsAny should detect Minimum/Maximum > 0")
+		t.Error("HasInt64RangeValidatorsAny should detect presence of Minimum/Maximum")
 	}
 
 	withoutRange := []openapi.TerraformAttribute{
@@ -147,7 +147,7 @@ func TestHasInt64RangeValidatorsAny(t *testing.T) {
 
 	nested := []openapi.TerraformAttribute{
 		{Name: "parent", NestedAttributes: []openapi.TerraformAttribute{
-			{Name: "child_range", Minimum: 1, Maximum: 100},
+			{Name: "child_range", Minimum: 1, HasMinimum: true, Maximum: 100, HasMaximum: true},
 		}},
 	}
 	if !HasInt64RangeValidatorsAny(nested) {
@@ -203,5 +203,14 @@ func TestScanPlanModifierUsage_SkipsBlocks(t *testing.T) {
 	_, _, _, usesList, _ := ScanPlanModifierUsage(attrs)
 	if usesList {
 		t.Error("Should not detect list plan modifier on block attributes")
+	}
+}
+
+func TestHasInt64RangeValidatorsAny_MinZero(t *testing.T) {
+	attrs := []openapi.TerraformAttribute{
+		{Name: "port", Minimum: 0, HasMinimum: true, Maximum: 65535, HasMaximum: true},
+	}
+	if !HasInt64RangeValidatorsAny(attrs) {
+		t.Error("want true for a field with HasMinimum (minimum:0)")
 	}
 }


### PR DESCRIPTION
## Summary
Root-cause fix so `int64validator` emits even when the lower bound is `minimum: 0` — previously dropped by a `> 0` sentinel in three layers. Introduces explicit `HasMinimum`/`HasMaximum` presence flags on `constraints.Parsed` and `openapi.TerraformAttribute`, threaded through `convert.go`, `scan.go`, and BOTH int64 emission paths (`render.go` nested builder + `templates.go` template). Widens the CI test gate to run `./tools/...`.

- Generator-only (no `internal/` edits); Constitution Check safe.
- `int64validator.Between(0, N)` / `AtLeast(0)` now emit for zero-lower-bound fields (e.g. proxy_port 0-65535, priority 0-255).
- `_build-test.yml` + `Makefile test` now run `./internal/... ./tools/...` (codegen tests were previously never gated).

## Verification
TDD per layer; `go test ./tools/...` green incl. min=0 cases; `make test` exits 0 (23 pkgs, ./internal/... still green); gofmt/go vet clean on changed files.

Closes #1234. Part of epic #1207.