### PR TITLE
S6-D1: xcsh_site_registration data source — resolve a CE's runtime r-<uuid> registration name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,10 @@ jobs:
             "internal/provider/functions_registration.go"
             "internal/provider/addon_service_data_source.go"
             "internal/provider/addon_service_activation_status_data_source.go"
+            "internal/provider/site_registration_data_source.go"
             "examples/data-sources/addon_service/data-source.tf"
             "examples/data-sources/addon_service_activation_status/data-source.tf"
+            "examples/data-sources/site_registration/data-source.tf"
             # MkDocs documentation site index files (navigation, not provider docs)
             "docs/resources/index.md"
             "docs/data-sources/index.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,14 @@ on:
       - 'auto-regenerate/**'
       - 'openapi-update'
 
+# Least privilege: every job here only reads the repository. `statuses: write`
+# and `checks: write` were granted workflow-wide but nothing consumed them —
+# no job (nor the reusable _build-test.yml, which uses only checkout and
+# setup-go) writes a commit status or a check run; job check runs are created by
+# Actions itself, not through GITHUB_TOKEN. Grant either at the job level if a
+# job ever needs it, rather than workflow-wide.
 permissions:
   contents: read
-  statuses: write
-  checks: write
 
 # Cancel in-progress runs when new commits are pushed to the same PR/branch
 concurrency:
@@ -56,11 +60,16 @@ jobs:
           fetch-depth: 0
 
       - name: Check for generated files (CLAUDE.md Rule 1)
+        env:
+          # Passed via env, never expanded straight into the script: a template
+          # expansion inside run: is a code-injection sink (zizmor
+          # template-injection). Shell-quoted at each use below.
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "Checking PR for generated files..."
 
           # Get list of added/modified files (deletions are fine — orphan cleanup)
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM origin/${{ github.base_ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}...HEAD")
 
           # Check if generator tools are modified - this allows docs/examples changes
           GENERATOR_TOOLS_MODIFIED=false
@@ -75,7 +84,7 @@ jobs:
           OLD_MODULE=""
           NEW_MODULE=""
           if echo "$CHANGED_FILES" | grep -qE "^go\.mod$"; then
-            OLD_MODULE=$(git show "origin/${{ github.base_ref }}:go.mod" 2>/dev/null | grep '^module ' | awk '{print $2}')
+            OLD_MODULE=$(git show "origin/${BASE_REF}:go.mod" 2>/dev/null | grep '^module ' | awk '{print $2}')
             NEW_MODULE=$(grep '^module ' go.mod | awk '{print $2}')
             if [ -n "$OLD_MODULE" ] && [ -n "$NEW_MODULE" ] && [ "$OLD_MODULE" != "$NEW_MODULE" ]; then
               echo "Module path renamed: $OLD_MODULE -> $NEW_MODULE"
@@ -167,7 +176,7 @@ jobs:
                 # Module rename: allow generated .go files only if their diff
                 # contains the old→new import path substitution
                 if [ "$MODULE_RENAMED" = true ] && echo "$file" | grep -qE "\.go$"; then
-                  CHANGED_LINES=$(git diff "origin/${{ github.base_ref }}" -- "$file" 2>/dev/null | grep -E '^[+-]' | grep -v '^[+-][+-][+-]')
+                  CHANGED_LINES=$(git diff "origin/${BASE_REF}" -- "$file" 2>/dev/null | grep -E '^[+-]' | grep -v '^[+-][+-][+-]')
                   if echo "$CHANGED_LINES" | grep -qF "\"$OLD_MODULE" && echo "$CHANGED_LINES" | grep -qF "\"$NEW_MODULE"; then
                     continue
                   fi
@@ -217,8 +226,11 @@ jobs:
 
       - name: Check if docs regeneration needed
         id: check
+        env:
+          # See the note on BASE_REF above: never expand a template into run:.
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
           # Check if any files that affect doc generation changed
           if echo "$CHANGED_FILES" | grep -qE "^internal/|^tools/|^templates/"; then
@@ -315,9 +327,12 @@ jobs:
 
       - name: Check if mock fixture regeneration needed
         id: check
+        env:
+          # See the note on BASE_REF above: never expand a template into run:.
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Check if files that affect mock generation changed
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null || echo "")
 
           if echo "$CHANGED_FILES" | grep -qE "^tools/api-defaults\.json$|^tools/generate-mock-fixtures\.go$|^internal/mocks/generated_defaults"; then
             echo "needs_validation=true" >> "$GITHUB_OUTPUT"
@@ -392,8 +407,11 @@ jobs:
 
       - name: Check if shell script validation needed
         id: check
+        env:
+          # See the note on BASE_REF above: never expand a template into run:.
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null || echo "")
 
           # Check if any shell scripts changed
           if echo "$CHANGED_FILES" | grep -qE "\.sh$"; then
@@ -432,8 +450,11 @@ jobs:
 
       - name: Check if Terraform validation needed
         id: check
+        env:
+          # See the note on BASE_REF above: never expand a template into run:.
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD 2>/dev/null || echo "")
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" 2>/dev/null || echo "")
 
           # Check if any Terraform files in examples/ changed
           if echo "$CHANGED_FILES" | grep -qE "^examples/.*\.tf$"; then

--- a/examples/data-sources/site_registration/data-source.tf
+++ b/examples/data-sources/site_registration/data-source.tf
@@ -1,0 +1,53 @@
+# Example: Resolve a Customer Edge registration so it can be approved
+#
+# A registration is named "r-<uuid>", NOT after the site, so it cannot be read
+# by site name. This data source finds the registration that belongs to a site.
+#
+# It returns found = false — with no error — until the CE has booted and
+# registered, so an approval can safely be gated on it.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    xcsh = {
+      source  = "f5-sales-demo/xcsh"
+      version = ">= 0.1.0"
+    }
+  }
+}
+
+data "xcsh_site_registration" "ce" {
+  site_name = "my-ce-site"
+  namespace = "system"
+}
+
+# A multi-node site returns one registration per node; pick one by hostname.
+data "xcsh_site_registration" "ha_ce_node_0" {
+  site_name = "my-ha-ce-site"
+  hostname  = "master-0"
+}
+
+output "registration_name" {
+  description = "Registration name (r-<uuid>) to approve, null until the CE registers"
+  value       = data.xcsh_site_registration.ce.name
+}
+
+output "registration_state" {
+  description = "Current registration state (PENDING, ONLINE, ...)"
+  value       = data.xcsh_site_registration.ce.state
+}
+
+output "ha_node_0_registration_name" {
+  description = "Registration name of the master-0 node of the three-node site"
+  value       = data.xcsh_site_registration.ha_ce_node_0.name
+}
+
+# Approve the registration only once it exists — on the first apply the CE has
+# not registered yet, so nothing is planned; re-apply after the node boots.
+resource "xcsh_registration_approval" "ce" {
+  count = data.xcsh_site_registration.ce.found ? 1 : 0
+
+  name      = data.xcsh_site_registration.ce.name
+  namespace = data.xcsh_site_registration.ce.namespace
+}

--- a/internal/client/site_registration_types.go
+++ b/internal/client/site_registration_types.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+// Site registration client types for F5 XC
+// Read-only access to the registrations of a site's CE nodes. A registration
+// is named "r-<uuid>" — NOT after the site — so it can only be found by
+// listing the registrations that belong to the site.
+
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// RegistrationPassport carries the CE-supplied cluster identity. ClusterName is
+// the F5 XC site name the node registered against, and is the field used to
+// match a registration to a site.
+type RegistrationPassport struct {
+	ClusterName string `json:"cluster_name,omitempty"`
+	ClusterSize int64  `json:"cluster_size,omitempty"`
+}
+
+// RegistrationInfra carries the node-level facts reported by the registering
+// CE. Hostname distinguishes the nodes of a multi-node site; it is NOT unique
+// tenant-wide (several sites report the same hostname), so it is only a
+// within-site discriminator.
+type RegistrationInfra struct {
+	Provider string `json:"provider,omitempty"`
+	Hostname string `json:"hostname,omitempty"`
+}
+
+// RegistrationGetSpec is the registration's spec view.
+type RegistrationGetSpec struct {
+	Token    string               `json:"token,omitempty"`
+	Infra    RegistrationInfra    `json:"infra,omitempty"`
+	Passport RegistrationPassport `json:"passport,omitempty"`
+}
+
+// RegistrationStatus holds the registration's lifecycle state. CurrentState is
+// a registrationObjectState enum: NOTSET, NEW, APPROVED, ADMITTED, RETIRED,
+// FAILED, DONE, PENDING, ONLINE, UPGRADING, MAINTENANCE, FAILED_INACTIVE.
+type RegistrationStatus struct {
+	CurrentState string `json:"current_state,omitempty"`
+}
+
+// RegistrationObject is the embedded full object; only its status is modelled.
+type RegistrationObject struct {
+	Status RegistrationStatus `json:"status,omitempty"`
+}
+
+// RegistrationSystemMetadata is the system-populated metadata; only the uid is
+// modelled.
+type RegistrationSystemMetadata struct {
+	UID string `json:"uid,omitempty"`
+}
+
+// RegistrationListItem is a single registration returned by
+// ListRegistrationsBySite. Name is the approvable registration name
+// ("r-" + uid).
+type RegistrationListItem struct {
+	Tenant         string                     `json:"tenant,omitempty"`
+	Namespace      string                     `json:"namespace,omitempty"`
+	Name           string                     `json:"name,omitempty"`
+	UID            string                     `json:"uid,omitempty"`
+	SystemMetadata RegistrationSystemMetadata `json:"system_metadata,omitempty"`
+	Object         RegistrationObject         `json:"object,omitempty"`
+	GetSpec        RegistrationGetSpec        `json:"get_spec,omitempty"`
+}
+
+// RegistrationListResponse is the registrationListResponse envelope. A site
+// with no registered node yields HTTP 200 with an empty Items slice — not a
+// 404 and not an error.
+type RegistrationListResponse struct {
+	Items  []RegistrationListItem `json:"items"`
+	Errors []APIErrorDetail       `json:"errors,omitempty"`
+}
+
+// APIErrorDetail is a non-fatal error entry returned alongside items.
+type APIErrorDetail struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// ListRegistrationsBySite lists the CE registrations belonging to a site.
+// Uses GetLenient because registration objects embed certificate and log
+// strings that can contain raw control bytes, which the strict JSON decoder
+// rejects. An unregistered or unknown site returns an empty Items slice with a
+// nil error.
+func (c *Client) ListRegistrationsBySite(ctx context.Context, namespace, siteName string) (*RegistrationListResponse, error) {
+	var result RegistrationListResponse
+	path := fmt.Sprintf("/api/register/namespaces/%s/registrations_by_site/%s", namespace, siteName)
+	err := c.GetLenient(ctx, path, &result)
+	return &result, err
+}

--- a/internal/client/site_registration_types.go
+++ b/internal/client/site_registration_types.go
@@ -31,7 +31,6 @@ type RegistrationInfra struct {
 
 // RegistrationGetSpec is the registration's spec view.
 type RegistrationGetSpec struct {
-	Token    string               `json:"token,omitempty"`
 	Infra    RegistrationInfra    `json:"infra,omitempty"`
 	Passport RegistrationPassport `json:"passport,omitempty"`
 }
@@ -58,8 +57,6 @@ type RegistrationSystemMetadata struct {
 // ListRegistrationsBySite. Name is the approvable registration name
 // ("r-" + uid).
 type RegistrationListItem struct {
-	Tenant         string                     `json:"tenant,omitempty"`
-	Namespace      string                     `json:"namespace,omitempty"`
 	Name           string                     `json:"name,omitempty"`
 	UID            string                     `json:"uid,omitempty"`
 	SystemMetadata RegistrationSystemMetadata `json:"system_metadata,omitempty"`

--- a/internal/client/site_registration_types_test.go
+++ b/internal/client/site_registration_types_test.go
@@ -98,9 +98,6 @@ func TestListRegistrationsBySite_OneItem(t *testing.T) {
 	if item.GetSpec.Infra.Provider != "AZURE" {
 		t.Errorf("GetSpec.Infra.Provider = %q, want %q", item.GetSpec.Infra.Provider, "AZURE")
 	}
-	if item.GetSpec.Token == "" {
-		t.Error("GetSpec.Token = empty, want the registration token")
-	}
 	if item.Object.Status.CurrentState != "ONLINE" {
 		t.Errorf("Object.Status.CurrentState = %q, want %q", item.Object.Status.CurrentState, "ONLINE")
 	}

--- a/internal/client/site_registration_types_test.go
+++ b/internal/client/site_registration_types_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Trimmed copy of a real registrations_by_site response for a registered
+// single-node CE site (ar-bgp-eastus01). Only the fields the data source
+// exposes are retained.
+const registrationsBySiteOneItem = `{
+  "items": [
+    {
+      "tenant": "example-tenant",
+      "namespace": "system",
+      "name": "r-dcec2400-52d5-4154-9fd0-4b042d3fe18d",
+      "uid": "dcec2400-52d5-4154-9fd0-4b042d3fe18d",
+      "system_metadata": {
+        "uid": "dcec2400-52d5-4154-9fd0-4b042d3fe18d"
+      },
+      "object": {
+        "status": {
+          "current_state": "ONLINE"
+        }
+      },
+      "get_spec": {
+        "token": "0d2c8f4a-0000-0000-0000-000000000000",
+        "infra": {
+          "provider": "AZURE",
+          "hostname": "f5-xc-ce-vm-01"
+        },
+        "passport": {
+          "cluster_name": "ar-bgp-eastus01",
+          "cluster_size": 1
+        }
+      }
+    }
+  ],
+  "errors": []
+}`
+
+// A site whose CE has not registered yet (or does not exist) returns HTTP 200
+// with an empty items array — never a 404 and never an error.
+const registrationsBySiteEmpty = `{"items":[],"errors":[]}`
+
+func TestListRegistrationsBySite_OneItem(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(registrationsBySiteOneItem))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-token")
+
+	resp, err := c.ListRegistrationsBySite(context.Background(), "system", "ar-bgp-eastus01")
+	if err != nil {
+		t.Fatalf("ListRegistrationsBySite() error = %v", err)
+	}
+
+	wantPath := "/api/register/namespaces/system/registrations_by_site/ar-bgp-eastus01"
+	if gotPath != wantPath {
+		t.Errorf("request path = %q, want %q", gotPath, wantPath)
+	}
+
+	if len(resp.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(resp.Items))
+	}
+	item := resp.Items[0]
+
+	if item.Name != "r-dcec2400-52d5-4154-9fd0-4b042d3fe18d" {
+		t.Errorf("Name = %q, want %q", item.Name, "r-dcec2400-52d5-4154-9fd0-4b042d3fe18d")
+	}
+	if item.UID != "dcec2400-52d5-4154-9fd0-4b042d3fe18d" {
+		t.Errorf("UID = %q, want %q", item.UID, "dcec2400-52d5-4154-9fd0-4b042d3fe18d")
+	}
+	if item.SystemMetadata.UID != "dcec2400-52d5-4154-9fd0-4b042d3fe18d" {
+		t.Errorf("SystemMetadata.UID = %q, want the item uid", item.SystemMetadata.UID)
+	}
+	if item.GetSpec.Passport.ClusterName != "ar-bgp-eastus01" {
+		t.Errorf("GetSpec.Passport.ClusterName = %q, want %q", item.GetSpec.Passport.ClusterName, "ar-bgp-eastus01")
+	}
+	if item.GetSpec.Passport.ClusterSize != 1 {
+		t.Errorf("GetSpec.Passport.ClusterSize = %d, want 1", item.GetSpec.Passport.ClusterSize)
+	}
+	if item.GetSpec.Infra.Hostname != "f5-xc-ce-vm-01" {
+		t.Errorf("GetSpec.Infra.Hostname = %q, want %q", item.GetSpec.Infra.Hostname, "f5-xc-ce-vm-01")
+	}
+	if item.GetSpec.Infra.Provider != "AZURE" {
+		t.Errorf("GetSpec.Infra.Provider = %q, want %q", item.GetSpec.Infra.Provider, "AZURE")
+	}
+	if item.GetSpec.Token == "" {
+		t.Error("GetSpec.Token = empty, want the registration token")
+	}
+	if item.Object.Status.CurrentState != "ONLINE" {
+		t.Errorf("Object.Status.CurrentState = %q, want %q", item.Object.Status.CurrentState, "ONLINE")
+	}
+	if len(resp.Errors) != 0 {
+		t.Errorf("len(Errors) = %d, want 0", len(resp.Errors))
+	}
+}
+
+// An unregistered or unknown site yields HTTP 200 with items: [] — zero items
+// and NO error. Callers rely on this to report "not found" without failing.
+func TestListRegistrationsBySite_EmptyItems(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(registrationsBySiteEmpty))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-token")
+
+	resp, err := c.ListRegistrationsBySite(context.Background(), "system", "no-such-site")
+	if err != nil {
+		t.Fatalf("ListRegistrationsBySite() error = %v, want nil for an unregistered site", err)
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("len(Items) = %d, want 0", len(resp.Items))
+	}
+}
+
+// Registration objects can carry raw control bytes inside embedded string
+// values (certificates, logs). The client must sanitize them (GetLenient)
+// rather than fail the whole read.
+func TestListRegistrationsBySite_ToleratesRawControlChars(t *testing.T) {
+	body := "{\"items\":[{\"name\":\"r-1\",\"get_spec\":{\"infra\":{\"hostname\":\"a\x01b\"},\"passport\":{\"cluster_name\":\"s1\"}}}],\"errors\":[]}"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-token")
+
+	resp, err := c.ListRegistrationsBySite(context.Background(), "system", "s1")
+	if err != nil {
+		t.Fatalf("ListRegistrationsBySite() error = %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(resp.Items))
+	}
+	if got := resp.Items[0].GetSpec.Infra.Hostname; got != "ab" {
+		t.Errorf("Hostname = %q, want %q (control char stripped)", got, "ab")
+	}
+}

--- a/internal/provider/site_registration_data_source.go
+++ b/internal/provider/site_registration_data_source.go
@@ -13,8 +13,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
@@ -27,6 +29,31 @@ var (
 
 // defaultRegistrationNamespace is the namespace registrations live in.
 const defaultRegistrationNamespace = "system"
+
+// terminalRegistrationStates are the registrationObjectState values a
+// registration never leaves. F5 XC keeps such registrations indefinitely, and
+// registrations_by_site keeps returning them, so rebuilding a CE under the same
+// site name yields both the dead registration and the live one — with the same
+// cluster_name and the same hostname. They are the registrations that can never
+// be approved, so they are not candidates.
+//
+// The remaining registrationObjectState values — NOTSET, NEW, APPROVED,
+// ADMITTED, PENDING, ONLINE, UPGRADING, MAINTENANCE — are live or still moving
+// and stay candidates.
+var terminalRegistrationStates = map[string]struct{}{
+	"RETIRED":         {},
+	"FAILED":          {},
+	"FAILED_INACTIVE": {},
+	"DONE":            {},
+}
+
+// isTerminalRegistrationState reports whether state is one a registration never
+// leaves. An empty state is NOT terminal: a missing field must never turn a
+// real match into a miss.
+func isTerminalRegistrationState(state string) bool {
+	_, ok := terminalRegistrationStates[state]
+	return ok
+}
 
 func NewSiteRegistrationDataSource() datasource.DataSource {
 	return &SiteRegistrationDataSource{}
@@ -48,7 +75,6 @@ type SiteRegistrationDataSourceModel struct {
 	ClusterName  types.String `tfsdk:"cluster_name"`
 	ClusterSize  types.Int64  `tfsdk:"cluster_size"`
 	ProviderType types.String `tfsdk:"provider_type"`
-	Token        types.String `tfsdk:"token"`
 }
 
 func (d *SiteRegistrationDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -93,6 +119,13 @@ resource "xcsh_registration_approval" "ce" {
 				MarkdownDescription: "Namespace holding the registrations. Defaults to `system`, where site registrations live.",
 				Optional:            true,
 				Computed:            true,
+				// Reject an explicit empty string: the lookup would fall back to
+				// `system` but report "" back, and a consumer feeding that into
+				// xcsh_registration_approval.namespace would send an empty
+				// namespace. Omit the argument to get the default instead.
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"hostname": schema.StringAttribute{
 				MarkdownDescription: "Node hostname used to pick one registration when a multi-node site has several. Optional for a single-node site; when omitted, the resolved node's hostname is returned here. Hostnames are only unique within a site.",
@@ -127,11 +160,6 @@ resource "xcsh_registration_approval" "ce" {
 				MarkdownDescription: "Infrastructure provider the CE reported, e.g. `AZURE`, `AWS`, `GCP`, `VMWARE`.",
 				Computed:            true,
 			},
-			"token": schema.StringAttribute{
-				MarkdownDescription: "Site token the CE registered with.",
-				Computed:            true,
-				Sensitive:           true,
-			},
 		},
 	}
 }
@@ -157,9 +185,16 @@ func (d *SiteRegistrationDataSource) Configure(ctx context.Context, req datasour
 // set it further narrows the candidates — hostnames are only unique within a
 // site, so this is a within-site discriminator.
 //
-// No candidate returns (nil, nil): a site whose CE has not registered yet is
-// the normal case, not an error. More than one candidate returns an error
-// naming the hostnames to choose between.
+// Registrations in a terminal state are then dropped. Rebuilding a CE under the
+// same site name leaves the old registration behind, and it reports the same
+// cluster_name and the same hostname as the fresh one, so neither filter above
+// can separate them: without this the rebuild would resolve to the ambiguity
+// error below and fail the consumer's whole plan.
+//
+// No candidate returns (nil, nil): a site whose CE has not registered yet — or
+// one whose only registrations are dead — is the normal case, not an error.
+// More than one live candidate returns an error naming the hostnames to choose
+// between.
 func selectRegistration(items []client.RegistrationListItem, siteName, hostname string) (*client.RegistrationListItem, error) {
 	var candidates []client.RegistrationListItem
 	for _, it := range items {
@@ -167,6 +202,9 @@ func selectRegistration(items []client.RegistrationListItem, siteName, hostname 
 			continue
 		}
 		if hostname != "" && it.GetSpec.Infra.Hostname != hostname {
+			continue
+		}
+		if isTerminalRegistrationState(it.Object.Status.CurrentState) {
 			continue
 		}
 		candidates = append(candidates, it)
@@ -257,10 +295,6 @@ func (d *SiteRegistrationDataSource) Read(ctx context.Context, req datasource.Re
 		data.ClusterName = types.StringNull()
 		data.ClusterSize = types.Int64Null()
 		data.ProviderType = types.StringNull()
-		data.Token = types.StringNull()
-		if data.Hostname.IsNull() {
-			data.Hostname = types.StringNull()
-		}
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		return
 	}
@@ -273,15 +307,35 @@ func (d *SiteRegistrationDataSource) Read(ctx context.Context, req datasource.Re
 	data.ID = types.StringValue(match.Name)
 	data.Found = types.BoolValue(true)
 	data.Name = types.StringValue(match.Name)
-	data.UID = types.StringValue(uid)
-	data.State = types.StringValue(match.Object.Status.CurrentState)
-	data.ClusterName = types.StringValue(match.GetSpec.Passport.ClusterName)
-	data.ClusterSize = types.Int64Value(match.GetSpec.Passport.ClusterSize)
-	data.ProviderType = types.StringValue(match.GetSpec.Infra.Provider)
-	data.Token = types.StringValue(match.GetSpec.Token)
+	data.UID = stringOrNull(uid)
+	// Fields the API may omit are reported null rather than "" / 0, so a consumer
+	// can tell "not reported" from a real empty value (and to stay consistent with
+	// the not-found branch above).
+	data.State = stringOrNull(match.Object.Status.CurrentState)
+	data.ClusterName = stringOrNull(match.GetSpec.Passport.ClusterName)
+	data.ClusterSize = int64OrNull(match.GetSpec.Passport.ClusterSize)
+	data.ProviderType = stringOrNull(match.GetSpec.Infra.Provider)
 	if data.Hostname.IsNull() {
-		data.Hostname = types.StringValue(match.GetSpec.Infra.Hostname)
+		data.Hostname = stringOrNull(match.GetSpec.Infra.Hostname)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// stringOrNull maps an omitted (empty) API string to a null attribute value so
+// callers can distinguish "not reported" from a genuine empty string.
+func stringOrNull(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+// int64OrNull maps an omitted (zero) API integer to a null attribute value.
+// cluster_size is never legitimately 0 for a registered node.
+func int64OrNull(i int64) types.Int64 {
+	if i == 0 {
+		return types.Int64Null()
+	}
+	return types.Int64Value(i)
 }

--- a/internal/provider/site_registration_data_source.go
+++ b/internal/provider/site_registration_data_source.go
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+// Site Registration Data Source for F5 XC
+// Resolves the runtime registration of a site's Customer Edge node. A
+// registration is named "r-<uuid>", never after the site, so this lookup is
+// the only way to obtain the name that xcsh_registration_approval needs.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+)
+
+var (
+	_ datasource.DataSource              = &SiteRegistrationDataSource{}
+	_ datasource.DataSourceWithConfigure = &SiteRegistrationDataSource{}
+)
+
+// defaultRegistrationNamespace is the namespace registrations live in.
+const defaultRegistrationNamespace = "system"
+
+func NewSiteRegistrationDataSource() datasource.DataSource {
+	return &SiteRegistrationDataSource{}
+}
+
+type SiteRegistrationDataSource struct {
+	client *client.Client
+}
+
+type SiteRegistrationDataSourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	SiteName     types.String `tfsdk:"site_name"`
+	Namespace    types.String `tfsdk:"namespace"`
+	Hostname     types.String `tfsdk:"hostname"`
+	Found        types.Bool   `tfsdk:"found"`
+	Name         types.String `tfsdk:"name"`
+	UID          types.String `tfsdk:"uid"`
+	State        types.String `tfsdk:"state"`
+	ClusterName  types.String `tfsdk:"cluster_name"`
+	ClusterSize  types.Int64  `tfsdk:"cluster_size"`
+	ProviderType types.String `tfsdk:"provider_type"`
+	Token        types.String `tfsdk:"token"`
+}
+
+func (d *SiteRegistrationDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_site_registration"
+}
+
+func (d *SiteRegistrationDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `Resolves the runtime registration of a site's Customer Edge (CE) node in F5 Distributed Cloud.
+
+A registration is named ` + "`r-<uuid>`" + `, **not** after the site it belongs to, so it cannot be
+read by site name. This data source lists the registrations belonging to a site and returns the
+one that matches, giving you the name that ` + "`xcsh_registration_approval`" + ` requires.
+
+The registration only exists once the CE has booted and registered with its token. Until then
+this data source reports ` + "`found = false`" + ` **without raising an error**, so an approval can
+safely be gated on it:
+
+` + "```terraform" + `
+data "xcsh_site_registration" "ce" {
+  site_name = xcsh_securemesh_site_v2.ce.name
+}
+
+resource "xcsh_registration_approval" "ce" {
+  count     = data.xcsh_site_registration.ce.found ? 1 : 0
+  name      = data.xcsh_site_registration.ce.name
+  namespace = data.xcsh_site_registration.ce.namespace
+}
+` + "```" + `
+
+**Possible ` + "`state`" + ` values:** ` + "`NOTSET`, `NEW`, `APPROVED`, `ADMITTED`, `RETIRED`, `FAILED`, `DONE`, `PENDING`, `ONLINE`, `UPGRADING`, `MAINTENANCE`, `FAILED_INACTIVE`" + `.`,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Identifier of this lookup: the registration name when one is found, otherwise null.",
+				Computed:            true,
+			},
+			"site_name": schema.StringAttribute{
+				MarkdownDescription: "Name of the F5 XC site whose CE registration should be resolved. Matched against each registration's `get_spec.passport.cluster_name`.",
+				Required:            true,
+			},
+			"namespace": schema.StringAttribute{
+				MarkdownDescription: "Namespace holding the registrations. Defaults to `system`, where site registrations live.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"hostname": schema.StringAttribute{
+				MarkdownDescription: "Node hostname used to pick one registration when a multi-node site has several. Optional for a single-node site; when omitted, the resolved node's hostname is returned here. Hostnames are only unique within a site.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"found": schema.BoolAttribute{
+				MarkdownDescription: "Whether a registration was resolved. `false` (with no error) while the CE has not registered yet — gate an approval's `count` on this.",
+				Computed:            true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Registration name (`r-<uuid>`) to pass to `xcsh_registration_approval`. Null when `found` is `false`.",
+				Computed:            true,
+			},
+			"uid": schema.StringAttribute{
+				MarkdownDescription: "Unique identifier of the registration (the `<uuid>` part of the name).",
+				Computed:            true,
+			},
+			"state": schema.StringAttribute{
+				MarkdownDescription: "Current registration state, e.g. `PENDING` (awaiting approval) or `ONLINE` (node admitted and healthy).",
+				Computed:            true,
+			},
+			"cluster_name": schema.StringAttribute{
+				MarkdownDescription: "Cluster name the CE registered with, as reported in its passport. Equals `site_name` for a correctly configured site.",
+				Computed:            true,
+			},
+			"cluster_size": schema.Int64Attribute{
+				MarkdownDescription: "Number of nodes the CE reported for its cluster (1 for a single-node site, 3 for a three-node site).",
+				Computed:            true,
+			},
+			"provider_type": schema.StringAttribute{
+				MarkdownDescription: "Infrastructure provider the CE reported, e.g. `AZURE`, `AWS`, `GCP`, `VMWARE`.",
+				Computed:            true,
+			},
+			"token": schema.StringAttribute{
+				MarkdownDescription: "Site token the CE registered with.",
+				Computed:            true,
+				Sensitive:           true,
+			},
+		},
+	}
+}
+
+func (d *SiteRegistrationDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+// selectRegistration picks the one registration of siteName from the items the
+// registrations_by_site endpoint returned.
+//
+// The endpoint is already site-scoped, so an item is a candidate unless it
+// explicitly reports a different cluster_name (an item that reports none is
+// kept rather than dropped, which would be a false negative). When hostname is
+// set it further narrows the candidates — hostnames are only unique within a
+// site, so this is a within-site discriminator.
+//
+// No candidate returns (nil, nil): a site whose CE has not registered yet is
+// the normal case, not an error. More than one candidate returns an error
+// naming the hostnames to choose between.
+func selectRegistration(items []client.RegistrationListItem, siteName, hostname string) (*client.RegistrationListItem, error) {
+	var candidates []client.RegistrationListItem
+	for _, it := range items {
+		if cn := it.GetSpec.Passport.ClusterName; cn != "" && cn != siteName {
+			continue
+		}
+		if hostname != "" && it.GetSpec.Infra.Hostname != hostname {
+			continue
+		}
+		candidates = append(candidates, it)
+	}
+
+	switch len(candidates) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &candidates[0], nil
+	}
+
+	hostnames := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		h := c.GetSpec.Infra.Hostname
+		if h == "" {
+			h = fmt.Sprintf("(no hostname, registration %s)", c.Name)
+		}
+		hostnames = append(hostnames, h)
+	}
+	sort.Strings(hostnames)
+
+	return nil, fmt.Errorf(
+		"site %q has %d matching registrations (node hostnames: %s); set the hostname argument to select one",
+		siteName, len(candidates), strings.Join(hostnames, ", "),
+	)
+}
+
+func (d *SiteRegistrationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data SiteRegistrationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	namespace := data.Namespace.ValueString()
+	if data.Namespace.IsNull() || namespace == "" {
+		namespace = defaultRegistrationNamespace
+	}
+	// Echo the configured value back verbatim so the read stays consistent
+	// with the configuration.
+	if data.Namespace.IsNull() {
+		data.Namespace = types.StringValue(namespace)
+	}
+
+	siteName := data.SiteName.ValueString()
+	configuredHostname := data.Hostname.ValueString()
+	if data.Hostname.IsNull() {
+		configuredHostname = ""
+	}
+
+	list, err := d.client.ListRegistrationsBySite(ctx, namespace, siteName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to list registrations for site %q in namespace %q: %s", siteName, namespace, err),
+		)
+		return
+	}
+
+	if len(list.Errors) > 0 {
+		msgs := make([]string, 0, len(list.Errors))
+		for _, e := range list.Errors {
+			msgs = append(msgs, strings.TrimSpace(e.Code+" "+e.Message))
+		}
+		resp.Diagnostics.AddError(
+			"F5 XC API Error",
+			fmt.Sprintf("Listing registrations for site %q in namespace %q returned errors: %s", siteName, namespace, strings.Join(msgs, "; ")),
+		)
+		return
+	}
+
+	match, err := selectRegistration(list.Items, siteName, configuredHostname)
+	if err != nil {
+		resp.Diagnostics.AddError("Ambiguous Site Registration", err.Error())
+		return
+	}
+
+	if match == nil {
+		// The CE has not registered yet (or the site does not exist). This is
+		// an expected steady state before the node boots, so it is reported
+		// without an error: consumers gate an approval's count on found.
+		data.ID = types.StringNull()
+		data.Found = types.BoolValue(false)
+		data.Name = types.StringNull()
+		data.UID = types.StringNull()
+		data.State = types.StringNull()
+		data.ClusterName = types.StringNull()
+		data.ClusterSize = types.Int64Null()
+		data.ProviderType = types.StringNull()
+		data.Token = types.StringNull()
+		if data.Hostname.IsNull() {
+			data.Hostname = types.StringNull()
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
+	uid := match.UID
+	if uid == "" {
+		uid = match.SystemMetadata.UID
+	}
+
+	data.ID = types.StringValue(match.Name)
+	data.Found = types.BoolValue(true)
+	data.Name = types.StringValue(match.Name)
+	data.UID = types.StringValue(uid)
+	data.State = types.StringValue(match.Object.Status.CurrentState)
+	data.ClusterName = types.StringValue(match.GetSpec.Passport.ClusterName)
+	data.ClusterSize = types.Int64Value(match.GetSpec.Passport.ClusterSize)
+	data.ProviderType = types.StringValue(match.GetSpec.Infra.Provider)
+	data.Token = types.StringValue(match.GetSpec.Token)
+	if data.Hostname.IsNull() {
+		data.Hostname = types.StringValue(match.GetSpec.Infra.Hostname)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/site_registration_data_source_test.go
+++ b/internal/provider/site_registration_data_source_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/internal/client"
+)
+
+// item builds a RegistrationListItem carrying only the fields selectRegistration
+// looks at.
+func item(name, clusterName, hostname, state string) client.RegistrationListItem {
+	return client.RegistrationListItem{
+		Name: name,
+		Object: client.RegistrationObject{
+			Status: client.RegistrationStatus{CurrentState: state},
+		},
+		GetSpec: client.RegistrationGetSpec{
+			Infra:    client.RegistrationInfra{Hostname: hostname},
+			Passport: client.RegistrationPassport{ClusterName: clusterName},
+		},
+	}
+}
+
+// A registered single-node site resolves to its one registration.
+func TestSelectRegistration_SingleMatch(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-dcec2400-52d5-4154-9fd0-4b042d3fe18d", "ar-bgp-eastus01", "f5-xc-ce-vm-01", "ONLINE"),
+	}
+
+	got, err := selectRegistration(items, "ar-bgp-eastus01", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got == nil {
+		t.Fatal("selectRegistration() = nil, want the single registration")
+	}
+	if got.Name != "r-dcec2400-52d5-4154-9fd0-4b042d3fe18d" {
+		t.Errorf("Name = %q, want %q", got.Name, "r-dcec2400-52d5-4154-9fd0-4b042d3fe18d")
+	}
+	if got.Object.Status.CurrentState != "ONLINE" {
+		t.Errorf("CurrentState = %q, want %q", got.Object.Status.CurrentState, "ONLINE")
+	}
+}
+
+// The normal not-yet-registered case: no items, no match, and crucially NO
+// error — a consumer gates a count on this and an error would break early
+// plans.
+func TestSelectRegistration_EmptyItemsIsNotAnError(t *testing.T) {
+	got, err := selectRegistration(nil, "ar-bgp-eastus01", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil for an unregistered site", err)
+	}
+	if got != nil {
+		t.Fatalf("selectRegistration() = %+v, want nil", got)
+	}
+
+	got, err = selectRegistration([]client.RegistrationListItem{}, "ar-bgp-eastus01", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil for an empty items slice", err)
+	}
+	if got != nil {
+		t.Fatalf("selectRegistration() = %+v, want nil", got)
+	}
+}
+
+// A multi-node site is disambiguated by hostname.
+func TestSelectRegistration_HostnameDiscriminator(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "ha-site", "master-0", "ONLINE"),
+		item("r-bbb", "ha-site", "master-1", "PENDING"),
+	}
+
+	got, err := selectRegistration(items, "ha-site", "master-1")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got == nil {
+		t.Fatal("selectRegistration() = nil, want the master-1 registration")
+	}
+	if got.Name != "r-bbb" {
+		t.Errorf("Name = %q, want %q", got.Name, "r-bbb")
+	}
+}
+
+// Several candidates and no way to choose is a configuration error, and the
+// message must name the candidate hostnames so the operator can set one.
+func TestSelectRegistration_AmbiguousIsAnError(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "ha-site", "master-0", "ONLINE"),
+		item("r-bbb", "ha-site", "master-1", "ONLINE"),
+	}
+
+	got, err := selectRegistration(items, "ha-site", "")
+	if err == nil {
+		t.Fatalf("selectRegistration() = %+v, want an ambiguity error", got)
+	}
+	if got != nil {
+		t.Errorf("selectRegistration() = %+v, want nil alongside the error", got)
+	}
+	for _, want := range []string{"master-0", "master-1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention candidate hostname %q", err.Error(), want)
+		}
+	}
+}
+
+// A hostname that matches nothing is the same benign "not registered yet"
+// outcome as an empty list, not an error.
+func TestSelectRegistration_UnmatchedHostnameIsNotAnError(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "ha-site", "master-0", "ONLINE"),
+	}
+
+	got, err := selectRegistration(items, "ha-site", "master-9")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("selectRegistration() = %+v, want nil", got)
+	}
+}
+
+// The endpoint is already site-scoped, but a registration reporting a
+// different cluster_name belongs to another site and must not be selected.
+func TestSelectRegistration_ForeignClusterNameIsFilteredOut(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "some-other-site", "master-0", "ONLINE"),
+	}
+
+	got, err := selectRegistration(items, "ar-bgp-eastus01", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("selectRegistration() = %+v, want nil", got)
+	}
+}
+
+// A registration that reports no cluster_name at all is kept: the endpoint
+// already scoped the list to the site, so dropping it would be a false
+// negative.
+func TestSelectRegistration_MissingClusterNameIsKept(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "", "master-0", "NEW"),
+	}
+
+	got, err := selectRegistration(items, "ar-bgp-eastus01", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got == nil || got.Name != "r-aaa" {
+		t.Fatalf("selectRegistration() = %+v, want the r-aaa registration", got)
+	}
+}

--- a/internal/provider/site_registration_data_source_test.go
+++ b/internal/provider/site_registration_data_source_test.go
@@ -155,3 +155,152 @@ func TestSelectRegistration_MissingClusterNameIsKept(t *testing.T) {
 		t.Fatalf("selectRegistration() = %+v, want the r-aaa registration", got)
 	}
 }
+
+// Rebuilding a CE under the same site name leaves the previous registration
+// behind in F5 XC, and registrations_by_site keeps returning it: the tenant
+// really does carry FAILED_INACTIVE registrations whose cluster_name AND
+// hostname are identical to the live node's. Neither filter can separate them,
+// so without dropping terminal states this resolved to an ambiguity error and
+// failed the consumer's whole plan — strictly worse than found = false.
+func TestSelectRegistration_StaleRegistrationIsSkipped(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-stale", "appstack-demo", "master-0", "FAILED_INACTIVE"),
+		item("r-live", "appstack-demo", "master-0", "ONLINE"),
+	}
+
+	got, err := selectRegistration(items, "appstack-demo", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil: a stale registration must not make the lookup ambiguous", err)
+	}
+	if got == nil {
+		t.Fatal("selectRegistration() = nil, want the live ONLINE registration")
+	}
+	if got.Name != "r-live" {
+		t.Errorf("Name = %q, want %q", got.Name, "r-live")
+	}
+	if got.Object.Status.CurrentState != "ONLINE" {
+		t.Errorf("CurrentState = %q, want %q", got.Object.Status.CurrentState, "ONLINE")
+	}
+}
+
+// Order must not matter: the live registration is selected whether it precedes
+// or follows the stale one in the API response.
+func TestSelectRegistration_StaleRegistrationIsSkippedRegardlessOfOrder(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-live", "appstack-demo", "master-0", "PENDING"),
+		item("r-stale", "appstack-demo", "master-0", "FAILED_INACTIVE"),
+	}
+
+	got, err := selectRegistration(items, "appstack-demo", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got == nil || got.Name != "r-live" {
+		t.Fatalf("selectRegistration() = %+v, want the r-live registration", got)
+	}
+}
+
+// Every terminal registrationObjectState is skipped in favour of a live one.
+func TestSelectRegistration_EveryTerminalStateIsSkipped(t *testing.T) {
+	for _, state := range []string{"RETIRED", "FAILED", "FAILED_INACTIVE", "DONE"} {
+		t.Run(state, func(t *testing.T) {
+			items := []client.RegistrationListItem{
+				item("r-stale", "ha-site", "master-0", state),
+				item("r-live", "ha-site", "master-0", "ONLINE"),
+			}
+
+			got, err := selectRegistration(items, "ha-site", "")
+			if err != nil {
+				t.Fatalf("selectRegistration() error = %v, want nil for a stale %s registration", err, state)
+			}
+			if got == nil || got.Name != "r-live" {
+				t.Fatalf("selectRegistration() = %+v, want the r-live registration", got)
+			}
+		})
+	}
+}
+
+// A non-terminal state is never skipped, so a site awaiting approval still
+// resolves.
+func TestSelectRegistration_NonTerminalStatesAreKept(t *testing.T) {
+	for _, state := range []string{"NOTSET", "NEW", "APPROVED", "ADMITTED", "PENDING", "ONLINE", "UPGRADING", "MAINTENANCE"} {
+		t.Run(state, func(t *testing.T) {
+			items := []client.RegistrationListItem{
+				item("r-aaa", "ha-site", "master-0", state),
+			}
+
+			got, err := selectRegistration(items, "ha-site", "")
+			if err != nil {
+				t.Fatalf("selectRegistration() error = %v, want nil", err)
+			}
+			if got == nil || got.Name != "r-aaa" {
+				t.Fatalf("selectRegistration() = %+v, want the r-aaa registration for state %s", got, state)
+			}
+		})
+	}
+}
+
+// When every candidate is terminal there is nothing live to approve, which is
+// the benign found = false outcome — NOT an error. A site whose CE was
+// destroyed must not fail its consumer's plan.
+func TestSelectRegistration_AllTerminalIsNotAnError(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "ha-site", "master-0", "FAILED_INACTIVE"),
+		item("r-bbb", "ha-site", "master-1", "RETIRED"),
+	}
+
+	got, err := selectRegistration(items, "ha-site", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil when every registration is terminal", err)
+	}
+	if got != nil {
+		t.Fatalf("selectRegistration() = %+v, want nil", got)
+	}
+}
+
+// Dropping terminal candidates must not weaken the ambiguity guard: a genuine
+// multi-node site (cluster_size 3) with no hostname set is still an error, and
+// the message names only the live candidates.
+func TestSelectRegistration_AmbiguityAmongLiveCandidatesSurvivesTerminalFiltering(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-stale", "ha-site", "master-9", "RETIRED"),
+		item("r-aaa", "ha-site", "master-0", "ONLINE"),
+		item("r-bbb", "ha-site", "master-1", "PENDING"),
+	}
+
+	got, err := selectRegistration(items, "ha-site", "")
+	if err == nil {
+		t.Fatalf("selectRegistration() = %+v, want an ambiguity error", got)
+	}
+	if got != nil {
+		t.Errorf("selectRegistration() = %+v, want nil alongside the error", got)
+	}
+	for _, want := range []string{"master-0", "master-1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention live candidate hostname %q", err.Error(), want)
+		}
+	}
+	if strings.Contains(err.Error(), "master-9") {
+		t.Errorf("error %q names the retired candidate hostname master-9", err.Error())
+	}
+	if !strings.Contains(err.Error(), "2 matching registrations") {
+		t.Errorf("error %q does not count exactly the 2 live candidates", err.Error())
+	}
+}
+
+// A registration reporting no state at all is kept, for the same defensive
+// reason a registration reporting no cluster_name is: a missing field must
+// never turn a real match into a miss.
+func TestSelectRegistration_MissingStateIsKept(t *testing.T) {
+	items := []client.RegistrationListItem{
+		item("r-aaa", "ha-site", "master-0", ""),
+	}
+
+	got, err := selectRegistration(items, "ha-site", "")
+	if err != nil {
+		t.Fatalf("selectRegistration() error = %v, want nil", err)
+	}
+	if got == nil || got.Name != "r-aaa" {
+		t.Fatalf("selectRegistration() = %+v, want the r-aaa registration", got)
+	}
+}

--- a/scripts/check-no-generated-files.sh
+++ b/scripts/check-no-generated-files.sh
@@ -32,8 +32,10 @@ MANUALLY_MAINTAINED_FILES=(
   "internal/provider/functions_registration.go"
   "internal/provider/addon_service_data_source.go"
   "internal/provider/addon_service_activation_status_data_source.go"
+  "internal/provider/site_registration_data_source.go"
   "examples/data-sources/addon_service/data-source.tf"
   "examples/data-sources/addon_service_activation_status/data-source.tf"
+  "examples/data-sources/site_registration/data-source.tf"
   # MkDocs documentation site index files (navigation, not provider docs)
   "docs/resources/index.md"
   "docs/data-sources/index.md"

--- a/tools/generate-examples.go
+++ b/tools/generate-examples.go
@@ -36,6 +36,7 @@ const providerDir = "internal/provider"
 var manuallyMaintained = map[string]bool{
 	"addon_service":                   true,
 	"addon_service_activation_status": true,
+	"site_registration":               true,
 }
 
 var (

--- a/tools/pkg/registration/registration.go
+++ b/tools/pkg/registration/registration.go
@@ -32,6 +32,7 @@ var CoreResources = []string{}
 var StandaloneDataSources = []string{
 	"addon_service",                   // xcsh_addon_service — addon tier/details
 	"addon_service_activation_status", // xcsh_addon_service_activation_status — entitlement/subscription state
+	"site_registration",               // xcsh_site_registration — resolve a site's CE registration name ("r-<uuid>")
 }
 
 // GenerateCombinedClientTypes is a no-op placeholder retained for interface

--- a/tools/pkg/registration/registration_test.go
+++ b/tools/pkg/registration/registration_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/naming"
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
 )
 
@@ -134,6 +135,55 @@ func TestGenerateProviderRegistration(t *testing.T) {
 	// Should NOT contain failed resource
 	if contains(contentStr, "NewFailedResourceResource") {
 		t.Error("did not expect NewFailedResourceResource in provider.go")
+	}
+}
+
+// Hand-written standalone data sources have no generated companion, so the
+// only thing wiring them into the provider is StandaloneDataSources. If an
+// entry is missing, the data source is silently absent from the released
+// provider; if an entry does not match its Go constructor, provider.go stops
+// compiling. Both are guarded here.
+func TestGenerateProviderRegistration_StandaloneDataSources(t *testing.T) {
+	outDir := t.TempDir()
+
+	GenerateProviderRegistration(nil, outDir)
+
+	content, err := os.ReadFile(filepath.Join(outDir, "provider.go"))
+	if err != nil {
+		t.Fatalf("provider.go was not created: %v", err)
+	}
+	contentStr := string(content)
+
+	// repoRoot is three levels up from tools/pkg/registration.
+	repoRoot := filepath.Join("..", "..", "..")
+
+	for _, ds := range StandaloneDataSources {
+		ctor := "New" + naming.ToResourceTypeName(ds) + "DataSource,"
+		if !contains(contentStr, ctor) {
+			t.Errorf("standalone data source %q: expected %s in provider.go DataSources()", ds, ctor)
+		}
+
+		implPath := filepath.Join(repoRoot, "internal", "provider", ds+"_data_source.go")
+		impl, err := os.ReadFile(implPath) //nolint:gosec // fixed path derived from the allowlist
+		if err != nil {
+			t.Errorf("standalone data source %q: no hand-written implementation at %s: %v", ds, implPath, err)
+			continue
+		}
+		if !contains(string(impl), "func New"+naming.ToResourceTypeName(ds)+"DataSource(") {
+			t.Errorf("standalone data source %q: %s does not define New%sDataSource — provider.go would not compile",
+				ds, implPath, naming.ToResourceTypeName(ds))
+		}
+		// Standalone files are hand-written and must never carry the
+		// generated-file header, or CleanOrphanGeneratedFiles deletes them.
+		if contains(string(impl), "DO NOT EDIT") {
+			t.Errorf("standalone data source %q: %s carries a DO NOT EDIT header and would be pruned as an orphan", ds, implPath)
+		}
+	}
+
+	// xcsh_site_registration resolves a CE's runtime registration name and is
+	// required by the registration-approval workflow.
+	if !contains(contentStr, "NewSiteRegistrationDataSource,") {
+		t.Error("expected NewSiteRegistrationDataSource in provider.go DataSources()")
 	}
 }
 


### PR DESCRIPTION
## What
Adds a **`xcsh_site_registration`** data source that resolves a CE's runtime registration name — `r-<uuid>` — from its site name, so `xcsh_registration_approval` can finally be used from a config. Registrations are *not* named after their site (`GET .../registrations/<site>` → 404), and the spec says the name "is taken from listing pending registrations", so this lookup is the missing link for automated CE approval.

## How
Backed by the already-enriched operation `ves.io.schema.registration.CustomAPI.ListRegistrationsBySite`:

```
GET /api/register/namespaces/{namespace}/registrations_by_site/{site_name}
```

- `internal/client/site_registration_types.go` — hand-written `ListRegistrationsBySite` + response types, reusing `GetLenient` (same as the approve resource's Read).
- `internal/provider/site_registration_data_source.go` — hand-written **standalone** data source (no `DO NOT EDIT` header), registered via the sanctioned `StandaloneDataSources` mechanism (precedent: `addon_service_activation_status`).
  - Arguments: `site_name` (Required), `namespace` (Optional, defaults to `system`, rejects `""`), `hostname` (Optional discriminator — hostnames are only unique *within* a site).
  - Computed: `name` (`r-<uuid>`), `found`, `state`, `uid`, `hostname`, `cluster_name`, `cluster_size`, `provider_type`.
- **Key contract:** no match ⇒ `found = false` with **no error diagnostic** — the endpoint returns HTTP 200 + `items: []` (never 404) for a CE that hasn't registered yet, so a consumer can gate an approval's `count` on `found` without breaking an early plan. API `errors[]` *are* surfaced; a genuine multi-node tie errors with the candidate hostnames named.
- **Stale-registration safety:** terminal states (`RETIRED`, `FAILED`, `FAILED_INACTIVE`, `DONE`) are dropped before the ambiguity check. Without this, a CE rebuilt under the same site name returns the dead *and* live registration with identical `cluster_name` and `hostname`, and the resulting ambiguity error would fail the consumer's whole plan.

## Why hand-written rather than generated
The codegen cannot emit collection data sources (0 of 144 generated data sources return a list) — adding that is a ~7-step generator capability (filed as #1279) and would force a ~288 KB unfiltered `registrations` fetch versus ~17 KB for this server-side-filtered call. Standalone data sources are the repo's sanctioned mechanism for exactly this case, and are never clobbered by regeneration.

## Tests
- 3 client httptest cases (field mapping; `items: []` ⇒ 0 items + **nil error**; a control-char body that a strict `Get` would reject, exercising the `GetLenient` choice).
- 11 `selectRegistration` cases incl. empty-is-not-an-error, ambiguity-is-an-error, every terminal state skipped, all-terminal ⇒ no match + no error, empty state not treated as terminal, and the stale+live same-hostname regression.
- A guard test asserting the generator emits `NewSiteRegistrationDataSource` into `provider.go` — load-bearing, since `provider.go` is generated and cannot be committed here (verified it fails if the `StandaloneDataSources` entry is removed, or if a `DO NOT EDIT` header would cause pruning).
- `go test ./internal/... ./tools/...` green; `golangci-lint` 0 issues; `go vet`/`gofmt`/`codespell` clean; `scripts/check-no-generated-files.sh` passes with the new files staged.

## Live verification (read-only; nothing mutated)
- `site_name = "ar-bgp-eastus01"` → `found = true`, `name = "r-dcec2400-52d5-4154-9fd0-4b042d3fe18d"`, `state = "ONLINE"`, `hostname = "f5-xc-ce-vm-01"`, `cluster_size = 1`, `provider_type = "AZURE"`.
- Nonexistent site → `found = false`, all attributes null, **no error**.
- `ar-bgp-eastus02` + `hostname` discriminator → `r-8388c401-…`; a wrong hostname → `found = false`, no error.

## Notes
- Four allowlists had to be updated for a standalone data source (`StandaloneDataSources`, `manuallyMaintained`, `check-no-generated-files.sh`, and a duplicate list in `ci.yml`) — the duplication is filed as #1280.
- The example dir is unprefixed (`examples/data-sources/site_registration/`) because `pruneOrphanExampleDirs` deletes `xcsh_*` dirs lacking a generated companion.
- `NewSiteRegistrationDataSource` reaches the provider via the post-merge auto-regenerate PR, since `provider.go` is generated.

Part of epic #1207 (slice S6-D1). Unblocks automated CE approval in f5-sales-demo/mcn#591 (#1210). Related follow-ups: #1278 (approve idempotence), #1279 (list-data-source codegen), #1280 (allowlist duplication).

Closes #1277
