### PR TITLE
S7 PR-2: stop the CI spelling pass corrupting generated wire keys (#1257) + collision guard

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -28,12 +28,64 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       success: ${{ steps.result.outputs.success }}
+    env:
+      # Gitignored working location for the released API spec bundle — the same
+      # path tools/generate-all-schemas.go defaults to.
+      SPEC_DIR: docs/specifications/api
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
+
+      - name: Download API specs
+        # TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames (#1257)
+        # compares tools/codespell-corrections.json against real API property
+        # names, so it needs the released spec bundle. This job is the ONLY place
+        # the guard can block a bad correction key BEFORE merge: the
+        # _generate-provider.yml copy of this download runs post-merge (on-merge.yml
+        # triggers on push: main), so without this step a collision could merge
+        # and would only be caught on its way to a release.
+        #
+        # f5-sales-demo/api-specs-enriched is public, so github.token with the
+        # inherited contents: read is sufficient — no extra permission needed.
+        # A fetch failure is a HARD failure: degrading to a skipped guard is the
+        # exact defect class #1257 is about. The bundle is one ~9 MB zip and is
+        # skipped entirely when the specs are already in the tree.
+        #
+        # SPEC_DIR reaches the shell through env: — an ${{ }} expansion inside
+        # run: is a code-injection sink (zizmor template-injection). Shell-quoted
+        # at each use below.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENRICHED_REPO: f5-sales-demo/api-specs-enriched
+        run: |
+          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
+          if [ "$SPEC_COUNT" -gt "0" ]; then
+            echo "Found $SPEC_COUNT existing spec files in ${SPEC_DIR}"
+            exit 0
+          fi
+
+          echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
+          mkdir -p "${SPEC_DIR}"
+          ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
+            '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
+          if [ -z "$ASSET_ID" ] || [ "$ASSET_ID" = "null" ]; then
+            echo "::error::No spec asset found in the latest $ENRICHED_REPO release; the #1257 codespell collision guard cannot run without it"
+            exit 1
+          fi
+          gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
+            -H "Accept: application/octet-stream" > /tmp/specs.zip
+          unzip -q -o /tmp/specs.zip -d "${SPEC_DIR}"
+          rm /tmp/specs.zip
+
+          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f | wc -l)
+          echo "Downloaded $SPEC_COUNT spec files"
+          if [ "$SPEC_COUNT" -eq "0" ]; then
+            echo "::error::Spec asset unpacked to no JSON specs in ${SPEC_DIR}"
+            exit 1
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -50,6 +102,11 @@ jobs:
         run: scripts/go-retry.sh 3 go build -v .
 
       - name: Test
+        # XCSH_SPEC_DIR is deliberately always set: the #1257 guard hard-fails on
+        # a set-but-unusable path, so a broken download can never masquerade as a
+        # clean run.
+        env:
+          XCSH_SPEC_DIR: ${{ env.SPEC_DIR }}
         run: scripts/go-retry.sh 2 go test -v -race ./internal/... ./tools/...
 
       - name: Set result

--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -32,22 +32,26 @@ jobs:
           fetch-depth: 0
 
       - name: Download specs if not present
+        # inputs.spec-dir reaches the shell through env: — an ${{ }} expansion
+        # inside run: is a code-injection sink (zizmor template-injection).
+        # Shell-quoted at each use below.
         env:
           GH_TOKEN: ${{ github.token }}
           ENRICHED_REPO: f5-sales-demo/api-specs-enriched
+          SPEC_DIR: ${{ inputs.spec-dir }}
         run: |
-          SPEC_COUNT=$(find "${{ inputs.spec-dir }}" -name "*.json" -type f 2>/dev/null | wc -l)
+          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
           if [ "$SPEC_COUNT" -eq "0" ]; then
             echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
-            mkdir -p "${{ inputs.spec-dir }}"
+            mkdir -p "${SPEC_DIR}"
             ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
               '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
             if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
               gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
                 -H "Accept: application/octet-stream" > /tmp/specs.zip
-              unzip -o /tmp/specs.zip -d "${{ inputs.spec-dir }}"
+              unzip -o /tmp/specs.zip -d "${SPEC_DIR}"
               rm /tmp/specs.zip
-              SPEC_COUNT=$(find "${{ inputs.spec-dir }}" -name "*.json" -type f | wc -l)
+              SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f | wc -l)
               echo "Downloaded $SPEC_COUNT spec files"
             else
               echo "::warning::Could not find spec asset in latest release"
@@ -58,9 +62,11 @@ jobs:
 
       - name: Verify specs exist
         id: verify
+        env:
+          SPEC_DIR: ${{ inputs.spec-dir }}
         run: |
-          SPEC_COUNT=$(find "${{ inputs.spec-dir }}" -name "*.json" -type f 2>/dev/null | wc -l)
-          echo "Found ${SPEC_COUNT} OpenAPI spec files in ${{ inputs.spec-dir }}"
+          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
+          echo "Found ${SPEC_COUNT} OpenAPI spec files in ${SPEC_DIR}"
           if [ "$SPEC_COUNT" -eq "0" ]; then
             echo "No spec files found - skipping generation"
             echo "has_specs=false" >> "$GITHUB_OUTPUT"
@@ -77,9 +83,11 @@ jobs:
 
       - name: Run code generator
         if: steps.verify.outputs.has_specs == 'true'
+        env:
+          SPEC_DIR: ${{ inputs.spec-dir }}
         run: |
           echo "Running code generator..."
-          go run tools/generate-all-schemas.go --spec-dir=${{ inputs.spec-dir }}
+          go run tools/generate-all-schemas.go --spec-dir="${SPEC_DIR}"
 
       - name: Run go mod tidy
         if: steps.verify.outputs.has_specs == 'true'
@@ -91,7 +99,13 @@ jobs:
 
       - name: Run tests
         if: steps.verify.outputs.has_specs == 'true'
-        run: scripts/go-retry.sh 2 go test -v ./internal/...
+        # ./tools/... runs here as well as in _build-test.yml because this is the
+        # only job where the spec artifact is present:
+        # TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames (#1257) needs
+        # it and skips without it.
+        env:
+          XCSH_SPEC_DIR: ${{ inputs.spec-dir }}
+        run: scripts/go-retry.sh 2 go test -v ./internal/... ./tools/...
 
       - name: Check for changes
         id: check

--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -99,10 +99,11 @@ jobs:
 
       - name: Run tests
         if: steps.verify.outputs.has_specs == 'true'
-        # ./tools/... runs here as well as in _build-test.yml because this is the
-        # only job where the spec artifact is present:
-        # TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames (#1257) needs
-        # it and skips without it.
+        # ./tools/... runs here as well as in _build-test.yml so the freshly
+        # regenerated tree is re-tested against the specs it was generated from.
+        # XCSH_SPEC_DIR makes TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames
+        # (#1257) run rather than skip; _build-test.yml downloads the same bundle
+        # so the guard also blocks on the PR, before merge.
         env:
           XCSH_SPEC_DIR: ${{ inputs.spec-dir }}
         run: scripts/go-retry.sh 2 go test -v ./internal/... ./tools/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ on:
 
 # Least privilege: every job here only reads the repository. `statuses: write`
 # and `checks: write` were granted workflow-wide but nothing consumed them —
-# no job (nor the reusable _build-test.yml, which uses only checkout and
-# setup-go) writes a commit status or a check run; job check runs are created by
-# Actions itself, not through GITHUB_TOKEN. Grant either at the job level if a
-# job ever needs it, rather than workflow-wide.
+# no job (nor the reusable _build-test.yml, whose GITHUB_TOKEN use is checkout
+# plus a read of the public api-specs-enriched release asset) writes a commit
+# status or a check run; job check runs are created by Actions itself, not
+# through GITHUB_TOKEN. `contents: read` covers both. Grant anything more at the
+# job level if a job ever needs it, rather than workflow-wide.
 permissions:
   contents: read
 
@@ -477,4 +478,3 @@ jobs:
           echo "Checking Terraform formatting in examples/..."
           terraform fmt -check -diff -recursive examples/
           echo "Terraform formatting validated successfully"
-

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -43,7 +43,8 @@ on:
 # GITHUB_TOKEN starts with no scopes; each job grants only what it consumes
 # (zizmor excessive-permissions). Verified: the only GITHUB_TOKEN consumers in
 # this workflow and its reusable callees are actions/checkout (contents: read),
-# the spec-asset download in _generate-provider.yml (contents: read) and the tag
+# the spec-asset downloads in _build-test.yml and _generate-provider.yml
+# (contents: read — api-specs-enriched is a public repo) and the tag
 # push / release upload / goreleaser release in _tag-release.yml
 # (contents: write). Every PR and issue mutation in create-regeneration-pr
 # authenticates with secrets.AUTO_MERGE_TOKEN, so pull-requests: write and
@@ -217,7 +218,7 @@ jobs:
       needs.detect-changes.outputs.should-process == 'true' &&
       needs.detect-changes.outputs.is-bot-commit != 'true'
     permissions:
-      contents: read # checkout, go build/test, golangci-lint — no API writes
+      contents: read # checkout, public-repo spec-asset read, go build/test, golangci-lint — no API writes
     uses: ./.github/workflows/_build-test.yml
     with:
       run-lint: true
@@ -523,8 +524,13 @@ jobs:
 
       - name: Close stale auto-regenerate PRs
         if: steps.check.outputs.has_changes == 'true'
+        # Repository context reaches the shell through env: — an ${{ }} expansion
+        # inside run: is a code-injection sink (zizmor template-injection), and
+        # the adjacent "Create branch and PR" step already routes github.sha this
+        # way. Shell-quoted at each use below.
         env:
           GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           # Find and close any open auto-regenerate PRs (they're superseded by this new regeneration)
           echo "Checking for stale auto-regenerate PRs..."
@@ -532,8 +538,8 @@ jobs:
 
           if [ -n "$STALE_PRS" ]; then
             for PR in $STALE_PRS; do
-              echo "Closing stale auto-regenerate PR #$PR (superseded by commit ${{ github.sha }})"
-              gh pr close "$PR" --comment "Superseded by newer regeneration from commit ${{ github.sha }}" || true
+              echo "Closing stale auto-regenerate PR #$PR (superseded by commit ${COMMIT_SHA})"
+              gh pr close "$PR" --comment "Superseded by newer regeneration from commit ${COMMIT_SHA}" || true
               # Also delete the stale branch
               BRANCH=$(gh pr view "$PR" --json headRefName --jq '.headRefName')
               git push origin --delete "$BRANCH" 2>/dev/null || true

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -40,10 +40,15 @@ on:
     # Note: No paths-ignore - all changes should trigger workflow
     # Specific path filtering happens in detect-changes job
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+# GITHUB_TOKEN starts with no scopes; each job grants only what it consumes
+# (zizmor excessive-permissions). Verified: the only GITHUB_TOKEN consumers in
+# this workflow and its reusable callees are actions/checkout (contents: read),
+# the spec-asset download in _generate-provider.yml (contents: read) and the tag
+# push / release upload / goreleaser release in _tag-release.yml
+# (contents: write). Every PR and issue mutation in create-regeneration-pr
+# authenticates with secrets.AUTO_MERGE_TOKEN, so pull-requests: write and
+# issues: write had no consumer at all.
+permissions: {}
 
 concurrency:
   group: on-merge-${{ github.sha }}
@@ -56,6 +61,8 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/checkout only
     outputs:
       specs-changed: ${{ steps.changes.outputs.specs }}
       code-changed: ${{ steps.changes.outputs.code }}
@@ -164,14 +171,16 @@ jobs:
 
       - name: Determine if processing should proceed
         id: should-process
+        # Step outputs reach the shell through env: — an ${{ }} expansion inside
+        # run: is a code-injection sink (zizmor template-injection).
+        env:
+          IS_BOT: ${{ steps.check-author.outputs.is_bot }}
+          SPECS: ${{ steps.changes.outputs.specs }}
+          CODE: ${{ steps.changes.outputs.code }}
+          TOOLS: ${{ steps.changes.outputs.tools }}
+          FUNCTIONS: ${{ steps.changes.outputs.functions }}
+          HAS_ANY_CHANGES: ${{ steps.changes.outputs.has_any_changes }}
         run: |
-          IS_BOT="${{ steps.check-author.outputs.is_bot }}"
-          SPECS="${{ steps.changes.outputs.specs }}"
-          CODE="${{ steps.changes.outputs.code }}"
-          TOOLS="${{ steps.changes.outputs.tools }}"
-          FUNCTIONS="${{ steps.changes.outputs.functions }}"
-          HAS_ANY_CHANGES="${{ steps.changes.outputs.has_any_changes }}"
-
           # Determine if regeneration would be needed
           NEEDS_REGEN="false"
           if [[ "$SPECS" == "true" || "$CODE" == "true" || "$TOOLS" == "true" || "$FUNCTIONS" == "true" ]]; then
@@ -207,6 +216,8 @@ jobs:
     if: |
       needs.detect-changes.outputs.should-process == 'true' &&
       needs.detect-changes.outputs.is-bot-commit != 'true'
+    permissions:
+      contents: read # checkout, go build/test, golangci-lint — no API writes
     uses: ./.github/workflows/_build-test.yml
     with:
       run-lint: true
@@ -224,6 +235,8 @@ jobs:
       needs.detect-changes.outputs.is-bot-commit != 'true' &&
       (needs.detect-changes.outputs.specs-changed == 'true' ||
        needs.detect-changes.outputs.tools-changed == 'true')
+    permissions:
+      contents: read # checkout + gh api read of the api-specs-enriched release asset
     uses: ./.github/workflows/_generate-provider.yml
 
   # ===========================================================================
@@ -242,6 +255,8 @@ jobs:
        needs.detect-changes.outputs.tools-changed == 'true' ||
        needs.detect-changes.outputs.functions-changed == 'true' ||
        (needs.regenerate-provider.result == 'success' && needs.regenerate-provider.outputs.changed == 'true'))
+    permissions:
+      contents: read # checkout + tfplugindocs; no API writes
     uses: ./.github/workflows/_generate-docs.yml
 
   # ===========================================================================
@@ -261,6 +276,11 @@ jobs:
       ((needs.regenerate-provider.result == 'success' && needs.regenerate-provider.outputs.changed == 'true') ||
        (needs.regenerate-docs.result == 'success' && needs.regenerate-docs.outputs.changed == 'true'))
     runs-on: ubuntu-latest
+    # Branch push, issue creation, PR creation and auto-merge all authenticate
+    # with secrets.AUTO_MERGE_TOKEN (checkout too, with persist-credentials:
+    # false), so GITHUB_TOKEN needs no write scope here.
+    permissions:
+      contents: read
     outputs:
       pr-created: ${{ steps.create-pr.outputs.pr_created }}
       pr-number: ${{ steps.create-pr.outputs.pr_number }}
@@ -364,8 +384,22 @@ jobs:
         run: |
           pip install codespell --quiet
 
+          # The spelling passes below deliberately touch PROSE ONLY (docs/, examples/).
+          # internal/provider/ is excluded on purpose: identifiers in generated Go are
+          # wire contracts. A blind text replace there silently renamed API fields: the
+          # correction for the mis-typed word "service" turned the upstream-misspelled
+          # F5 XC field blocked_sevice into blocked_service, which the API silently
+          # ignores, and the correction for "checking" broke the bot_defense flow-label
+          # checkin property the same way. Commit 069611d2 ("auto-regenerate", which
+          # reported "Provider code: false") renamed blocked_sevice into
+          # blocked_service across every site resource purely through this step.
+          # See #1257; the regression guard is
+          # TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames in
+          # tools/pkg/codegen/codespell_guard_test.go. Spelling in generated Go must be
+          # fixed in the spec or the generator, never by rewriting the output.
+
           # 1. Auto-fix unambiguous spelling typos
-          codespell --write-changes docs/ examples/ internal/provider/ --quiet-level 2 || true
+          codespell --write-changes docs/ examples/ --quiet-level 2 || true
 
           # 2. Fix ambiguous typos + inject terraform blocks into examples missing them
           python3 -c "
@@ -377,12 +411,12 @@ jobs:
               with open('tools/codespell-corrections.json') as f:
                   corrections = json.load(f).get('corrections', {})
 
-          # Apply spelling corrections to all generated content
+          # Apply spelling corrections to generated prose only (see note above)
           for wrong, right in corrections.items():
-              for root in ['docs', 'examples', 'internal/provider']:
+              for root in ['docs', 'examples']:
                   for dirpath, _, filenames in os.walk(root):
                       for fn in filenames:
-                          if fn.endswith(('.md', '.tf', '.go')):
+                          if fn.endswith(('.md', '.tf')):
                               fp = os.path.join(dirpath, fn)
                               txt = open(fp).read()
                               fixed = txt.replace(wrong, right)
@@ -511,11 +545,18 @@ jobs:
       - name: Create branch and PR
         id: create-pr
         if: steps.check.outputs.has_changes == 'true'
+        # Job outputs and repository context reach the shell through env: — an
+        # ${{ }} expansion inside run: is a code-injection sink (zizmor
+        # template-injection). Shell-quoted at each use below.
         env:
           GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          PROVIDER_CHANGED: ${{ needs.regenerate-provider.outputs.changed || 'false' }}
+          DOCS_CHANGED: ${{ needs.regenerate-docs.outputs.changed || 'false' }}
         run: |
           # Create a unique branch name
-          BRANCH_NAME="auto-regenerate/${{ github.sha }}"
+          BRANCH_NAME="auto-regenerate/${COMMIT_SHA}"
 
           # Create and checkout new branch
           git checkout -b "$BRANCH_NAME"
@@ -523,11 +564,11 @@ jobs:
           # Commit the changes
           git commit -m "chore: auto-regenerate provider and documentation
 
-          Triggered by commit: ${{ github.sha }}
+          Triggered by commit: ${COMMIT_SHA}
 
           Changes regenerated:
-          - Provider code: ${{ needs.regenerate-provider.outputs.changed || 'false' }}
-          - Documentation: ${{ needs.regenerate-docs.outputs.changed || 'false' }}
+          - Provider code: ${PROVIDER_CHANGED}
+          - Documentation: ${DOCS_CHANGED}
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
@@ -535,17 +576,17 @@ jobs:
 
           # Push the branch (clear checkout extraheader and use PAT so push triggers CI)
           git config --unset-all http.https://github.com/.extraheader || true
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
           git push origin "$BRANCH_NAME"
 
           # Create a tracking issue (required by "Check linked issues" CI check)
           ISSUE_URL=$(gh issue create \
-            --title "chore: auto-regenerate provider from ${{ github.sha }}" \
-            --body "Automated regeneration triggered by commit ${{ github.sha }}.
+            --title "chore: auto-regenerate provider from ${COMMIT_SHA}" \
+            --body "Automated regeneration triggered by commit ${COMMIT_SHA}.
 
           Changes:
-          - Provider code: ${{ needs.regenerate-provider.outputs.changed || 'false' }}
-          - Documentation: ${{ needs.regenerate-docs.outputs.changed || 'false' }}" \
+          - Provider code: ${PROVIDER_CHANGED}
+          - Documentation: ${DOCS_CHANGED}" \
             --label "automated" \
             --label "regeneration")
           ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
@@ -556,11 +597,11 @@ jobs:
           Automated regeneration of provider code and/or documentation.
 
           ## Triggered By
-          Commit: ${{ github.sha }}
+          Commit: ${COMMIT_SHA}
 
           ## Changes
-          - Provider code regenerated: ${{ needs.regenerate-provider.outputs.changed || 'false' }}
-          - Documentation regenerated: ${{ needs.regenerate-docs.outputs.changed || 'false' }}
+          - Provider code regenerated: ${PROVIDER_CHANGED}
+          - Documentation regenerated: ${DOCS_CHANGED}
 
           Closes #${ISSUE_NUMBER}"
 
@@ -616,6 +657,8 @@ jobs:
           needs.create-regeneration-pr.result == 'skipped'
         )
       )
+    permissions:
+      contents: write # push the version tag, create the release, upload assets
     uses: ./.github/workflows/_tag-release.yml
     secrets:
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -629,27 +672,44 @@ jobs:
     needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, create-regeneration-pr, tag-release]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {} # writes only to GITHUB_STEP_SUMMARY
     steps:
       - name: Print summary
+        # Job outputs reach the shell through env: — an ${{ }} expansion inside
+        # run: is a code-injection sink (zizmor template-injection).
+        env:
+          SHOULD_PROCESS: ${{ needs.detect-changes.outputs.should-process }}
+          IS_BOT_COMMIT: ${{ needs.detect-changes.outputs.is-bot-commit }}
+          NEEDS_REGENERATION: ${{ needs.detect-changes.outputs.needs-regeneration }}
+          SPECS_CHANGED: ${{ needs.detect-changes.outputs.specs-changed }}
+          CODE_CHANGED: ${{ needs.detect-changes.outputs.code-changed }}
+          TOOLS_CHANGED: ${{ needs.detect-changes.outputs.tools-changed }}
+          FUNCTIONS_CHANGED: ${{ needs.detect-changes.outputs.functions-changed }}
+          DOCS_CHANGED: ${{ needs.detect-changes.outputs.docs-changed }}
+          BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+          PROVIDER_RESULT: ${{ needs.regenerate-provider.result }}
+          DOCS_RESULT: ${{ needs.regenerate-docs.result }}
+          PR_RESULT: ${{ needs.create-regeneration-pr.result }}
+          TAG_RELEASE_RESULT: ${{ needs.tag-release.result }}
         run: |
           {
             echo "## On-Merge Workflow Summary"
             echo ""
             echo "| Step | Result |"
             echo "|------|--------|"
-            echo "| Should Process | ${{ needs.detect-changes.outputs.should-process }} |"
-            echo "| Is Bot Commit | ${{ needs.detect-changes.outputs.is-bot-commit }} |"
-            echo "| Needs Regeneration | ${{ needs.detect-changes.outputs.needs-regeneration }} |"
-            echo "| Specs Changed | ${{ needs.detect-changes.outputs.specs-changed }} |"
-            echo "| Code Changed | ${{ needs.detect-changes.outputs.code-changed }} |"
-            echo "| Tools Changed | ${{ needs.detect-changes.outputs.tools-changed }} |"
-            echo "| Functions Changed | ${{ needs.detect-changes.outputs.functions-changed }} |"
-            echo "| Docs Changed | ${{ needs.detect-changes.outputs.docs-changed }} |"
-            echo "| Build/Test | ${{ needs.build-test.result }} |"
-            echo "| Provider Regenerated | ${{ needs.regenerate-provider.result }} |"
-            echo "| Docs Regenerated | ${{ needs.regenerate-docs.result }} |"
-            echo "| Regeneration PR Created | ${{ needs.create-regeneration-pr.result }} |"
-            echo "| Tagged/Released | ${{ needs.tag-release.result }} |"
+            echo "| Should Process | ${SHOULD_PROCESS} |"
+            echo "| Is Bot Commit | ${IS_BOT_COMMIT} |"
+            echo "| Needs Regeneration | ${NEEDS_REGENERATION} |"
+            echo "| Specs Changed | ${SPECS_CHANGED} |"
+            echo "| Code Changed | ${CODE_CHANGED} |"
+            echo "| Tools Changed | ${TOOLS_CHANGED} |"
+            echo "| Functions Changed | ${FUNCTIONS_CHANGED} |"
+            echo "| Docs Changed | ${DOCS_CHANGED} |"
+            echo "| Build/Test | ${BUILD_TEST_RESULT} |"
+            echo "| Provider Regenerated | ${PROVIDER_RESULT} |"
+            echo "| Docs Regenerated | ${DOCS_RESULT} |"
+            echo "| Regeneration PR Created | ${PR_RESULT} |"
+            echo "| Tagged/Released | ${TAG_RELEASE_RESULT} |"
             echo ""
             echo "### Delayed Tagging Logic"
             echo "- Bot commits -> Tag immediately (regeneration complete)"

--- a/tools/codespell-corrections.json
+++ b/tools/codespell-corrections.json
@@ -1,8 +1,6 @@
 {
-  "_comment": "Upstream API spelling corrections for generated docs. Used by on-merge.yml to fix ambiguous typos that codespell --write-changes skips. Format: misspelling -> correction.",
+  "_comment": "Upstream API spelling corrections for generated PROSE ONLY (docs/, examples/). Used by on-merge.yml to fix ambiguous typos that codespell --write-changes skips. Format: misspelling -> correction, applied as a blind substring replace. A key must never occur inside a real spec property name: doing so silently renames an API field (#1257). TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames enforces that. Pad a key with spaces when it would otherwise match an identifier; prose typos inside spec descriptions belong upstream in api-specs config/spelling_corrections.yaml.",
   "corrections": {
-    "Sevice": "Service",
-    "sevice": "service",
     " ADN ": " AND ",
     "Cahce": "Cache",
     "assesment": "assessment",
@@ -15,8 +13,6 @@
     " inclusing ": " including ",
     " lables ": " labels ",
     " Lables ": " Labels ",
-    "checkin": "checking",
-    "Checkin": "Checking",
     " defin ": " define "
   }
 }

--- a/tools/pkg/codegen/codespell_guard_test.go
+++ b/tools/pkg/codegen/codespell_guard_test.go
@@ -60,13 +60,11 @@ func codespellCorrections(t *testing.T, root string) map[string]string {
 // tools/generate-all-schemas.go discovers it (openapi.FindDomainSpecFiles over
 // the --spec-dir layout). Properties are collected recursively: nested objects,
 // array items and map values all contribute names that reach generated code.
-// Returns nil when the artifact is not present locally.
+//
+// specDir must already be a validated v2 spec directory; every problem from
+// here on is fatal, never a skip.
 func specPropertyNames(t *testing.T, specDir string) map[string]struct{} {
 	t.Helper()
-
-	if !openapi.IsV2SpecDirectory(specDir) {
-		return nil
-	}
 
 	files, err := openapi.FindDomainSpecFiles(specDir)
 	if err != nil {
@@ -121,9 +119,17 @@ func collectPropertyNames(node any, out map[string]struct{}) {
 // a key collides with a property when the key occurs as a SUBSTRING of the
 // property name, compared case-insensitively.
 //
-//   - Substring, not equality, because `txt.replace` is a substring operation:
-//     the `checkin` -> `checking` entry corrupted both the property `checkin`
-//     and the property `msg_hdr_checking_disabled`.
+//   - Substring, not equality, because `txt.replace` is a substring operation.
+//     The `checkin` -> `checking` entry shows both faces of that. SHIPPED
+//     damage: it renamed the bot_defense flow-label property `checkin` (51
+//     corrupted identifiers in internal/provider/) and, because `checkin` also
+//     occurs inside the ordinary word `checking`, it doubly-corrupted prose into
+//     `checkingg` (7 instances still in the tree, e.g. "during health checkingg"
+//     in healthcheck_resource.go). LATENT damage: the spec property
+//     `msg_hdr_checking_disabled` would become `msg_hdr_checkingg_disabled` by
+//     the same substring hit — it is not corrupted today only because nothing in
+//     generated Go emits that property yet. Equality matching would have missed
+//     both the prose and the latent case.
 //   - Case-insensitive, because generated code carries each property name both
 //     verbatim (the wire key `blocked_sevice`) and inside CamelCase Go
 //     identifiers (`BlockedSevice`), so an upper-case key variant is exactly as
@@ -135,16 +141,37 @@ func collectPropertyNames(node any, out map[string]struct{}) {
 func TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames(t *testing.T) {
 	root := repoRootFromTest(t)
 
-	specDir := os.Getenv("XCSH_SPEC_DIR")
-	if specDir == "" {
+	// XCSH_SPEC_DIR is how CI points this guard at the released spec bundle.
+	// When it is SET, a bad value is a hard failure: a configured-but-broken
+	// path that skipped would leave CI green while the guard never ran, which is
+	// precisely how #1257 shipped. Only an UNSET variable with no bundle at the
+	// generator's default location may skip.
+	configuredValue, configured := os.LookupEnv("XCSH_SPEC_DIR")
+	specDir := configuredValue
+	if !configured {
 		specDir = filepath.Join(root, "docs", "specifications", "api")
+	} else if !filepath.IsAbs(specDir) {
+		// A relative value is REPO-relative, like the generator's --spec-dir
+		// (which runs from the repo root). `go test` runs each test with its
+		// package directory as the working directory, so resolving it against
+		// the cwd would silently miss CI's own `XCSH_SPEC_DIR=docs/specifications/api`.
+		specDir = filepath.Join(root, specDir)
 	}
 
-	properties := specPropertyNames(t, specDir)
-	if properties == nil {
+	if !openapi.IsV2SpecDirectory(specDir) {
+		if configured {
+			reason := "it is not a v2 OpenAPI spec bundle (expected an index.json and a domains/ directory)"
+			if _, err := os.Stat(specDir); err != nil {
+				reason = fmt.Sprintf("it cannot be read: %v", err)
+			}
+			t.Fatalf("XCSH_SPEC_DIR=%q (resolved to %s) is set but %s.\n"+
+				"Point it at an unpacked api-specs-enriched release, or unset it — this guard must not skip once it is configured (#1257).",
+				configuredValue, specDir, reason)
+		}
 		t.Skipf("spec artifact not present at %s; set XCSH_SPEC_DIR to the released spec bundle to run this guard", specDir)
 	}
 
+	properties := specPropertyNames(t, specDir)
 	corrections := codespellCorrections(t, root)
 
 	keys := make([]string, 0, len(corrections))

--- a/tools/pkg/codegen/codespell_guard_test.go
+++ b/tools/pkg/codegen/codespell_guard_test.go
@@ -22,10 +22,11 @@ import (
 // verbatim as a JSON wire key (`"blocked_sevice"`) and again inside derived
 // identifiers (`BlockedSevice`, `schemaFleetBlockedSevicesListType`), so any
 // correction key that occurs inside a real property name silently renames an
-// API field. That is exactly what happened: `sevice`->`service` turned the
-// upstream-misspelled field `blocked_sevice` into `blocked_service`, which the
-// F5 XC API silently ignores, and `checkin`->`checking` broke the bot_defense
-// flow-label `checkin` property the same way.
+// API field. That is exactly what happened: the correction for the mis-typed
+// word "service" turned the upstream-misspelled field `blocked_sevice` into
+// `blocked_service`, which the F5 XC API silently ignores, and the correction
+// for "checking" broke the bot_defense flow-label `checkin` property the same
+// way.
 //
 // The spelling pass no longer touches internal/provider/, but the corrections
 // file is still applied to prose that is generated from these same property
@@ -121,15 +122,16 @@ func collectPropertyNames(node any, out map[string]struct{}) {
 // property name, compared case-insensitively.
 //
 //   - Substring, not equality, because `txt.replace` is a substring operation:
-//     `checkin` -> `checking` corrupts both the property `checkin` and the
-//     property `msg_hdr_checking_disabled` (-> `msg_hdr_checkingg_disabled`).
+//     the `checkin` -> `checking` entry corrupted both the property `checkin`
+//     and the property `msg_hdr_checking_disabled`.
 //   - Case-insensitive, because generated code carries each property name both
-//     verbatim (the wire key) and in CamelCase (Go identifiers), so `Sevice` is
-//     just as dangerous as `sevice`.
+//     verbatim (the wire key `blocked_sevice`) and inside CamelCase Go
+//     identifiers (`BlockedSevice`), so an upper-case key variant is exactly as
+//     dangerous as its lower-case twin.
 //   - Keys are compared EXACTLY AS WRITTEN, with no trimming. Space-padded keys
-//     such as `" ADN "` or `" defin "` cannot occur inside a property name, so
-//     they are correctly reported as safe; trimming them would invent false
-//     positives (` defin ` would "collide" with `api_definition`).
+//     such as `" ADN "` cannot occur inside a property name and are therefore
+//     correctly reported as safe; trimming them would invent false positives
+//     against longer property names such as `api_definition`.
 func TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames(t *testing.T) {
 	root := repoRootFromTest(t)
 
@@ -165,8 +167,8 @@ func TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames(t *testing.T) {
 		}
 		sort.Strings(hits)
 		failures = append(failures, fmt.Sprintf(
-			"  %q -> %q collides with spec propert%s: %s",
-			key, corrections[key], plural(len(hits)), strings.Join(hits, ", "),
+			"  %q -> %q collides with %d spec name(s): %s",
+			key, corrections[key], len(hits), strings.Join(hits, ", "),
 		))
 	}
 
@@ -176,11 +178,4 @@ func TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames(t *testing.T) {
 			"Remove the key, or narrow it (e.g. pad it with spaces) so it can only match prose.",
 			len(failures), strings.Join(failures, "\n"))
 	}
-}
-
-func plural(n int) string {
-	if n == 1 {
-		return "y"
-	}
-	return "ies"
 }

--- a/tools/pkg/codegen/codespell_guard_test.go
+++ b/tools/pkg/codegen/codespell_guard_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package codegen
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+)
+
+// Regression guard for #1257.
+//
+// CI's "Fix generated content for lint compliance" step used to apply
+// tools/codespell-corrections.json to generated Go with a blind
+// `txt.replace(wrong, right)`. Generated Go embeds every OpenAPI property name
+// verbatim as a JSON wire key (`"blocked_sevice"`) and again inside derived
+// identifiers (`BlockedSevice`, `schemaFleetBlockedSevicesListType`), so any
+// correction key that occurs inside a real property name silently renames an
+// API field. That is exactly what happened: `sevice`->`service` turned the
+// upstream-misspelled field `blocked_sevice` into `blocked_service`, which the
+// F5 XC API silently ignores, and `checkin`->`checking` broke the bot_defense
+// flow-label `checkin` property the same way.
+//
+// The spelling pass no longer touches internal/provider/, but the corrections
+// file is still applied to prose that is generated from these same property
+// names (docs/, examples/). This test keeps the data itself honest so the class
+// of defect cannot come back through another entry.
+
+// codespellCorrections loads the misspelling -> correction map that CI applies.
+func codespellCorrections(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	path := filepath.Join(root, "tools", "codespell-corrections.json")
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	var file struct {
+		Corrections map[string]string `json:"corrections"`
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	if len(file.Corrections) == 0 {
+		t.Fatalf("%s declares no corrections; the guard would be vacuous", path)
+	}
+	return file.Corrections
+}
+
+// specPropertyNames returns every property name declared anywhere in the
+// released spec artifact the generator consumes, discovered exactly the way
+// tools/generate-all-schemas.go discovers it (openapi.FindDomainSpecFiles over
+// the --spec-dir layout). Properties are collected recursively: nested objects,
+// array items and map values all contribute names that reach generated code.
+// Returns nil when the artifact is not present locally.
+func specPropertyNames(t *testing.T, specDir string) map[string]struct{} {
+	t.Helper()
+
+	if !openapi.IsV2SpecDirectory(specDir) {
+		return nil
+	}
+
+	files, err := openapi.FindDomainSpecFiles(specDir)
+	if err != nil {
+		t.Fatalf("discovering domain specs in %s: %v", specDir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no domain specs found in %s", specDir)
+	}
+
+	names := make(map[string]struct{})
+	for _, file := range files {
+		data, err := os.ReadFile(file) // #nosec G304 -- path from spec discovery
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		var doc any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("parsing %s: %v", file, err)
+		}
+		collectPropertyNames(doc, names)
+	}
+	if len(names) == 0 {
+		t.Fatalf("collected no property names from %s", specDir)
+	}
+	return names
+}
+
+// collectPropertyNames walks a decoded JSON document and records the keys of
+// every "properties" object it encounters, at any depth.
+func collectPropertyNames(node any, out map[string]struct{}) {
+	switch typed := node.(type) {
+	case map[string]any:
+		if props, ok := typed["properties"].(map[string]any); ok {
+			for name := range props {
+				out[name] = struct{}{}
+			}
+		}
+		for _, child := range typed {
+			collectPropertyNames(child, out)
+		}
+	case []any:
+		for _, child := range typed {
+			collectPropertyNames(child, out)
+		}
+	}
+}
+
+// TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames asserts that no
+// spelling-correction key can rewrite a real API property name.
+//
+// Matching rule (deliberately mirrors what the CI replacement actually does):
+// a key collides with a property when the key occurs as a SUBSTRING of the
+// property name, compared case-insensitively.
+//
+//   - Substring, not equality, because `txt.replace` is a substring operation:
+//     `checkin` -> `checking` corrupts both the property `checkin` and the
+//     property `msg_hdr_checking_disabled` (-> `msg_hdr_checkingg_disabled`).
+//   - Case-insensitive, because generated code carries each property name both
+//     verbatim (the wire key) and in CamelCase (Go identifiers), so `Sevice` is
+//     just as dangerous as `sevice`.
+//   - Keys are compared EXACTLY AS WRITTEN, with no trimming. Space-padded keys
+//     such as `" ADN "` or `" defin "` cannot occur inside a property name, so
+//     they are correctly reported as safe; trimming them would invent false
+//     positives (` defin ` would "collide" with `api_definition`).
+func TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames(t *testing.T) {
+	root := repoRootFromTest(t)
+
+	specDir := os.Getenv("XCSH_SPEC_DIR")
+	if specDir == "" {
+		specDir = filepath.Join(root, "docs", "specifications", "api")
+	}
+
+	properties := specPropertyNames(t, specDir)
+	if properties == nil {
+		t.Skipf("spec artifact not present at %s; set XCSH_SPEC_DIR to the released spec bundle to run this guard", specDir)
+	}
+
+	corrections := codespellCorrections(t, root)
+
+	keys := make([]string, 0, len(corrections))
+	for key := range corrections {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var failures []string
+	for _, key := range keys {
+		lowerKey := strings.ToLower(key)
+		var hits []string
+		for property := range properties {
+			if strings.Contains(strings.ToLower(property), lowerKey) {
+				hits = append(hits, property)
+			}
+		}
+		if len(hits) == 0 {
+			continue
+		}
+		sort.Strings(hits)
+		failures = append(failures, fmt.Sprintf(
+			"  %q -> %q collides with spec propert%s: %s",
+			key, corrections[key], plural(len(hits)), strings.Join(hits, ", "),
+		))
+	}
+
+	if len(failures) > 0 {
+		t.Errorf("tools/codespell-corrections.json contains %d key(s) that rewrite real API property names (#1257).\n%s\n\n"+
+			"Every such key silently renames a wire field wherever the corrections are applied. "+
+			"Remove the key, or narrow it (e.g. pad it with spaces) so it can only match prose.",
+			len(failures), strings.Join(failures, "\n"))
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}


### PR DESCRIPTION
## What
A CI step was silently rewriting **identifiers inside generated Go**, corrupting API wire keys. This makes the spelling pass prose-only, drops the four identifier-colliding correction keys, and adds a guard test so it cannot recur.

## The bug (the issue's original root cause was wrong — corrected there)
The F5 XC field is **misspelled upstream**: `blocked_sevice` (no "r"). A raw `PUT` with `blocked_sevice` returns **HTTP 200** and round-trips; the provider was sending `blocked_service`, so the server silently ignored it and the block vanished on read-back.

The spec and the generator were both **correct**. `.github/workflows/on-merge.yml` ("Fix generated content for lint compliance") ran `codespell --write-changes … internal/provider/` plus a blind `txt.replace` over every generated `.go`, driven by `tools/codespell-corrections.json`. Smoking gun: commit `069611d2` — reporting *"Provider code: false"* — renamed `blocked_sevice` → `blocked_service` across the site resources.

Measured evidence that **both** identifier and prose corruption were live in `main`: 51 corrupted `checking` identifiers **and** 7 doubly-corrupted prose instances (`"during health checkingg"`, from `"checking".replace("checkin","checking")`). Fresh output is the exact mirror: 51 `checkin` + 7 `checking`.

## Fix
- `on-merge.yml`: `internal/provider/` removed from **both** the `codespell --write-changes` target list and the Python replacement loop — the pass is now prose-only, with a comment citing #1257 and `069611d2`.
- Dropped the four colliding keys from `tools/codespell-corrections.json`. Justified, not test-accommodation: every occurrence of `sevice` (4) and of `checkin` not followed by `g` (25) in the spec is an **identifier**, zero are prose, and codespell is word-boundary aware so it never touched `blocked_sevice` — the Python loop was the sole culprit.
- New guard `tools/pkg/codegen/codespell_guard_test.go`: no correction key may occur as a case-insensitive substring of any spec property name (5726 names, walked recursively). Failed first, naming all four keys.

**Restored wire keys** (verified by regeneration, then reset): `blocked_sevice` = 8 / `blocked_service` = 0 in `securemesh_site_v2_resource.go` across **7** site resources (not 8 — `fleet` emits neither spelling); `checkin` = 8 / `checking` = 0 in `http_loadbalancer_resource.go`.

## Review-driven fixes
- **The guard had never run anywhere** — not just on PRs. Both callers pass a repo-relative spec dir, but `go test` runs each test with its *package* directory as cwd, so the env var missed and the guard silently skipped even post-merge. A relative value now resolves against the module root, matching `--spec-dir` semantics.
- **The guard could not fail on a PR:** `_generate-provider.yml` is called only by `on-merge.yml` (`push: main`), so it ran post-merge — a bad key could merge. `_build-test.yml` now fetches the release asset (the source repo is public, so `github.token` + the already-granted `contents: read` suffices) and **fails the job** if the asset is missing or unpacks empty.
- **Silent-vacuity hole closed:** an explicitly-set `XCSH_SPEC_DIR` that is missing or not a v2 layout now **hard-fails** instead of skipping; skipping only happens when the variable is unset. Verified in all three states (bogus → FAIL, valid → PASS and non-vacuous, unset → SKIP).

## zizmor
Editing these workflows pulls them into Super-Linter's audited set, so **30 pre-existing findings were fixed at the source — zero `zizmor.yaml` edits, zero inline suppressions** (`zizmor.yaml` is a docs-control-protected file, so ignoring was never an option): `on-merge.yml` 23 → 0 (20 `template-injection` via step-level `env:` + shell-quoted `"${VAR}"`; **3 High `excessive-permissions`** by replacing workflow-level `contents`/`pull-requests`/`issues: write` with `permissions: {}` + per-job least privilege) and `_generate-provider.yml` 7 → 0. Post-change: `zizmor` reports no findings; `actionlint` exit 0.

The permission narrowing was audited **job-by-job**, including all four reusable callees and the third-party release workflow (which declares no `permissions:` of its own and inherits the caller's). `pull-requests: write` and `issues: write` had **no consumer at all** — every PR/issue mutation uses `secrets.AUTO_MERGE_TOKEN` — and only `_tag-release.yml` needs `contents: write` (tag push, GoReleaser, `gh release upload`).

**⚠️ Watch the first post-merge run.** This is the release pipeline; only a real run exercises tag push, release publish and PR creation. If it fails, revert the permission hunks — the codespell fix and guard are independent of them.

## Consumer impact (coordinate)
The next regeneration renames the Terraform attribute to `blocked_sevice` on 7 site resources — breaking, acceptable under this repo's no-backward-compat rule, and it makes `blocked_services` **functional for the first time** (it was silently ignored by the API). The `mcn` coverage probe currently fails to parse against a correctly-generated provider (`Did you mean "blocked_sevice"?`) and is updated in the follow-up consumer PR.

## Follow-ups filed
- **api-specs-enriched#1063** — 87 upstream prose typos now reach schema descriptions (previously masked by the removed pass). Verified this reddens no CI gate and user-facing docs stay clean; the fix belongs upstream and must stay prose-only.
- **#1293** — the specs-download block is now duplicated in two workflows (plus a note on a hermetic fixture alternative).
- **#1290** — pre-existing: stale-PR branch deletion has no usable credential and can only fail silently. Deliberately untouched here.

Part of epic #1207 (slice S7).

Closes #1257
