### PR TITLE
S7 PR-1: fix securemesh_site_v2 import-marker drift (#1244) and config-declared empty metadata maps (#1286)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,6 @@ wheels/
 *.test
 *.out
 vendor/
-# Built provider binary at the repo root (make build / go build .) — anchored so it
-# does not ignore the identically-named repo directory when nested elsewhere.
-/terraform-provider-xcsh
 
 # Terraform
 .terraform/

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ wheels/
 *.test
 *.out
 vendor/
+# Built provider binary at the repo root (make build / go build .) — anchored so it
+# does not ignore the identically-named repo directory when nested elsewhere.
+/terraform-provider-xcsh
 
 # Terraform
 .terraform/

--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -536,12 +536,27 @@ var (
 	flagNSPrefix = flag.String("ns-prefix", "tf-discover", "Prefix for auto-created test namespace")
 )
 
+// strandedObjects records every discovery probe object whose DELETE never succeeded.
+// Discovery creates real objects in SHARED namespaces (securemesh_site_v2 lands in
+// "system", alongside the live demo sites — #1244), so a failed cleanup leaks a
+// tf-discover-* object forever. Anything recorded here fails the run (see main).
+var strandedObjects []string
+
 // ============================================================================
 // Main
 // ============================================================================
 
 func main() {
 	flag.Parse()
+
+	// Registered FIRST so it runs LAST (defers are LIFO): the test-namespace cleanup
+	// deferred below still gets to run before the process exits non-zero.
+	exitCode := 0
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
 
 	if !*flagAll && *flagResource == "" && *flagPattern == "" && !*flagValidate {
 		fmt.Println("Usage: go run tools/discover-defaults.go [options]")
@@ -704,6 +719,16 @@ func main() {
 	fmt.Printf("Skipped:         %d\n", db.Skipped)
 	fmt.Printf("Failed:          %d\n", db.Failed)
 	fmt.Printf("Output:          %s\n", *flagOutput)
+
+	// A leaked probe object in a shared namespace is a real defect, not a warning: fail the
+	// run (the monthly -all workflow) so it gets noticed and cleaned up.
+	if len(strandedObjects) > 0 {
+		fmt.Fprintf(os.Stderr, "\n!! %d discovery probe object(s) could not be deleted and are STRANDED:\n", len(strandedObjects))
+		for _, p := range strandedObjects {
+			fmt.Fprintf(os.Stderr, "!!   %s\n", p)
+		}
+		exitCode = 1
+	}
 }
 
 // ============================================================================
@@ -948,7 +973,19 @@ func cleanupResource(ctx context.Context, apiClient *client.Client, resourceName
 		fmt.Printf("  DELETE %s\n", deletePath)
 	}
 
-	_ = apiClient.Delete(ctx, deletePath)
+	// Retry a failing DELETE (transient 5xx, or the brief referential BAD_REQUEST the API
+	// returns while an object is still referenced) and never swallow the final error: an
+	// undeleted probe object is stranded in a shared namespace. Detach from the discovery
+	// deadline so cleanup still runs when that context is already spent.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
+	defer cancel()
+	if err := discovery.DeleteWithRetry(func() error {
+		return apiClient.Delete(cleanupCtx, deletePath)
+	}, 3, 2*time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "\n!! CLEANUP FAILED: DELETE %s after 3 attempts: %v\n", deletePath, err)
+		fmt.Fprintf(os.Stderr, "!! probe object %s is STRANDED and must be deleted by hand.\n\n", name)
+		strandedObjects = append(strandedObjects, deletePath)
+	}
 }
 
 func pluralizeResource(name string) string {

--- a/tools/discover-defaults.go
+++ b/tools/discover-defaults.go
@@ -465,6 +465,58 @@ var ResourceConfigs = map[string]MinimalConfig{
 			"dscp_value": 46,
 		},
 	},
+
+	// Secure Mesh Site v2 (#1244). A single-node `azure` `not_managed` site creates,
+	// reads and deletes with HTTP 200 and NO backing Azure VM, so its server defaults
+	// are discoverable — which is how the per-interface `labels {}` empty marker that
+	// caused #1244 gets auto-derived instead of hand-seeded. Minimal spec only: send
+	// nothing we want to DISCOVER as a default (interface_list[].labels, and the site
+	// oneof base members). Lives in the fixed "system" namespace (see the path switch
+	// in createAndGetResource / cleanupResource), never a per-run test namespace.
+	"securemesh_site_v2": {
+		Category:  CategoryCloudSite,
+		Namespace: false, // system namespace
+		RequiredSpec: map[string]interface{}{
+			"azure": map[string]interface{}{
+				"not_managed": map[string]interface{}{
+					"node_list": []interface{}{
+						map[string]interface{}{
+							"hostname": "tf-discover-node-01",
+							"type":     "Control",
+							"interface_list": []interface{}{
+								map[string]interface{}{
+									"name":               "eth0",
+									"ethernet_interface": map[string]interface{}{"device": "eth0"},
+									"network_option": map[string]interface{}{
+										"site_local_network": map[string]interface{}{},
+									},
+									"dhcp_client":      map[string]interface{}{},
+									"no_ipv6_address":  map[string]interface{}{},
+									"monitor_disabled": map[string]interface{}{},
+									"site_to_site_connectivity_interface_disabled": map[string]interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+			"block_all_services": map[string]interface{}{},
+			"disable_ha":         map[string]interface{}{},
+			"dns_ntp_config": map[string]interface{}{
+				"f5_dns_default": map[string]interface{}{},
+				"f5_ntp_default": map[string]interface{}{},
+			},
+			"local_vrf": map[string]interface{}{
+				"default_config":     map[string]interface{}{},
+				"default_sli_config": map[string]interface{}{},
+			},
+			"performance_enhancement_mode": map[string]interface{}{
+				"perf_mode_l3_enhanced": map[string]interface{}{
+					"no_jumbo": map[string]interface{}{},
+				},
+			},
+		},
+	},
 }
 
 // ============================================================================
@@ -838,6 +890,10 @@ func createAndGetResource(ctx context.Context, apiClient *client.Client, resourc
 	case "contact":
 		createPath = "/api/web/system/contacts"
 		getPath = fmt.Sprintf("/api/web/system/contacts/%s", name)
+	case "securemesh_site_v2":
+		// Site objects exist only in the fixed "system" namespace (#1244).
+		createPath = "/api/config/namespaces/system/securemesh_site_v2s"
+		getPath = fmt.Sprintf("/api/config/namespaces/system/securemesh_site_v2s/%s", name)
 	default:
 		// Most resources follow this pattern
 		pluralName := pluralizeResource(resourceName)
@@ -881,6 +937,8 @@ func cleanupResource(ctx context.Context, apiClient *client.Client, resourceName
 		deletePath = fmt.Sprintf("/api/web/namespaces/%s", name)
 	case "contact":
 		deletePath = fmt.Sprintf("/api/web/system/contacts/%s", name)
+	case "securemesh_site_v2":
+		deletePath = fmt.Sprintf("/api/config/namespaces/system/securemesh_site_v2s/%s", name)
 	default:
 		pluralName := pluralizeResource(resourceName)
 		deletePath = fmt.Sprintf("/api/config/namespaces/%s/%s/%s", namespace, pluralName, name)

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -430,6 +430,9 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesEmptyMarkerListElement_Issue
 	}{
 		{"OriginPool", "Labels", "labels"},
 		{"HTTPLoadBalancer", "EndpointSubsets", "endpoint_subsets"},
+		// #1244: same class on securemesh_site_v2 — the server materializes labels {} on
+		// every azure.not_managed.node_list[].interface_list[] element.
+		{"SecuremeshSiteV2", "Labels", "labels"},
 	}
 	for _, c := range cases {
 		var sb strings.Builder
@@ -442,20 +445,23 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesEmptyMarkerListElement_Issue
 	}
 }
 
-// #1103 non-collision: seeding OriginPool.labels suppresses ONLY the origin_servers[]
-// empty-marker block. The top-level metadata.labels is a types.Map rendered by a
+// #1103 / #1244 non-collision: seeding a resource's "labels" suppresses ONLY the
+// empty-marker blocks (origin_pool origin_servers[].labels, securemesh_site_v2
+// interface_list[].labels). The top-level metadata.labels is a types.Map rendered by a
 // different path that never consults isImportDefaultSuppressed, so a map-typed "labels"
 // child must NOT acquire an empty-marker import-suppression guard.
 func TestRenderUnmarshalChild_MetadataLabelsMapNotSuppressed_Issue1103(t *testing.T) {
-	var sb strings.Builder
-	mapAttr := openapi.TerraformAttribute{GoName: "Labels", TfsdkTag: "labels", JsonName: "labels", Type: "map", ElementType: "string"}
-	renderUnmarshalChild(&sb, "OriginPool", "", mapAttr, "metaMap", "", "", "single", "\t")
-	got := sb.String()
-	if strings.Contains(got, "EmptyModel{}") {
-		t.Errorf("metadata.labels (types.Map) must not render as an empty-marker block; got:\n%s", got)
-	}
-	if strings.Contains(got, "if !isImport {") {
-		t.Errorf("metadata.labels (types.Map) must not acquire an empty-marker import-suppression guard; got:\n%s", got)
+	for _, rc := range []string{"OriginPool", "SecuremeshSiteV2"} {
+		var sb strings.Builder
+		mapAttr := openapi.TerraformAttribute{GoName: "Labels", TfsdkTag: "labels", JsonName: "labels", Type: "map", ElementType: "string"}
+		renderUnmarshalChild(&sb, rc, "", mapAttr, "metaMap", "", "", "single", "\t")
+		got := sb.String()
+		if strings.Contains(got, "EmptyModel{}") {
+			t.Errorf("%s metadata.labels (types.Map) must not render as an empty-marker block; got:\n%s", rc, got)
+		}
+		if strings.Contains(got, "if !isImport {") {
+			t.Errorf("%s metadata.labels (types.Map) must not acquire an empty-marker import-suppression guard; got:\n%s", rc, got)
+		}
 	}
 }
 

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -695,6 +695,71 @@ func TestUnmarshal_PreservesUnconfiguredList(t *testing.T) {
 	}
 }
 
+// #1286: the metadata read-back must distinguish "absent from config" from
+// "declared empty". A config that declares `labels = {}` (or `annotations = {}`)
+// gets no labels back from the F5 XC API, and nulling the attribute on every Read
+// makes a plain post-apply plan drift `+ labels = {}` forever — no import involved.
+// So when the API returns no entries: keep a KNOWN EMPTY prior value as an empty
+// map, and null it only when the prior value is itself null (never declared) or
+// unknown. A prior value with entries must still be nulled, so genuine
+// out-of-band deletion still shows as drift.
+func TestResourceTemplate_PreservesConfigDeclaredEmptyMetadataMap_Issue1286(t *testing.T) {
+	// Render a real resource file: the assertion is on emitted Go, not template text.
+	tmpl := &openapi.ResourceTemplate{
+		Name:               "zz_metadata_probe",
+		TitleCase:          "ZZMetadataProbe",
+		Description:        "Probe.",
+		HasNamespaceInPath: true,
+		APIPath:            "/api/config/namespaces/%s/zz_metadata_probes",
+		APIPathItem:        "/api/config/namespaces/%s/zz_metadata_probes/%s",
+		Attributes: []openapi.TerraformAttribute{
+			{Name: "name", GoName: "Name", TfsdkTag: "name", Type: "string", JsonName: "name", Required: true},
+			{Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string", JsonName: "namespace", Required: true},
+		},
+	}
+	dir := t.TempDir()
+	if err := GenerateResourceFile(tmpl, dir); err != nil {
+		t.Fatalf("GenerateResourceFile: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "zz_metadata_probe_resource.go"))
+	if err != nil {
+		t.Fatalf("reading rendered resource: %v", err)
+	}
+	got := string(b)
+
+	// Isolate the Read body — the only place the API response overwrites metadata maps.
+	readIdx := strings.Index(got, ") Read(ctx context.Context")
+	if readIdx == -1 {
+		t.Fatal("rendered resource has no Read method")
+	}
+	read := got[readIdx:]
+	if end := strings.Index(read, ") Update(ctx context.Context"); end != -1 {
+		read = read[:end]
+	}
+
+	for _, attr := range []string{"Labels", "Annotations"} {
+		nullAssign := "data." + attr + " = types.MapNull(types.StringType)"
+		emptyAssign := "data." + attr + " = types.MapValueMust(types.StringType, nil)"
+		if !strings.Contains(read, emptyAssign) {
+			t.Errorf("Read must preserve a config-declared empty %s as an empty map (#1286); expected %q in:\n%s", attr, emptyAssign, read)
+		}
+		if !strings.Contains(read, nullAssign) {
+			t.Errorf("Read must still null %s when it was never declared (#1286); expected %q in:\n%s", attr, nullAssign, read)
+		}
+		// Every null assignment must be gated on the prior value being null/unknown —
+		// an unguarded null is exactly the #1286 drift.
+		for _, guard := range []string{
+			"data." + attr + ".IsNull()",
+			"data." + attr + ".IsUnknown()",
+			"len(data." + attr + ".Elements()) == 0",
+		} {
+			if !strings.Contains(read, guard) {
+				t.Errorf("Read must gate the %s null-vs-empty decision on the prior value (#1286); expected %q in:\n%s", attr, guard, read)
+			}
+		}
+	}
+}
+
 // Import mode is a one-shot: the generated Read must clear the isImport private-state marker,
 // otherwise every subsequent refresh re-enters import mode and drifts on server-managed fields.
 func TestResourceTemplate_ClearsImportMarkerAfterImport(t *testing.T) {

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -445,23 +445,98 @@ func TestRenderUnmarshalSingleChild_ImportSuppressesEmptyMarkerListElement_Issue
 	}
 }
 
-// #1103 / #1244 non-collision: seeding a resource's "labels" suppresses ONLY the
-// empty-marker blocks (origin_pool origin_servers[].labels, securemesh_site_v2
-// interface_list[].labels). The top-level metadata.labels is a types.Map rendered by a
-// different path that never consults isImportDefaultSuppressed, so a map-typed "labels"
-// child must NOT acquire an empty-marker import-suppression guard.
-func TestRenderUnmarshalChild_MetadataLabelsMapNotSuppressed_Issue1103(t *testing.T) {
-	for _, rc := range []string{"OriginPool", "SecuremeshSiteV2"} {
-		var sb strings.Builder
-		mapAttr := openapi.TerraformAttribute{GoName: "Labels", TfsdkTag: "labels", JsonName: "labels", Type: "map", ElementType: "string"}
-		renderUnmarshalChild(&sb, rc, "", mapAttr, "metaMap", "", "", "single", "\t")
-		got := sb.String()
-		if strings.Contains(got, "EmptyModel{}") {
-			t.Errorf("%s metadata.labels (types.Map) must not render as an empty-marker block; got:\n%s", rc, got)
+// #1103 / #1244 non-collision: seeding a resource's "labels" suppresses ONLY the nested
+// empty-marker blocks (origin_pool origin_servers[].labels, securemesh_site_v2's 13
+// *EmptyModel labels). The top-level metadata `labels` is a types.Map emitted by static
+// ResourceTemplate text that never consults isImportDefaultSuppressed, and it is written
+// BEFORE the isImport marker is even read — so it must never acquire the suppression
+// guard. Render a real resource file (TitleCase SecuremeshSiteV2, so the seed is live)
+// carrying both shapes and assert the two paths differ: metadata unguarded, nested guarded.
+func TestResourceTemplate_MetadataLabelsMapNotImportSuppressed_Issue1244(t *testing.T) {
+	marker := func(go_, tfsdk string) openapi.TerraformAttribute {
+		return openapi.TerraformAttribute{GoName: go_, TfsdkTag: tfsdk, JsonName: tfsdk, IsBlock: true, NestedBlockType: "single"}
+	}
+	tmpl := &openapi.ResourceTemplate{
+		Name:               "zz_labels_probe",
+		TitleCase:          "SecuremeshSiteV2",
+		Description:        "Probe.",
+		HasNamespaceInPath: true,
+		APIPath:            "/api/config/namespaces/%s/zz_labels_probes",
+		APIPathItem:        "/api/config/namespaces/%s/zz_labels_probes/%s",
+		Attributes: []openapi.TerraformAttribute{
+			{Name: "name", GoName: "Name", TfsdkTag: "name", Type: "string", JsonName: "name", Required: true},
+			{Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string", JsonName: "namespace", Required: true},
+			// spec.azure.node_list[].labels {} — the nested empty-marker shape the #1244 seed targets.
+			{
+				Name: "azure", GoName: "Azure", TfsdkTag: "azure", JsonName: "azure",
+				IsBlock: true, NestedBlockType: "single", IsSpecField: true, Optional: true,
+				NestedAttributes: []openapi.TerraformAttribute{{
+					GoName: "NodeList", TfsdkTag: "node_list", JsonName: "node_list",
+					IsBlock: true, NestedBlockType: "list", Optional: true,
+					NestedAttributes: []openapi.TerraformAttribute{
+						{GoName: "NodeName", TfsdkTag: "node_name", JsonName: "node_name", Type: "string", Optional: true},
+						marker("Labels", "labels"),
+					},
+				}},
+			},
+		},
+	}
+	dir := t.TempDir()
+	if err := GenerateResourceFile(tmpl, dir); err != nil {
+		t.Fatalf("GenerateResourceFile: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "zz_labels_probe_resource.go"))
+	if err != nil {
+		t.Fatalf("reading rendered resource: %v", err)
+	}
+	got := string(b)
+
+	// Isolate the Read body — the only place the API response overwrites state.
+	readIdx := strings.Index(got, ") Read(ctx context.Context")
+	if readIdx == -1 {
+		t.Fatal("rendered resource has no Read method")
+	}
+	read := got[readIdx:]
+	if end := strings.Index(read, ") Update(ctx context.Context"); end != -1 {
+		read = read[:end]
+	}
+
+	// ---- top-level metadata labels/annotations: present, and NOT import-guarded ----
+	metaStart := strings.Index(read, "priorLabelsEmpty :=")
+	metaEnd := strings.Index(read, "isImport := false")
+	if metaStart == -1 || metaEnd == -1 || metaEnd <= metaStart {
+		t.Fatalf("cannot locate the metadata read-back region in the rendered Read:\n%s", read)
+	}
+	meta := read[metaStart:metaEnd]
+	for _, want := range []string{
+		"data.Labels = types.MapValueMust(types.StringType, nil)",
+		"data.Labels = types.MapNull(types.StringType)",
+		"data.Annotations = types.MapNull(types.StringType)",
+	} {
+		if !strings.Contains(meta, want) {
+			t.Errorf("metadata read-back must emit %q; region was:\n%s", want, meta)
 		}
-		if strings.Contains(got, "if !isImport {") {
-			t.Errorf("%s metadata.labels (types.Map) must not acquire an empty-marker import-suppression guard; got:\n%s", rc, got)
-		}
+	}
+	// The region ends where isImport is declared, so any mention of it here means the
+	// metadata map read-back was pulled onto the import-suppression path (#1244 collision).
+	if strings.Contains(meta, "isImport") {
+		t.Errorf("metadata labels/annotations read-back must not be import-guarded (#1244 non-collision); region was:\n%s", meta)
+	}
+	if strings.Contains(meta, "EmptyModel") {
+		t.Errorf("metadata labels must stay a types.Map, never an empty-marker block; region was:\n%s", meta)
+	}
+
+	// ---- nested labels {} inside node_list[]: IS import-guarded by the #1244 seed ----
+	nestedStart := strings.Index(read, "Labels: func() *SecuremeshSiteV2EmptyModel {")
+	if nestedStart == -1 {
+		t.Fatalf("rendered Read has no nested labels empty-marker closure:\n%s", read)
+	}
+	nested := read[nestedStart:]
+	if end := strings.Index(nested, "}(),"); end != -1 {
+		nested = nested[:end]
+	}
+	if !strings.Contains(nested, "if !isImport {") {
+		t.Errorf("nested node_list[].labels {} must guard its response-populate with !isImport (#1244); closure was:\n%s", nested)
 	}
 }
 

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -162,6 +162,17 @@ var importDefaultSuppressionsSeed = map[string][]string{
 		"any_country",
 		"any_ip",
 	},
+	// #1244: same class as OriginPool.labels — labels {} is a plain optional empty-marker
+	// block (a label selector the schema models as empty-only) that the F5 XC API ALWAYS
+	// materializes on every azure.not_managed.node_list[].interface_list[] element, verified
+	// live on a single-node securemesh_site_v2 probe. A config that omits it (every real
+	// module does) re-plans `- labels {}` on whole-object import, so suppress it on import.
+	// Does NOT affect the top-level metadata.labels types.Map (a different read path that
+	// never consults isImportDefaultSuppressed) — all 13 nested labels in this resource are
+	// *SecuremeshSiteV2EmptyModel.
+	"SecuremeshSiteV2": {
+		"labels",
+	},
 	// SPol effort (service_policy coverage). Suppress ONLY the oneof base members the F5 XC
 	// API echoes when the module OMITS their parent — verified live by GETting a created
 	// service_policy (f5-sales-demo): a rule that declares no client/asn/ip matcher still

--- a/tools/pkg/codegen/import_suppressions.go
+++ b/tools/pkg/codegen/import_suppressions.go
@@ -164,12 +164,21 @@ var importDefaultSuppressionsSeed = map[string][]string{
 	},
 	// #1244: same class as OriginPool.labels — labels {} is a plain optional empty-marker
 	// block (a label selector the schema models as empty-only) that the F5 XC API ALWAYS
-	// materializes on every azure.not_managed.node_list[].interface_list[] element, verified
-	// live on a single-node securemesh_site_v2 probe. A config that omits it (every real
-	// module does) re-plans `- labels {}` on whole-object import, so suppress it on import.
-	// Does NOT affect the top-level metadata.labels types.Map (a different read path that
-	// never consults isImportDefaultSuppressed) — all 13 nested labels in this resource are
-	// *SecuremeshSiteV2EmptyModel.
+	// materializes, verified live on a single-node azure not_managed securemesh_site_v2
+	// probe (azure.not_managed.node_list[].interface_list[].labels). A config that omits it
+	// (every real module does) re-plans `- labels {}` on whole-object import, so suppress it
+	// on import.
+	//
+	// Blast radius: suppression matches on the LEAF name, so this covers every nested
+	// `labels` in the resource — all 13 *SecuremeshSiteV2EmptyModel fields, i.e. the
+	// per-interface labels on all 11 not_managed provider arms (aws, azure, baremetal,
+	// equinix, gcp, kvm, nutanix, oci, openshift_virtualization, openstack, vmware) plus
+	// local_vrf.{slo,sli}_config.labels. Those 13 fields are rendered at 39 unmarshal sites,
+	// so regeneration adds 39 `if !isImport {` guards. Only the azure arm is live-verified;
+	// the others are the identical schema shape, and suppressing an empty marker the server
+	// re-applies is safe either way. Does NOT affect the top-level metadata.labels types.Map:
+	// that is a types.Map written by static ResourceTemplate text before the isImport marker
+	// is even read, and never consults isImportDefaultSuppressed.
 	"SecuremeshSiteV2": {
 		"labels",
 	},

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -424,6 +424,8 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 	// value: a known-empty prior map stays an empty map, anything else (null = never
 	// declared, or unknown) becomes null. A prior map WITH entries still nulls, so a
 	// genuine out-of-band deletion is still reported as drift.
+	// The MapValueMust below cannot panic: it panics only on diagnostics, and with nil
+	// elements NewMapValue's sole error path (per-element type mismatch) is unreachable.
 	priorLabelsEmpty := !data.Labels.IsNull() && !data.Labels.IsUnknown() && len(data.Labels.Elements()) == 0
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -417,6 +417,16 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 		data.Description = types.StringNull()
 	}
 
+	// #1286: the API omits an empty metadata map entirely, so "no entries in the
+	// response" is ambiguous — it means either "never declared" or "declared empty".
+	// Nulling both makes a config that declares labels = {} drift (+ labels = {}) on
+	// every plan after apply, with no import involved. Resolve it from the prior
+	// value: a known-empty prior map stays an empty map, anything else (null = never
+	// declared, or unknown) becomes null. A prior map WITH entries still nulls, so a
+	// genuine out-of-band deletion is still reported as drift.
+	priorLabelsEmpty := !data.Labels.IsNull() && !data.Labels.IsUnknown() && len(data.Labels.Elements()) == 0
+	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
+
 	// Filter out system-managed labels (ves.io/*) that are injected by the platform
 	if len(apiResource.Metadata.Labels) > 0 {
 		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels)
@@ -426,9 +436,13 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 			if !resp.Diagnostics.HasError() {
 				data.Labels = labels
 			}
+		} else if priorLabelsEmpty {
+			data.Labels = types.MapValueMust(types.StringType, nil)
 		} else {
 			data.Labels = types.MapNull(types.StringType)
 		}
+	} else if priorLabelsEmpty {
+		data.Labels = types.MapValueMust(types.StringType, nil)
 	} else {
 		data.Labels = types.MapNull(types.StringType)
 	}
@@ -439,6 +453,8 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 		if !resp.Diagnostics.HasError() {
 			data.Annotations = annotations
 		}
+	} else if priorAnnotationsEmpty {
+		data.Annotations = types.MapValueMust(types.StringType, nil)
 	} else {
 		data.Annotations = types.MapNull(types.StringType)
 	}

--- a/tools/pkg/discovery/cleanup.go
+++ b/tools/pkg/discovery/cleanup.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package discovery
+
+import "time"
+
+// DeleteWithRetry calls del up to attempts times, sleeping backoff (doubled after each
+// failure) between tries, and returns the error from the last attempt (nil as soon as one
+// succeeds). attempts < 1 is treated as 1.
+//
+// Discovery creates real `tf-discover-*` probe objects in a SHARED tenant namespace
+// (securemesh_site_v2 lands in "system", right next to live demo sites), so a DELETE that
+// fails once — a transient 5xx, or the brief referential BAD_REQUEST the F5 XC API returns
+// while an object is still referenced — must be retried and, if it still fails, reported
+// to the caller. Discarding the error strands the probe object forever.
+func DeleteWithRetry(del func() error, attempts int, backoff time.Duration) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var err error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+		if err = del(); err == nil {
+			return nil
+		}
+	}
+	return err
+}

--- a/tools/pkg/discovery/cleanup_test.go
+++ b/tools/pkg/discovery/cleanup_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package discovery
+
+import (
+	"errors"
+	"testing"
+)
+
+// A cleanup DELETE that fails must be retried and, when every attempt fails, must surface
+// the error — discover-defaults previously discarded it, silently stranding a tf-discover-*
+// probe object in the shared "system" namespace next to the live demo sites.
+func TestDeleteWithRetry(t *testing.T) {
+	boom := errors.New("500 internal error")
+
+	tests := []struct {
+		name         string
+		attempts     int
+		failuresLeft int // how many calls fail before succeeding; >attempts = never succeeds
+		wantCalls    int
+		wantErr      bool
+	}{
+		{name: "succeeds first try", attempts: 3, failuresLeft: 0, wantCalls: 1},
+		{name: "succeeds after transient failure", attempts: 3, failuresLeft: 2, wantCalls: 3},
+		{name: "exhausts attempts and reports the error", attempts: 3, failuresLeft: 9, wantCalls: 3, wantErr: true},
+		{name: "attempts below one still tries once", attempts: 0, failuresLeft: 9, wantCalls: 1, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls, left := 0, tc.failuresLeft
+			err := DeleteWithRetry(func() error {
+				calls++
+				if left > 0 {
+					left--
+					return boom
+				}
+				return nil
+			}, tc.attempts, 0)
+
+			if calls != tc.wantCalls {
+				t.Errorf("called del %d times, want %d", calls, tc.wantCalls)
+			}
+			if tc.wantErr {
+				if !errors.Is(err, boom) {
+					t.Errorf("err = %v, want %v so the caller can report the stranded object", err, boom)
+				}
+			} else if err != nil {
+				t.Errorf("err = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/tools/pkg/resource/resource.go
+++ b/tools/pkg/resource/resource.go
@@ -106,12 +106,12 @@ var SkippedResources = map[string]SkipReason{
 		SkipGenerate: false,
 		SkipAPITest:  true,
 	},
-	"securemesh_site_v2": {
-		Reason:      "Requires physical Secure Mesh hardware v2",
-		Category:    "infrastructure",
-		SkipGenerate: false,
-		SkipAPITest:  true,
-	},
+	// securemesh_site_v2 is deliberately NOT skipped: a single-node `azure`
+	// `not_managed` site creates/reads/deletes with HTTP 200 and no backing VM or
+	// physical hardware (verified live), so its server defaults ARE discoverable. It
+	// was skipped as "requires physical hardware v2", which is what stopped
+	// discover-defaults from auto-deriving the per-interface `labels {}` marker and
+	// left #1244 to be hand-seeded. See ResourceConfigs in tools/discover-defaults.go.
 	"voltstack_site": {
 		Reason:      "Requires physical VoltStack hardware",
 		Category:    "infrastructure",

--- a/tools/pkg/resource/resource_test.go
+++ b/tools/pkg/resource/resource_test.go
@@ -131,6 +131,9 @@ func TestIsSkippedForAPITest(t *testing.T) {
 		{"gcp_vpc_site", true},       // Requires GCP credentials
 		{"cloud_credentials", true},  // Requires cloud provider secrets
 		{"securemesh_site", true},    // Requires physical hardware
+		// #1244: v2 is NOT skipped — a single-node azure not_managed site creates
+		// Azure-free (HTTP 200), so discover-defaults can derive its server defaults.
+		{"securemesh_site_v2", false},
 		{"fleet", true},              // Requires existing infrastructure
 		{"cminstance", true},         // Requires subscription
 		{"http_loadbalancer", false}, // Not in skip list


### PR DESCRIPTION
## What
Two independent read-back defects that made `xcsh_securemesh_site_v2` unable to reach a clean plan. Both were re-verified live on v3.77.3 before being fixed, and both are fixed in `tools/**` (no generated file is touched).

### Fix A — nested `labels {}` drifts on import (#1244)
Whole-object `terraform import` re-planned `- labels {}` at `azure.not_managed.node_list[].interface_list[].labels`; the server always materializes `"labels": {}` on every interface element.

The suppression machinery was **fine** — it is data-driven and matches by leaf name at any depth — but `importDefaultSuppressionsSeed` had **no `SecuremeshSiteV2` key at all** (`OriginPool` has `"labels"`). Auto-derive never filled it because `ResourceConfigs` in `tools/discover-defaults.go` omitted `securemesh_site_v2`.

- Seeded `"SecuremeshSiteV2": {"labels"}`.
- Added a `securemesh_site_v2` entry to `ResourceConfigs` so it **auto-derives** in future rather than relying on someone remembering to seed. Live-proven: `discover-defaults -resource securemesh_site_v2` create/GET/DELETE all return 200 and derive `spec.azure.not_managed.node_list.interface_list.labels` `is_marker_block=true` — exactly what the seed hand-writes.
- Required removing `securemesh_site_v2` from the API-test skip list, because `discoverResource` checks the skip *before* the config template, so the new entry would have been dead code. The stated skip reason ("Requires physical Secure Mesh hardware v2") is false. `securemesh_site` (v1) stays skipped.

Regeneration adds the `if !isImport {` guard at **39** sites, all inside `Labels: func() *SecuremeshSiteV2EmptyModel` closures in `securemesh_site_v2_resource.go` and **zero** elsewhere.

### Fix B — a config-declared empty `labels = {}` drifts on every plan (#1286)
Unrelated to import: the metadata read-back set `types.MapNull` whenever the API returned no labels, discarding a config-declared empty map, so a plain post-apply plan re-proposed `+ labels = {}` **forever**. This is the shared metadata path in all 272 resources.

Now an empty map in config is preserved; absent-from-config still reads back null. Live-proven on a disposable probe: `apply` then `plan` → **"No changes"**, and a state-writing `apply -refresh-only` left `labels = {}` in state (old code wrote null) while never-declared `annotations` stayed `null` — both halves.

## ⚠️ Reviewers, note this operational change
Un-skipping `securemesh_site_v2` means `.github/workflows/discover-defaults.yml` (`-all`, **monthly** cron, self-hosted runner, real credentials) will now create and delete a real site object in the shared `system` namespace. Cleanup previously **discarded the DELETE error**, so a failed delete would have silently stranded a `tf-discover-*` object next to the live demo sites. Hardened here: `DeleteWithRetry` (extracted to `tools/pkg/discovery`, unit-tested) retries 3× with backoff on a context detached from the spent discovery deadline, prints a loud `CLEANUP FAILED`/`STRANDED` report, records the object, and makes `main` exit non-zero.

## Tests
- `Issue1103` suppression table gains `{"SecuremeshSiteV2","Labels","labels"}`.
- The old non-collision test was **vacuous** and has been replaced: `renderUnmarshalChild` returns an empty string for map-typed attributes, so its assertions could never fail. The new `TestResourceTemplate_MetadataLabelsMapNotImportSuppressed_Issue1244` renders a real resource file and asserts the metadata region emits `MapValueMust`/`MapNull` with no `isImport` mention and no `EmptyModel`, while the nested closure *is* `if !isImport {`-wrapped. Proven non-vacuous by three mutants, each failing alone: dropping the seed, reverting the #1286 emission, and import-gating `priorLabelsEmpty`. (The silent-empty-emission behaviour itself is filed as #1291.)
- New `TestDeleteWithRetry` (4 cases) and an extended `TestIsSkippedForAPITest`.
- `go test ./internal/... ./tools/...` green; `make build`; `golangci-lint` 0 issues; `gofmt`/`codespell` clean. A full regeneration produced 131 resources / 12 data sources / 0 failures and `go build ./...` exit 0; 130 of 131 `*_resource.go` carry the new metadata branch (the one exception uses the action-resource template and has no metadata read-back).

## Known follow-ups (not fixed here)
- **#1286 does not close the import half.** On import, state carries only id/name/namespace, so a config with `labels = {}` still shows `+ labels = {}` on the first post-import plan, and `ReadRequest` exposes no config for the provider to resolve it. The consumer cleanup therefore needs `labels = length(var.labels) > 0 ? var.labels : null`.
- **#1287** — these empty `labels {}` markers exist because codegen misclassifies `map<string,string>` properties as empty blocks (107 properties). Seeding is the right near-term fix; #1287 is the structural one.
- **#1291** — `renderUnmarshalScalarChild` silently emits nothing for unsupported types.
- **docs-control#773** — the 115 MB build artifact is still not ignored by the managed `.gitignore` template. Deliberately **not** re-added locally (that file is `protected_files`, and this exact entry was added in #837 then removed by a sync in #1002); this clone uses `.git/info/exclude` as a stopgap.

Part of epic #1207 (slice S7).

Closes #1244
Closes #1286
