### PR TITLE
fix(ci): close zizmor injection and excessive-permission findings

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -60,9 +60,9 @@ jobs:
 
       - name: Calculate next version
         id: version
+        env:
+          LATEST_TAG: ${{ steps.get_tag.outputs.latest_tag }}
         run: |
-          LATEST_TAG="${{ steps.get_tag.outputs.latest_tag }}"
-
           # Remove 'v' prefix
           VERSION=${LATEST_TAG#v}
 
@@ -101,21 +101,28 @@ jobs:
           echo "Next version: $NEW_TAG"
 
       - name: Version Diagnostics
+        env:
+          RUN_ID: ${{ github.run_id }}
+          TRIGGER_SHA: ${{ github.sha }}
+          LATEST_TAG: ${{ steps.get_tag.outputs.latest_tag }}
+          NEW_TAG: ${{ steps.version.outputs.new_tag }}
+          BUMP: ${{ steps.version.outputs.bump }}
         run: |
           echo "=== VERSION DIAGNOSTICS (tag-release) ==="
-          echo "Workflow run ID: ${{ github.run_id }}"
-          echo "Triggered by SHA: ${{ github.sha }}"
+          echo "Workflow run ID: ${RUN_ID}"
+          echo "Triggered by SHA: ${TRIGGER_SHA}"
           echo "Current HEAD SHA: $(git rev-parse HEAD)"
-          echo "Latest git tag: ${{ steps.get_tag.outputs.latest_tag }}"
-          echo "Calculated next version: ${{ steps.version.outputs.new_tag }}"
-          echo "Version bump type: ${{ steps.version.outputs.bump }}"
-          echo "Tag exists check: $(git rev-parse ${{ steps.version.outputs.new_tag }} 2>/dev/null && echo 'YES - ALREADY EXISTS' || echo 'NO - WILL CREATE')"
+          echo "Latest git tag: ${LATEST_TAG}"
+          echo "Calculated next version: ${NEW_TAG}"
+          echo "Version bump type: ${BUMP}"
+          echo "Tag exists check: $(git rev-parse "$NEW_TAG" 2>/dev/null && echo 'YES - ALREADY EXISTS' || echo 'NO - WILL CREATE')"
           echo "============================================"
 
       - name: Check if tag exists
         id: check
+        env:
+          NEW_TAG: ${{ steps.version.outputs.new_tag }}
         run: |
-          NEW_TAG="${{ steps.version.outputs.new_tag }}"
           if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Tag $NEW_TAG already exists"
@@ -129,9 +136,8 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         env:
           LATEST_TAG: ${{ steps.get_tag.outputs.latest_tag }}
+          NEW_TAG: ${{ steps.version.outputs.new_tag }}
         run: |
-          NEW_TAG="${{ steps.version.outputs.new_tag }}"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -187,9 +193,10 @@ jobs:
           ref: ${{ needs.tag.outputs.new_tag }}
 
       - name: Create MCP data tarball
+        env:
+          NEW_TAG: ${{ needs.tag.outputs.new_tag }}
         run: |
-          VERSION="${{ needs.tag.outputs.new_tag }}"
-          VERSION="${VERSION#v}"
+          VERSION="${NEW_TAG#v}"
 
           echo "Creating MCP data tarball for v${VERSION}..."
 
@@ -229,12 +236,12 @@ jobs:
       - name: Upload to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ needs.tag.outputs.new_tag }}
         run: |
-          VERSION="${{ needs.tag.outputs.new_tag }}"
-          VERSION="${VERSION#v}"
+          VERSION="${NEW_TAG#v}"
 
-          gh release upload "${{ needs.tag.outputs.new_tag }}" \
+          gh release upload "$NEW_TAG" \
             "mcp-data-${VERSION}.tar.gz" \
             --clobber
 
-          echo "Uploaded mcp-data-${VERSION}.tar.gz to release ${{ needs.tag.outputs.new_tag }}"
+          echo "Uploaded mcp-data-${VERSION}.tar.gz to release ${NEW_TAG}"

--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -34,6 +34,9 @@ jobs:
   tag:
     name: Create Version Tag
     runs-on: ubuntu-latest
+    # Pushes the new version tag.
+    permissions:
+      contents: write
     outputs:
       new_tag: ${{ steps.version.outputs.new_tag }}
       latest_tag: ${{ steps.get_tag.outputs.latest_tag }}
@@ -150,6 +153,9 @@ jobs:
     name: Create Release
     needs: tag
     if: needs.tag.outputs.created == 'true' && inputs.create-release
+    # goreleaser publishes the GitHub release; that is the only scope it needs.
+    permissions:
+      contents: write
     # Using our fork with updated action versions to fix cache 400 errors
     # Original: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5
     # Fork updates: checkout@v6.0.1, setup-go@v6.1.0, ghaction-import-gpg@v6.3.0
@@ -171,6 +177,9 @@ jobs:
     needs: [tag, release]
     if: needs.tag.outputs.created == 'true' && inputs.create-release
     runs-on: ubuntu-latest
+    # Attaches the MCP data tarball to the release via `gh release upload`.
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -225,8 +225,10 @@ jobs:
 
     steps:
       - name: Check runner availability
+        env:
+          RUNNER_NAME: ${{ runner.name }}
         run: |
-          echo "Running on self-hosted runner: ${{ runner.name }}"
+          echo "Running on self-hosted runner: ${RUNNER_NAME}"
           echo ""
           echo "Verifying F5 XC API connectivity..."
 
@@ -347,9 +349,10 @@ jobs:
 
       - name: Cleanup P12 certificate
         if: always() && steps.verify-creds.outputs.auth_method == 'p12'
+        env:
+          P12_DIR: ${{ steps.setup-p12.outputs.p12_dir }}
         run: |
           # Securely remove the temporary P12 file
-          P12_DIR="${{ steps.setup-p12.outputs.p12_dir }}"
           if [ -n "$P12_DIR" ] && [ -d "$P12_DIR" ]; then
             rm -rf "$P12_DIR"
             echo "✓ Temporary P12 certificate cleaned up"
@@ -467,21 +470,24 @@ jobs:
 
       - name: Cleanup P12 certificate
         if: always() && steps.setup-p12.outputs.p12_dir != ''
+        env:
+          P12_DIR: ${{ steps.setup-p12.outputs.p12_dir }}
         run: |
-          P12_DIR="${{ steps.setup-p12.outputs.p12_dir }}"
           if [ -n "$P12_DIR" ] && [ -d "$P12_DIR" ]; then
             rm -rf "$P12_DIR"
             echo "✓ Temporary P12 certificate cleaned up"
           fi
 
       - name: Post cleanup summary
+        env:
+          SWEPT_NAMESPACES: ${{ steps.sweep.outputs.swept_namespaces || '0' }}
         run: |
           {
             echo "## Resource Cleanup"
             echo ""
             echo "Sweepers ran to clean up test resources left behind by acceptance tests."
             echo ""
-            echo "- Namespaces cleaned: ${{ steps.sweep.outputs.swept_namespaces || '0' }}"
+            echo "- Namespaces cleaned: ${SWEPT_NAMESPACES}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -90,10 +90,12 @@ on:
   schedule:
     - cron: '0 2 * * 1'  # Monday 2 AM UTC
 
+# Least privilege by default. `checks: write` is granted only on the two jobs that
+# publish a JUnit check run via mikepenz/action-junit-report. `pull-requests: write`
+# was previously granted workflow-wide but nothing here writes to a PR — the report
+# action is not configured to comment (`comment` defaults to false) — so it is dropped.
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
 
 # Only one acceptance test run at a time
 concurrency:
@@ -115,6 +117,11 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       github.event.inputs.mode != 'real-only'
 
+    # Publishes the "Mock Test Results" check run.
+    permissions:
+      contents: read
+      checks: write
+
     outputs:
       mock_passed: ${{ steps.run-tests.outputs.passed }}
       mock_failed: ${{ steps.run-tests.outputs.failed }}
@@ -131,12 +138,17 @@ jobs:
 
       - name: Run mock tests
         id: run-tests
+        env:
+          # workflow_dispatch inputs are free-text; via env they stay inert data
+          # instead of expanding into the run body as shell.
+          INPUT_PARALLEL: ${{ github.event.inputs.parallel }}
+          INPUT_TIMEOUT: ${{ github.event.inputs.timeout }}
         run: |
           mkdir -p test-reports
 
           # Mock tests run in PARALLEL - no rate limiting needed
-          PARALLEL="${{ github.event.inputs.parallel || '4' }}"
-          TIMEOUT="${{ github.event.inputs.timeout || '10' }}"
+          PARALLEL="${INPUT_PARALLEL:-4}"
+          TIMEOUT="${INPUT_TIMEOUT:-10}"
 
           echo "Running mock tests with parallelism: $PARALLEL"
 
@@ -200,6 +212,11 @@ jobs:
        github.event.inputs.mode == 'real-only')
     # Allow workflow to continue if self-hosted runner is unavailable
     continue-on-error: ${{ github.event_name == 'schedule' }}
+
+    # Publishes the "Real API Test Results" check run.
+    permissions:
+      contents: read
+      checks: write
 
     outputs:
       real_passed: ${{ steps.run-tests.outputs.passed }}
@@ -286,13 +303,17 @@ jobs:
           XCSH_P12_FILE: ${{ steps.setup-p12.outputs.p12_file }}
           XCSH_P12_PASSWORD: ${{ secrets.XCSH_P12_PASSWORD }}
           TF_ACC: '1'
+          # See the mock-tests job: dispatch inputs and step outputs are passed as
+          # env so they cannot expand into the run body as shell.
+          INPUT_TIMEOUT: ${{ github.event.inputs.timeout }}
+          AUTH_METHOD: ${{ steps.verify-creds.outputs.auth_method }}
         run: |
           mkdir -p test-reports
 
-          TIMEOUT="${{ github.event.inputs.timeout || '10' }}"
+          TIMEOUT="${INPUT_TIMEOUT:-10}"
 
           echo "Running real API tests SEQUENTIALLY with rate limiting"
-          echo "Auth method: ${{ steps.verify-creds.outputs.auth_method }}"
+          echo "Auth method: ${AUTH_METHOD}"
           echo "Timeout per test: ${TIMEOUT}m"
 
           # Real API tests run SEQUENTIALLY (-parallel 1) with rate limiting

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -44,9 +44,11 @@ on:
   schedule:
     - cron: '0 6 1 * *'  # First day of month at 6am UTC
 
+# Least privilege by default: read-only at the workflow level. The `discover` job
+# raises this to write because it pushes a branch and opens a PR; `summary` only
+# prints, so it inherits read-only.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Only one discovery run at a time
 concurrency:
@@ -67,6 +69,11 @@ jobs:
     runs-on: self-hosted
     # Allow manual runs to fail gracefully if runner unavailable
     continue-on-error: ${{ github.event_name == 'schedule' }}
+
+    # Pushes the discovery branch and opens the PR that carries the results.
+    permissions:
+      contents: write
+      pull-requests: write
 
     outputs:
       changes_detected: ${{ steps.check-changes.outputs.changes_detected }}
@@ -120,9 +127,14 @@ jobs:
           XCSH_API_URL: ${{ secrets.XCSH_API_URL }}
           XCSH_P12_FILE: ${{ secrets.XCSH_P12_FILE }}
           XCSH_P12_PASSWORD: ${{ secrets.XCSH_P12_PASSWORD }}
+          # `resource` is a free-text workflow_dispatch input, so interpolating it
+          # into the run body below would let it expand into executable shell.
+          # Both inputs come in as env and are read as inert shell variables.
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_RESOURCE: ${{ inputs.resource }}
         run: |
-          MODE="${{ inputs.mode || 'discover' }}"
-          RESOURCE="${{ inputs.resource }}"
+          MODE="${INPUT_MODE:-discover}"
+          RESOURCE="$INPUT_RESOURCE"
 
           echo "::group::Running discovery (mode: $MODE)"
 

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -82,8 +82,10 @@ jobs:
 
     steps:
       - name: Check runner availability
+        env:
+          RUNNER_NAME: ${{ runner.name }}
         run: |
-          echo "Running on self-hosted runner: ${{ runner.name }}"
+          echo "Running on self-hosted runner: ${RUNNER_NAME}"
           echo ""
           echo "Verifying VPN connectivity..."
           # The self-hosted runner should have VPN configured
@@ -199,6 +201,12 @@ jobs:
           inputs.mode != 'validate'
         env:
           GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+          # Discovery counts reach the commit message and PR body as env rather than
+          # as `${{ }}` expansions inside the run body. The PR-body heredoc stays
+          # single-quoted because it contains backticks that must not be evaluated,
+          # so its values go in by placeholder substitution below.
+          RESOURCES_DISCOVERED: ${{ steps.discover.outputs.resources_discovered }}
+          RESOURCES_FAILED: ${{ steps.discover.outputs.resources_failed }}
         run: |
           # Configure git
           git config user.name "github-actions[bot]"
@@ -212,13 +220,13 @@ jobs:
           git add tools/api-defaults.json internal/mocks/generated_defaults.go
 
           # Commit
-          git commit -m "$(cat <<'EOF'
+          git commit -m "$(cat <<EOF
           chore: update API-discovered defaults
 
           Automated update from discover-defaults workflow.
 
-          Resources discovered: ${{ steps.discover.outputs.resources_discovered }}
-          Resources failed: ${{ steps.discover.outputs.resources_failed }}
+          Resources discovered: ${RESOURCES_DISCOVERED}
+          Resources failed: ${RESOURCES_FAILED}
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
@@ -229,10 +237,10 @@ jobs:
           # Push
           git push origin "$BRANCH"
 
-          # Create PR
-          gh pr create \
-            --title "chore: update API-discovered defaults" \
-            --body "$(cat <<'EOF'
+          # Create PR. The heredoc stays single-quoted so the backticks in the body
+          # below are not evaluated as command substitution; the two discovery counts
+          # are substituted in afterwards instead of being expanded here.
+          PR_BODY=$(cat <<'EOF'
           ## Summary
 
           Automated update of API-discovered default values.
@@ -244,8 +252,8 @@ jobs:
 
           ## Discovery Results
 
-          - Resources discovered: ${{ steps.discover.outputs.resources_discovered }}
-          - Resources failed: ${{ steps.discover.outputs.resources_failed }}
+          - Resources discovered: __RESOURCES_DISCOVERED__
+          - Resources failed: __RESOURCES_FAILED__
 
           ## Testing
 
@@ -255,7 +263,13 @@ jobs:
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
           EOF
-          )" \
+          )
+          PR_BODY=${PR_BODY//__RESOURCES_DISCOVERED__/$RESOURCES_DISCOVERED}
+          PR_BODY=${PR_BODY//__RESOURCES_FAILED__/$RESOURCES_FAILED}
+
+          gh pr create \
+            --title "chore: update API-discovered defaults" \
+            --body "$PR_BODY" \
             --label "automated,documentation"
 
       - name: Upload discovery log
@@ -276,14 +290,18 @@ jobs:
     if: always()
     steps:
       - name: Report results
+        env:
+          RESOURCES_DISCOVERED: ${{ needs.discover.outputs.resources_discovered || 'N/A' }}
+          RESOURCES_FAILED: ${{ needs.discover.outputs.resources_failed || 'N/A' }}
+          CHANGES_DETECTED: ${{ needs.discover.outputs.changes_detected || 'N/A' }}
         run: |
           echo "## API Default Discovery Results"
           echo ""
           echo "| Metric | Value |"
           echo "|--------|-------|"
-          echo "| Resources Discovered | ${{ needs.discover.outputs.resources_discovered || 'N/A' }} |"
-          echo "| Resources Failed | ${{ needs.discover.outputs.resources_failed || 'N/A' }} |"
-          echo "| Changes Detected | ${{ needs.discover.outputs.changes_detected || 'N/A' }} |"
+          echo "| Resources Discovered | ${RESOURCES_DISCOVERED} |"
+          echo "| Resources Failed | ${RESOURCES_FAILED} |"
+          echo "| Changes Detected | ${CHANGES_DETECTED} |"
           echo ""
 
           if [ "${{ needs.discover.result }}" = "failure" ]; then


### PR DESCRIPTION
## Problem

`Lint Code Base` runs super-linter with `VALIDATE_ALL_CODEBASE=false`, so zizmor only
ever audited workflow files a PR *changed*. Findings in this repo's workflows were
therefore never surfaced. The new scheduled Workflow Security Audit (docs-control#775)
exposed them.

Part of #1294 was **already fixed on `main`** while this branch sat unpushed —
`on-merge.yml` and `_generate-provider.yml` are done, and done better than this branch
originally had them (`main` grants `create-regeneration-pr` only `contents: read`, having
verified every PR/issue mutation authenticates with `secrets.AUTO_MERGE_TOKEN`, so the
write scopes had no consumer at all). Those files were dropped from this branch in favour
of `main`'s versions. What remains here is the three workflows nothing has touched yet.

## Change

- **template-injection** (`acc-tests.yml`, `discover-defaults.yml`) — `workflow_dispatch`
  inputs and step outputs bound at job scope through `env:` and read as quoted shell
  variables, so they reach `run:` bodies as inert data instead of expanding into
  executable shell before bash parses them.
- **excessive-permissions** (`acc-tests.yml`, `discover-defaults.yml`, `_tag-release.yml`)
  — read-only default at workflow level; narrow write scopes only on the jobs that
  publish a check run, push a branch, open a PR, push a tag or publish a release, each
  with a comment stating why. `acc-tests.yml` also drops a workflow-wide
  `pull-requests: write` that had no consumer — the JUnit report action is not configured
  to comment.

## Verification

`zizmor --config zizmor.yaml --min-severity medium .github/workflows/`, exit status
captured by redirect rather than through a pipe:

| | exit | findings |
|---|---|---|
| base (`main` @ `0a65384`) | 14 | 7 high, 2 medium |
| this branch | **0** | **none** |

All 9 baseline findings sit in the three files this PR touches. `actionlint` passes clean
(exit 0). Biome does not apply — it ignores `.github/workflows/`.

`_tag-release.yml` is on the release path, so the tag/release behaviour wants confirming
by artifact on the next release rather than by a green check alone.

Closes #1294
