### PR TITLE
S6-B-fix: action codegen — inject namespace path-param, snake_case name, exclude non-scalar props, compile test

### DIFF
--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -4,12 +4,15 @@ package codegen
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/schema"
 )
 
 func TestEscapeGoString(t *testing.T) {
@@ -1199,9 +1202,9 @@ func TestActionResourceApprove(t *testing.T) {
 		ActionState:        "APPROVED",
 		ReadObjectPath:     "/api/register/namespaces/%s/registrations/%s",
 		Attributes: []openapi.TerraformAttribute{
-			{Name: "name", GoName: "Name", TfsdkTag: "name", Type: "string", JsonName: "name", Required: true, PlanModifier: "RequiresReplace"},
 			{Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string", JsonName: "namespace", Required: true, PlanModifier: "RequiresReplace"},
-			{Name: "passport", GoName: "Passport", TfsdkTag: "passport", Type: "string", JsonName: "passport", Optional: true, Sensitive: true, PlanModifier: "RequiresReplace"},
+			{Name: "backup_connected_region", GoName: "BackupConnectedRegion", TfsdkTag: "backup_connected_region", Type: "string", JsonName: "backup_connected_region", Optional: true, PlanModifier: "RequiresReplace"},
+			{Name: "name", GoName: "Name", TfsdkTag: "name", Type: "string", JsonName: "name", Required: true, PlanModifier: "RequiresReplace"},
 			{Name: "state", GoName: "State", TfsdkTag: "state", Type: "string", JsonName: "state", Optional: true, Computed: true, StringDefault: "APPROVED", PlanModifier: "RequiresReplace"},
 		},
 	}
@@ -1254,6 +1257,176 @@ func TestActionResourceApprove(t *testing.T) {
 	// Client types file carries the request struct.
 	if !strings.Contains(types, "type RegistrationApproval struct") {
 		t.Errorf("types file missing request struct; got:\n%s", types)
+	}
+}
+
+// repoRootFromTest returns the module root by walking up from this test file's
+// location (…/tools/pkg/codegen/codegen_test.go -> module root).
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// file = <root>/tools/pkg/codegen/codegen_test.go
+	root := filepath.Join(filepath.Dir(file), "..", "..", "..")
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("could not locate module root (no go.mod at %s): %v", root, err)
+	}
+	return root
+}
+
+// approveCompileSpec mirrors the REAL registration-approval action spec shape:
+// a camelCase request-body component ("registrationApprovalReq") carrying
+// x-f5xc-action, a mix of scalar string props, object props (annotations,
+// labels), non-enum $ref props (passport, tunnel_type) and a $ref-enum `state`,
+// and an approve POST path whose {namespace} segment is NOT a body property.
+func approveCompileSpec() *openapi.Spec {
+	return &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"registrationApprovalReq": {
+					Type:        "object",
+					XF5xcAction: "approve",
+					Properties: map[string]openapi.Schema{
+						"name":                    {Type: "string"},
+						"backup_connected_region": {Type: "string"},
+						"annotations":             {Type: "object"},
+						"labels":                  {Type: "object"},
+						"passport":                {AllOf: []openapi.Schema{{Ref: "#/components/schemas/registrationPassport"}}},
+						"tunnel_type":             {AllOf: []openapi.Schema{{Ref: "#/components/schemas/schemaSiteToSiteTunnelType"}}},
+						"state":                   {Ref: "#/components/schemas/registrationObjectState"},
+					},
+				},
+			},
+		},
+		Paths: map[string]interface{}{
+			"/api/register/namespaces/{namespace}/registration/{name}/approve": map[string]interface{}{
+				"post": map[string]interface{}{
+					"requestBody": map[string]interface{}{
+						"content": map[string]interface{}{
+							"application/json": map[string]interface{}{
+								"schema": map[string]interface{}{
+									"$ref": "#/components/schemas/registrationApprovalReq",
+								},
+							},
+						},
+					},
+				},
+			},
+			"/api/register/namespaces/{namespace}/registrations/{name}": map[string]interface{}{
+				"get": map[string]interface{}{},
+			},
+		},
+	}
+}
+
+// TestActionResourceCompiles is the compile-level guard for action-resource
+// codegen. It runs the full pipeline from an in-memory spec whose shape mirrors
+// the real registration-approval action (camelCase Req schema; {namespace} path
+// param that is NOT a body property; object + non-enum $ref props that must be
+// excluded), then WRITES the generated Go into the module tree and runs
+// `go build` to prove the output actually COMPILES.
+//
+// This is the gap that previously let a broken generator ship: the earlier tests
+// only asserted rendered substrings and never compiled the result, so the
+// `data.Namespace undefined` type error (namespace was never emitted as a model
+// field) went unnoticed. The generated resource file imports internal/client and
+// internal/validators, which — by Go's internal-package visibility rule — are
+// importable only from within this module; a bare t.TempDir() outside the module
+// cannot resolve them. So the throwaway resource package is created UNDER
+// internal/ (unique dir), the client request struct is dropped into
+// internal/client, both are built, and both are removed on cleanup. A dir whose
+// package clause is `provider` builds fine via `go build ./internal/<dir>/`
+// without colliding with the real provider package.
+func TestActionResourceCompiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping go build compile check in -short mode")
+	}
+
+	spec := approveCompileSpec()
+
+	// 1. Discovery must snake_case the resource name.
+	var found *openapi.ResourcePath
+	for _, a := range openapi.ExtractActionsFromPaths(spec) {
+		ac := a
+		if ac.ResourceName == "registration_approval" {
+			found = &ac
+		}
+	}
+	if found == nil {
+		t.Fatalf("ExtractActionsFromPaths did not yield snake_case resource name registration_approval; got %+v", openapi.ExtractActionsFromPaths(spec))
+	}
+
+	// 2. Schema extraction: exact attribute set, object/$ref props excluded.
+	stub := func(*openapi.Spec, string) (string, string, bool) { return "", "", true }
+	tmpl, err := schema.ExtractActionResourceSchema(spec, "registration_approval", stub)
+	if err != nil {
+		t.Fatalf("ExtractActionResourceSchema: %v", err)
+	}
+	got := map[string]openapi.TerraformAttribute{}
+	for _, a := range tmpl.Attributes {
+		got[a.TfsdkTag] = a
+	}
+	for _, excluded := range []string{"annotations", "labels", "passport", "tunnel_type"} {
+		if _, ok := got[excluded]; ok {
+			t.Errorf("object/$ref prop %q must be excluded from action attributes", excluded)
+		}
+	}
+	if ns, ok := got["namespace"]; !ok || !ns.Required {
+		t.Errorf("namespace must be present and Required (injected path param); got %+v ok=%v", got["namespace"], ok)
+	}
+
+	// 3. Generate into the module tree and compile.
+	root := repoRootFromTest(t)
+	clientDir := filepath.Join(root, "internal", "client")
+	clientTypes := filepath.Join(clientDir, "registration_approval_types.go")
+	if _, err := os.Stat(clientTypes); err == nil {
+		t.Fatalf("refusing to clobber existing %s", clientTypes)
+	}
+	provDir, err := os.MkdirTemp(filepath.Join(root, "internal"), "zz_actioncompile_")
+	if err != nil {
+		t.Fatalf("mkdir temp provider dir: %v", err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(provDir)
+		os.Remove(clientTypes)
+	})
+
+	if err := GenerateActionResource(tmpl, provDir, clientDir); err != nil {
+		t.Fatalf("GenerateActionResource: %v", err)
+	}
+
+	resBytes, err := os.ReadFile(filepath.Join(provDir, "registration_approval_resource.go"))
+	if err != nil {
+		t.Fatalf("reading generated resource: %v", err)
+	}
+	res := string(resBytes)
+	// Model must carry a Namespace field (the bug: it did not). gofmt aligns
+	// struct fields, so match name + type across arbitrary whitespace.
+	if !regexp.MustCompile(`\bNamespace\s+types\.String\b`).MatchString(res) {
+		t.Errorf("generated model missing Namespace field:\n%s", res)
+	}
+	// snake_case TF type name, not camelCase struct/typename.
+	if !strings.Contains(res, `+ "_registration_approval"`) {
+		t.Errorf("generated resource missing snake_case type name _registration_approval:\n%s", res)
+	}
+	if strings.Contains(res, "Registrationapproval") {
+		t.Errorf("generated resource contains camelCase-derived name 'Registrationapproval':\n%s", res)
+	}
+	// Excluded props must not appear as model fields.
+	for _, bad := range []string{"Labels", "Passport", "TunnelType", "Annotations"} {
+		if regexp.MustCompile(`\b` + bad + `\s+types\.String\b`).MatchString(res) {
+			t.Errorf("generated model contains excluded field %q:\n%s", bad, res)
+		}
+	}
+
+	buildTarget := "./internal/" + filepath.Base(provDir) + "/"
+	cmd := exec.Command("go", "build", buildTarget)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated action resource failed to compile (%v):\n%s", err, out)
 	}
 }
 

--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -13,6 +13,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
 )
 
 // ParseFile reads and parses an OpenAPI specification file.
@@ -446,7 +448,11 @@ func ExtractActionsFromPaths(spec *Spec) []ResourcePath {
 			continue
 		}
 		action := compSchema.XF5xcAction
-		resourceName := strings.TrimSuffix(schemaName, "Req")
+		// The request-body component schema name is camelCase (e.g.
+		// "registrationApprovalReq"); the Terraform resource name must be
+		// snake_case ("registration_approval") so the emitted type
+		// (xcsh_registration_approval), Go struct, and file names are correct.
+		resourceName := naming.ToSnakeCase(strings.TrimSuffix(schemaName, "Req"))
 		if seen[resourceName] {
 			continue
 		}

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -388,12 +388,17 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 // ExtractActionResourceSchema builds an action-style resource template from a
 // request-body schema carrying a schema-level x-f5xc-action. Unlike a CRUD
 // resource it has no CreateSpecType/GetSpecType: its attributes derive directly
-// from the flat action request body (namespace, name, state, passport, …), the
-// singular action POST path and the pluralized sibling object GET path are
-// captured for Create/Read, `state` constant-defaults to APPROVED, `passport` is
-// write-only, and every user-settable field forces replace (there is no in-place
-// update). extractAPIPath is accepted for signature parity with the CRUD
-// extractor but unused — action paths come from the discovered x-f5xc-action.
+// from the flat action request body. Only scalar string props (plus the `state`
+// enum) become attributes; object props (annotations, labels) and non-enum $ref
+// props (passport, tunnel_type) are skipped because they are not representable as
+// plain string attributes. `namespace` is a path parameter (not a body property)
+// and is injected so the generated model carries a Namespace field for the
+// action/read path Sprintf. The singular action POST path and the pluralized
+// sibling object GET path are captured for Create/Read, `state`
+// constant-defaults to APPROVED, and every user-settable field forces replace
+// (there is no in-place update). extractAPIPath is accepted for signature parity
+// with the CRUD extractor but unused — action paths come from the discovered
+// x-f5xc-action.
 func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func(spec *openapi.Spec, resourceName string) (string, string, bool)) (*openapi.ResourceTemplate, error) {
 	// Locate the action for this resource among the spec's discovered actions.
 	var action *openapi.ResourcePath
@@ -420,8 +425,24 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 	}
 	sort.Strings(propNames)
 
+	// The action model is rendered as a flat set of string attributes. Only
+	// scalar string props (plus the `state` enum $ref, special-cased below) map
+	// cleanly to a StringAttribute. Object props (annotations, labels) and
+	// non-enum $ref props (passport, tunnel_type) are structured values that must
+	// NOT be emitted as strings, so they are skipped entirely.
 	var attributes []openapi.TerraformAttribute
+	haveNamespace := false
 	for _, name := range propNames {
+		prop := reqSchema.Properties[name]
+		isState := name == "state"
+		if prop.Type != "string" && !isState {
+			// Skip object / non-enum $ref props (annotations, labels, passport,
+			// tunnel_type): they are not representable as a plain string attribute.
+			continue
+		}
+		if name == "namespace" {
+			haveNamespace = true
+		}
 		attr := openapi.TerraformAttribute{
 			Name:        name,
 			GoName:      naming.ToResourceTypeName(name),
@@ -432,6 +453,8 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 		}
 		switch name {
 		case "name", "namespace":
+			// Path parameters ({namespace}/{name}); the request schema's `required`
+			// list is null, so force these Required.
 			attr.Required = true
 		case "state":
 			// state constant-defaults to APPROVED; Optional+Computed so it may be
@@ -439,14 +462,27 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 			attr.Optional = true
 			attr.Computed = true
 			attr.StringDefault = "APPROVED"
-		case "passport":
-			// passport is write-only: supplied on create, never read back.
-			attr.Optional = true
-			attr.Sensitive = true
 		default:
 			attr.Optional = true
 		}
 		attributes = append(attributes, attr)
+	}
+
+	// `namespace` is a PATH parameter ({namespace}), not a request-body property,
+	// so it is absent from reqSchema.Properties. Inject it (mirroring how CRUD
+	// resources declare namespace) so the generated model carries a Namespace
+	// field for the action/read path Sprintf. Placed first to keep it adjacent to
+	// the other ID component.
+	if !haveNamespace {
+		attributes = append([]openapi.TerraformAttribute{{
+			Name:        "namespace",
+			GoName:      "Namespace",
+			TfsdkTag:    "namespace",
+			Type:        "string",
+			JsonName:    "namespace",
+			Required:    true,
+			IsSpecField: false,
+		}}, attributes...)
 	}
 
 	// An action has no PUT/update endpoint, so force every settable field to

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -249,14 +249,25 @@ func actionApproveSpec() (*openapi.Spec, func(*openapi.Spec, string) (string, st
 	spec := &openapi.Spec{
 		Components: openapi.Components{
 			Schemas: map[string]openapi.Schema{
-				"registration_approvalReq": {
+				// Mirror the real spec: the request-body component is camelCase
+				// ("registrationApprovalReq") and its properties mix scalar strings
+				// with object props (annotations, labels) and non-enum $ref props
+				// (passport, tunnel_type). `namespace` is a PATH parameter, not a
+				// body property, so it is intentionally absent here. `state` is a
+				// $ref to a string enum.
+				"registrationApprovalReq": {
 					Type:        "object",
 					XF5xcAction: "approve",
 					Properties: map[string]openapi.Schema{
-						"namespace": {Type: "string"},
-						"name":      {Type: "string"},
-						"state":     {Type: "string"},
-						"passport":  {Type: "string"},
+						"name":                    {Type: "string"},
+						"backup_connected_region": {Type: "string"},
+						"connected_region":        {Type: "string"},
+						"preferred_active_re":     {Type: "string"},
+						"annotations":             {Type: "object"},
+						"labels":                  {Type: "object"},
+						"passport":                {AllOf: []openapi.Schema{{Ref: "#/components/schemas/registrationPassport"}}},
+						"tunnel_type":             {AllOf: []openapi.Schema{{Ref: "#/components/schemas/schemaSiteToSiteTunnelType"}}},
+						"state":                   {Ref: "#/components/schemas/registrationObjectState"},
 					},
 				},
 			},
@@ -268,7 +279,7 @@ func actionApproveSpec() (*openapi.Spec, func(*openapi.Spec, string) (string, st
 						"content": map[string]interface{}{
 							"application/json": map[string]interface{}{
 								"schema": map[string]interface{}{
-									"$ref": "#/components/schemas/registration_approvalReq",
+									"$ref": "#/components/schemas/registrationApprovalReq",
 								},
 							},
 						},
@@ -321,11 +332,51 @@ func TestActionResourceApprove(t *testing.T) {
 		t.Error("state attribute missing")
 	} else if st.StringDefault != "APPROVED" {
 		t.Errorf("state StringDefault = %q, want APPROVED", st.StringDefault)
+	} else if !(st.Optional && st.Computed) {
+		t.Error("state must be Optional+Computed")
 	}
-	if pp := findAttr(result.Attributes, "passport"); pp == nil {
-		t.Error("passport attribute missing")
-	} else if !pp.Sensitive {
-		t.Error("passport must be a write-only (Sensitive) attribute")
+
+	// namespace is a path parameter (not a body property); it must be injected
+	// as a Required attribute so the generated model carries a Namespace field.
+	if ns := findAttr(result.Attributes, "namespace"); ns == nil {
+		t.Error("namespace attribute missing (must be injected from the path param)")
+	} else if !ns.Required {
+		t.Error("namespace must be Required")
+	}
+
+	// name is a path parameter; the request schema's required list is null, so it
+	// must be forced Required.
+	if nm := findAttr(result.Attributes, "name"); nm == nil {
+		t.Error("name attribute missing")
+	} else if !nm.Required {
+		t.Error("name must be Required")
+	}
+
+	// Scalar string metadata props are emitted as optional attributes.
+	if bc := findAttr(result.Attributes, "backup_connected_region"); bc == nil {
+		t.Error("backup_connected_region attribute missing")
+	} else if !bc.Optional {
+		t.Error("backup_connected_region must be Optional")
+	}
+
+	// Object props (annotations, labels) and non-enum $ref props (passport,
+	// tunnel_type) are not representable as plain string attributes and must be
+	// excluded entirely.
+	for _, excluded := range []string{"annotations", "labels", "passport", "tunnel_type"} {
+		if a := findAttr(result.Attributes, excluded); a != nil {
+			t.Errorf("attribute %q must be excluded (object/$ref prop), but it was emitted", excluded)
+		}
+	}
+
+	// The full expected attribute set is exactly these four.
+	wantAttrs := map[string]bool{
+		"namespace": true, "name": true, "state": true,
+		"backup_connected_region": true, "connected_region": true, "preferred_active_re": true,
+	}
+	for _, a := range result.Attributes {
+		if !wantAttrs[a.TfsdkTag] {
+			t.Errorf("unexpected attribute %q in action model", a.TfsdkTag)
+		}
 	}
 }
 


### PR DESCRIPTION
## What
Fix the action-resource generator so `registration_approval` (from `x-f5xc-action`) actually **compiles** and is correctly named when generated from the real `v2.1.188` spec. The prior codegen generated the resource but it failed to build (`data.Namespace undefined`), so the v2.1.188 auto-regen shipped without it and no provider release was cut.

## Root cause
- **Compile blocker:** `namespace` is a URL path parameter (`/api/register/namespaces/{namespace}/registration/{name}/approve`), NOT a `registrationApprovalReq` body property — so the generated model had no `Namespace` field, yet the template references `data.Namespace`.
- **Naming:** `TrimSuffix(schemaName,"Req")` = `registrationApproval` (camelCase) → `xcsh_registrationApproval`.
- **Object-as-string:** object/`$ref` body props were flattened to `StringAttribute`.
- **Test gap:** the codegen tests only asserted rendered substrings — they never compiled the output.

## Fix (tools/** only)
- `parser.go`: `naming.ToSnakeCase(TrimSuffix(schemaName,"Req"))` → `registration_approval`.
- `extract.go` `ExtractActionResourceSchema`: inject a Required `namespace` attribute (path param) when absent from body props; force `name` Required; emit only scalar `type:string` props + the `state` enum, excluding object props (`annotations`,`labels`) and non-enum `$ref` props (`passport`,`tunnel_type`). Final surface: `{namespace, name, state=APPROVED, backup_connected_region, connected_region, preferred_active_re}` — matches the proven approve payload `{namespace,name,state:"APPROVED"}` (namespace is correctly sent in both the URL and the body).
- New **compile-level** test `TestActionResourceCompiles`: generates the action resource into a temp package and runs `go build` — fails-first on the `data.Namespace` bug, passes after. Closes the test gap that allowed the miss.

## Verification
- `go test ./tools/... ./internal/...` green; `golangci-lint` 0 issues; `gofmt` clean.
- Local regen against the released `v2.1.188` artifact emits `internal/provider/registration_approval_resource.go` (snake_case) that compiles under `go build ./internal/...`.
- No generated provider files committed (they land via post-merge auto-regen).

`passport` is excluded for now (optional; if the live approve requires it, it becomes a nested block — tracked follow-up).

Part of epic #1207 (S6). Fixes the B1 generator; unblocks the registration_approval release + mcn wiring (#1206/#1210).

Closes #1267
