### PR TITLE
S9: honour x-f5xc-wire-name — present corrected property names, keep F5's wire keys

### DIFF
--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -1086,7 +1086,7 @@ func (d *{{.TitleCase}}DataSource) Read(ctx context.Context, req datasource.Read
 
 	// Map spec fields from API response
 {{- range .Attributes}}{{if and .Computed (not (eq .Name "id")) (not (eq .Name "name")) (not (eq .Name "namespace")) (not (eq .Name "description")) (not (eq .Name "labels")) (not (eq .Name "annotations"))}}
-	if v, ok := resource.Spec["{{.TfsdkTag}}"]; ok && v != nil {
+	if v, ok := resource.Spec["{{.JsonName}}"]; ok && v != nil {
 		data.{{.GoName}} = types.StringValue(fmt.Sprintf("%v", v))
 	} else {
 		data.{{.GoName}} = types.StringNull()

--- a/tools/pkg/codegen/testdata/wire_name_absent.golden
+++ b/tools/pkg/codegen/testdata/wire_name_absent.golden
@@ -1,0 +1,225 @@
+// ---- struct fields ----
+	AdvertisedService []map[string]interface{} `json:"advertised_service"`
+	BlockedServices map[string]interface{} `json:"blocked_services"`
+	PublicAdvertisement bool `json:"public_advertisement,omitempty"`
+// ---- marshal (create) ----
+	if !data.AdvertisedService.IsNull() && !data.AdvertisedService.IsUnknown() {
+		var AdvertisedServiceElems []ZzWireProbeAdvertisedServiceModel
+		diags := data.AdvertisedService.ElementsAs(ctx, &AdvertisedServiceElems, false)
+		resp.Diagnostics.Append(diags...)
+		if !resp.Diagnostics.HasError() && len(AdvertisedServiceElems) > 0 {
+			var AdvertisedServiceList []map[string]interface{}
+			for _, AdvertisedServiceItem := range AdvertisedServiceElems {
+				AdvertisedServiceItemMap := make(map[string]interface{})
+				if !AdvertisedServiceItem.Port.IsNull() && !AdvertisedServiceItem.Port.IsUnknown() {
+					AdvertisedServiceItemMap["port"] = AdvertisedServiceItem.Port.ValueInt64()
+				}
+				AdvertisedServiceList = append(AdvertisedServiceList, AdvertisedServiceItemMap)
+			}
+			createReq.Spec["advertised_service"] = AdvertisedServiceList
+		}
+	}
+	if data.BlockedServices != nil {
+		BlockedServicesMap := make(map[string]interface{})
+		if !data.BlockedServices.BlockedService.IsNull() && !data.BlockedServices.BlockedService.IsUnknown() {
+			var BlockedServiceElems []ZzWireProbeBlockedServicesBlockedServiceModel
+			diags := data.BlockedServices.BlockedService.ElementsAs(ctx, &BlockedServiceElems, false)
+			resp.Diagnostics.Append(diags...)
+			if !resp.Diagnostics.HasError() && len(BlockedServiceElems) > 0 {
+				var BlockedServiceList []map[string]interface{}
+				for _, BlockedServiceItem := range BlockedServiceElems {
+					BlockedServiceItemMap := make(map[string]interface{})
+					if !BlockedServiceItem.BlockedServiceName.IsNull() && !BlockedServiceItem.BlockedServiceName.IsUnknown() {
+						BlockedServiceItemMap["blocked_service_name"] = BlockedServiceItem.BlockedServiceName.ValueString()
+					}
+					if !BlockedServiceItem.NetworkType.IsNull() && !BlockedServiceItem.NetworkType.IsUnknown() {
+						BlockedServiceItemMap["network_type"] = BlockedServiceItem.NetworkType.ValueString()
+					}
+					BlockedServiceList = append(BlockedServiceList, BlockedServiceItemMap)
+				}
+				BlockedServicesMap["blocked_service"] = BlockedServiceList
+			}
+		}
+		if data.BlockedServices.DisableLBSourceIPPersistence != nil {
+			BlockedServicesMap["disable_lb_source_ip_persistence"] = map[string]interface{}{}
+		}
+		if data.BlockedServices.SourceIPPersistence != nil {
+			BlockedServicesSourceIPPersistenceMap := make(map[string]interface{})
+			if !data.BlockedServices.SourceIPPersistence.PersistenceTimeout.IsNull() && !data.BlockedServices.SourceIPPersistence.PersistenceTimeout.IsUnknown() {
+				BlockedServicesSourceIPPersistenceMap["persistence_timeout"] = data.BlockedServices.SourceIPPersistence.PersistenceTimeout.ValueInt64()
+			}
+			BlockedServicesMap["source_ip_persistence"] = BlockedServicesSourceIPPersistenceMap
+		}
+		createReq.Spec["blocked_services"] = BlockedServicesMap
+	}
+	if !data.PublicAdvertisement.IsNull() && !data.PublicAdvertisement.IsUnknown() {
+		createReq.Spec["public_advertisement"] = data.PublicAdvertisement.ValueBool()
+	}
+// ---- marshal (update) ----
+	if !data.AdvertisedService.IsNull() && !data.AdvertisedService.IsUnknown() {
+		var AdvertisedServiceElems []ZzWireProbeAdvertisedServiceModel
+		diags := data.AdvertisedService.ElementsAs(ctx, &AdvertisedServiceElems, false)
+		resp.Diagnostics.Append(diags...)
+		if !resp.Diagnostics.HasError() && len(AdvertisedServiceElems) > 0 {
+			var AdvertisedServiceList []map[string]interface{}
+			for _, AdvertisedServiceItem := range AdvertisedServiceElems {
+				AdvertisedServiceItemMap := make(map[string]interface{})
+				if !AdvertisedServiceItem.Port.IsNull() && !AdvertisedServiceItem.Port.IsUnknown() {
+					AdvertisedServiceItemMap["port"] = AdvertisedServiceItem.Port.ValueInt64()
+				}
+				AdvertisedServiceList = append(AdvertisedServiceList, AdvertisedServiceItemMap)
+			}
+			apiResource.Spec["advertised_service"] = AdvertisedServiceList
+		}
+	}
+	if data.BlockedServices != nil {
+		BlockedServicesMap := make(map[string]interface{})
+		if !data.BlockedServices.BlockedService.IsNull() && !data.BlockedServices.BlockedService.IsUnknown() {
+			var BlockedServiceElems []ZzWireProbeBlockedServicesBlockedServiceModel
+			diags := data.BlockedServices.BlockedService.ElementsAs(ctx, &BlockedServiceElems, false)
+			resp.Diagnostics.Append(diags...)
+			if !resp.Diagnostics.HasError() && len(BlockedServiceElems) > 0 {
+				var BlockedServiceList []map[string]interface{}
+				for _, BlockedServiceItem := range BlockedServiceElems {
+					BlockedServiceItemMap := make(map[string]interface{})
+					if !BlockedServiceItem.BlockedServiceName.IsNull() && !BlockedServiceItem.BlockedServiceName.IsUnknown() {
+						BlockedServiceItemMap["blocked_service_name"] = BlockedServiceItem.BlockedServiceName.ValueString()
+					}
+					if !BlockedServiceItem.NetworkType.IsNull() && !BlockedServiceItem.NetworkType.IsUnknown() {
+						BlockedServiceItemMap["network_type"] = BlockedServiceItem.NetworkType.ValueString()
+					}
+					BlockedServiceList = append(BlockedServiceList, BlockedServiceItemMap)
+				}
+				BlockedServicesMap["blocked_service"] = BlockedServiceList
+			}
+		}
+		if data.BlockedServices.DisableLBSourceIPPersistence != nil {
+			BlockedServicesMap["disable_lb_source_ip_persistence"] = map[string]interface{}{}
+		}
+		if data.BlockedServices.SourceIPPersistence != nil {
+			BlockedServicesSourceIPPersistenceMap := make(map[string]interface{})
+			if !data.BlockedServices.SourceIPPersistence.PersistenceTimeout.IsNull() && !data.BlockedServices.SourceIPPersistence.PersistenceTimeout.IsUnknown() {
+				BlockedServicesSourceIPPersistenceMap["persistence_timeout"] = data.BlockedServices.SourceIPPersistence.PersistenceTimeout.ValueInt64()
+			}
+			BlockedServicesMap["source_ip_persistence"] = BlockedServicesSourceIPPersistenceMap
+		}
+		apiResource.Spec["blocked_services"] = BlockedServicesMap
+	}
+	if !data.PublicAdvertisement.IsNull() && !data.PublicAdvertisement.IsUnknown() {
+		apiResource.Spec["public_advertisement"] = data.PublicAdvertisement.ValueBool()
+	}
+// ---- unmarshal ----
+	if !isImport && (data.AdvertisedService.IsNull() || len(data.AdvertisedService.Elements()) == 0) {
+		data.AdvertisedService = types.ListNull(types.ObjectType{AttrTypes: ZzWireProbeAdvertisedServiceModelAttrTypes})
+	} else if listData, ok := apiResource.Spec["advertised_service"].([]interface{}); ok && len(listData) > 0 {
+		var AdvertisedServiceList []ZzWireProbeAdvertisedServiceModel
+		var existingAdvertisedServiceItems []ZzWireProbeAdvertisedServiceModel
+		if !data.AdvertisedService.IsNull() && !data.AdvertisedService.IsUnknown() {
+			data.AdvertisedService.ElementsAs(ctx, &existingAdvertisedServiceItems, false)
+		}
+		for listIdx, item := range listData {
+			_ = listIdx
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				AdvertisedServiceList = append(AdvertisedServiceList, ZzWireProbeAdvertisedServiceModel{
+					Port: func() types.Int64 {
+						if v, ok := itemMap["port"].(float64); ok && v != 0 {
+							return types.Int64Value(int64(v))
+						}
+						return types.Int64Null()
+					}(),
+				})
+			}
+		}
+		listVal, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: ZzWireProbeAdvertisedServiceModelAttrTypes}, AdvertisedServiceList)
+		resp.Diagnostics.Append(diags...)
+		if !resp.Diagnostics.HasError() {
+			data.AdvertisedService = listVal
+		}
+	} else {
+		data.AdvertisedService = types.ListNull(types.ObjectType{AttrTypes: ZzWireProbeAdvertisedServiceModelAttrTypes})
+	}
+	if blockData, ok := apiResource.Spec["blocked_services"].(map[string]interface{}); ok && (isImport || data.BlockedServices != nil) {
+		data.BlockedServices = &ZzWireProbeBlockedServicesModel{
+			BlockedService: func() types.List {
+				if !isImport && data.BlockedServices != nil && (data.BlockedServices.BlockedService.IsNull() || len(data.BlockedServices.BlockedService.Elements()) == 0) {
+					return types.ListNull(types.ObjectType{AttrTypes: ZzWireProbeBlockedServicesBlockedServiceModelAttrTypes})
+				}
+				var BlockedServiceExisting []ZzWireProbeBlockedServicesBlockedServiceModel
+				if !isImport && data.BlockedServices != nil && !data.BlockedServices.BlockedService.IsNull() && !data.BlockedServices.BlockedService.IsUnknown() {
+					data.BlockedServices.BlockedService.ElementsAs(ctx, &BlockedServiceExisting, false)
+				}
+				if rawList, ok := blockData["blocked_service"].([]interface{}); ok && len(rawList) > 0 {
+					var BlockedServiceResult []ZzWireProbeBlockedServicesBlockedServiceModel
+					for BlockedServiceIdx, BlockedServiceItem := range rawList {
+						_ = BlockedServiceIdx
+						if BlockedServiceItemMap, ok := BlockedServiceItem.(map[string]interface{}); ok {
+							BlockedServiceResult = append(BlockedServiceResult, ZzWireProbeBlockedServicesBlockedServiceModel{
+								BlockedServiceName: func() types.String {
+									if v, ok := BlockedServiceItemMap["blocked_service_name"].(string); ok && v != "" {
+										return types.StringValue(v)
+									}
+									return types.StringNull()
+								}(),
+								NetworkType: func() types.String {
+									if v, ok := BlockedServiceItemMap["network_type"].(string); ok && v != "" {
+										return types.StringValue(v)
+									}
+									return types.StringNull()
+								}(),
+							})
+						}
+					}
+					listVal, _ := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: ZzWireProbeBlockedServicesBlockedServiceModelAttrTypes}, BlockedServiceResult)
+					return listVal
+				}
+				return types.ListNull(types.ObjectType{AttrTypes: ZzWireProbeBlockedServicesBlockedServiceModelAttrTypes})
+			}(),
+			DisableLBSourceIPPersistence: func() *ZzWireProbeEmptyModel {
+				if !isImport && data.BlockedServices != nil {
+					return data.BlockedServices.DisableLBSourceIPPersistence
+				}
+				if _, ok := blockData["disable_lb_source_ip_persistence"].(map[string]interface{}); ok {
+					return &ZzWireProbeEmptyModel{}
+				}
+				return nil
+			}(),
+			SourceIPPersistence: func() *ZzWireProbeBlockedServicesSourceIPPersistenceModel {
+				if !isImport && data.BlockedServices != nil && data.BlockedServices.SourceIPPersistence != nil {
+					return data.BlockedServices.SourceIPPersistence
+				}
+				if SourceIPPersistenceData, ok := blockData["source_ip_persistence"].(map[string]interface{}); ok {
+					return &ZzWireProbeBlockedServicesSourceIPPersistenceModel{
+						PersistenceTimeout: func() types.Int64 {
+							if !isImport && data.BlockedServices != nil && data.BlockedServices.SourceIPPersistence != nil && !data.BlockedServices.SourceIPPersistence.PersistenceTimeout.IsUnknown() {
+								return data.BlockedServices.SourceIPPersistence.PersistenceTimeout
+							}
+							if v, ok := SourceIPPersistenceData["persistence_timeout"].(float64); ok && v != 0 {
+								return types.Int64Value(int64(v))
+							}
+							return types.Int64Null()
+						}(),
+					}
+				}
+				return nil
+			}(),
+		}
+	}
+	// Top-level Optional bool: preserve prior state to avoid API default drift
+	if !isImport && !data.PublicAdvertisement.IsNull() && !data.PublicAdvertisement.IsUnknown() {
+		// Normal Read: preserve existing state value (do nothing)
+	} else {
+		if v, ok := apiResource.Spec["public_advertisement"].(bool); ok {
+			data.PublicAdvertisement = types.BoolValue(v)
+		} else {
+			data.PublicAdvertisement = types.BoolNull()
+		}
+	}
+// ---- computed read-back ----
+	// Set computed fields from API response
+	if v, ok := created.Spec["public_advertisement"].(bool); ok {
+		data.PublicAdvertisement = types.BoolValue(v)
+	} else if data.PublicAdvertisement.IsUnknown() {
+		// API didn't return value and plan was unknown - set to null
+		data.PublicAdvertisement = types.BoolNull()
+	}
+	// If plan had a value, preserve it

--- a/tools/pkg/codegen/wire_name_test.go
+++ b/tools/pkg/codegen/wire_name_test.go
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package codegen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/schema"
+)
+
+// Codegen tests for x-f5xc-wire-name (#1323).
+//
+// F5's spec misspells several property names. The wire key must stay misspelled —
+// verified live: a PUT with `blocked_sevice` returns HTTP 200 and round-trips,
+// while `blocked_service` is silently ignored by the server (#1257). The buffer
+// zone presents the CORRECTED spelling as the property name and records the wire
+// key in x-f5xc-wire-name, so generated code must split the two: the Terraform
+// attribute, model field and docs use the corrected name, while EVERY JSON key —
+// client struct tag, request marshal AND response unmarshal — uses the wire key.
+// If only one side used the wire key the field would silently stop working.
+
+// wireProbeSpec is a synthetic CRUD spec whose annotated properties mirror the
+// real shapes of the three misspelled families, at every nesting position that
+// has its own emitter:
+//
+//   - public_advertisement          top-level scalar (wire: public_advertisment)
+//   - advertised_service            top-level LIST block (wire: advertised_sevice)
+//   - blocked_services              top-level SINGLE block (unannotated parent)
+//   - .blocked_service              list-of-objects child (wire: blocked_sevice)
+//     — the real fleetBlockedServicesListType.blocked_sevice shape
+//   - ..blocked_service_name        scalar inside a LIST ELEMENT
+//   - .source_ip_persistence        nested single block (wire: ..._persistance)
+//   - ..persistence_timeout         scalar inside a nested single block
+//   - .disable_lb_source_ip_persistence  allOf-$ref EMPTY MARKER child, the real
+//     origin_pool advanced_options shape
+//
+// annotate=false yields the byte-identical-output control: the same tree with
+// every x-f5xc-wire-name removed.
+func wireProbeSpec(annotate bool) *openapi.Spec {
+	wire := func(name string) string {
+		if annotate {
+			return name
+		}
+		return ""
+	}
+	return &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"ioschemaEmpty": {Type: "object"},
+				"zz_wire_probeCreateSpecType": {
+					Type:        "object",
+					Description: "Synthetic wire-name probe.",
+					Properties: map[string]openapi.Schema{
+						"public_advertisement": {
+							Type:          "boolean",
+							Description:   "Advertised publicly.",
+							XF5xcWireName: wire("public_advertisment"),
+						},
+						"advertised_service": {
+							Type:          "array",
+							Description:   "Advertised services.",
+							XF5xcWireName: wire("advertised_sevice"),
+							Items: &openapi.Schema{
+								Type: "object",
+								Properties: map[string]openapi.Schema{
+									"port": {Type: "integer"},
+								},
+							},
+						},
+						"blocked_services": {
+							Type:        "object",
+							Description: "Blocked service configuration.",
+							Properties: map[string]openapi.Schema{
+								"blocked_service": {
+									Type:          "array",
+									Description:   "Blocking or denial configuration.",
+									XF5xcWireName: wire("blocked_sevice"),
+									Items: &openapi.Schema{
+										Type: "object",
+										Properties: map[string]openapi.Schema{
+											"blocked_service_name": {
+												Type:          "string",
+												XF5xcWireName: wire("blocked_sevice_name"),
+											},
+											"network_type": {Type: "string"},
+										},
+									},
+								},
+								"source_ip_persistence": {
+									Type:          "object",
+									Description:   "Source IP persistence.",
+									XF5xcWireName: wire("source_ip_persistance"),
+									Properties: map[string]openapi.Schema{
+										"persistence_timeout": {
+											Type:          "integer",
+											XF5xcWireName: wire("persistance_timeout"),
+										},
+									},
+								},
+								"disable_lb_source_ip_persistence": {
+									AllOf:         []openapi.Schema{{Ref: "#/components/schemas/ioschemaEmpty"}},
+									XF5xcWireName: wire("disable_lb_source_ip_persistance"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// wireProbeAPIPath is the extractAPIPath stub for the synthetic probe resource.
+func wireProbeAPIPath(*openapi.Spec, string) (string, string, bool) {
+	return "/api/config/namespaces/%s/zz_wire_probes", "/api/config/namespaces/%s/zz_wire_probes/%s", true
+}
+
+// wireProbeTemplate extracts the probe resource template from the fixture.
+func wireProbeTemplate(t *testing.T, annotate bool) *openapi.ResourceTemplate {
+	t.Helper()
+	tmpl, err := schema.ExtractResourceSchema(wireProbeSpec(annotate), "zz_wire_probe", wireProbeAPIPath)
+	if err != nil {
+		t.Fatalf("ExtractResourceSchema: %v", err)
+	}
+	return tmpl
+}
+
+// wireProbeRenders returns the renders that consume JsonName — the client struct
+// tags, the request marshal, the response unmarshal and the computed read-back —
+// concatenated in a stable order. These are the complete set of emitters that
+// decide a JSON key, so byte-identity here IS the "unannotated output is
+// unchanged" claim.
+func wireProbeRenders(tmpl *openapi.ResourceTemplate) string {
+	var sb strings.Builder
+	sb.WriteString("// ---- struct fields ----\n")
+	sb.WriteString(RenderSpecStructFields(tmpl.Attributes, "\t"))
+	sb.WriteString("// ---- marshal (create) ----\n")
+	sb.WriteString(RenderSpecMarshalCodeForCreate(tmpl.Attributes, "\t", tmpl.TitleCase))
+	sb.WriteString("// ---- marshal (update) ----\n")
+	sb.WriteString(RenderSpecMarshalCode(tmpl.Attributes, "\t", tmpl.TitleCase))
+	sb.WriteString("// ---- unmarshal ----\n")
+	sb.WriteString(RenderSpecUnmarshalCode(tmpl.Attributes, "\t", tmpl.TitleCase))
+	sb.WriteString("// ---- computed read-back ----\n")
+	sb.WriteString(RenderCreateComputedFieldsCode(tmpl.Attributes, "\t"))
+	return sb.String()
+}
+
+// TestWireNameRoundTripsInBothDirections asserts that, for every annotated
+// property, the WIRE key is the JSON key on both the request-construction and the
+// read-back path, while the CORRECTED name is what Terraform and the Go model
+// present. It also asserts the inverse in both directions: the corrected name is
+// never used as a JSON key, and the wire key never leaks into a tfsdk tag, schema
+// attribute name or Go identifier.
+func TestWireNameRoundTripsInBothDirections(t *testing.T) {
+	tmpl := wireProbeTemplate(t, true)
+
+	structFields := RenderSpecStructFields(tmpl.Attributes, "\t")
+	marshal := RenderSpecMarshalCodeForCreate(tmpl.Attributes, "\t", tmpl.TitleCase)
+	unmarshal := RenderSpecUnmarshalCode(tmpl.Attributes, "\t", tmpl.TitleCase)
+	tfSchema := RenderNestedAttributes(tmpl.Attributes, "\t") +
+		RenderNestedBlocks(tmpl.Attributes, "\t") +
+		RenderNestedModelTypes(tmpl.TitleCase, tmpl.Attributes) +
+		RenderBlockFields(tmpl.TitleCase, tmpl.Attributes)
+
+	cases := []struct {
+		desc      string
+		corrected string
+		wire      string
+		// topLevel properties additionally carry a client struct JSON tag.
+		topLevel bool
+	}{
+		{desc: "top-level scalar", corrected: "public_advertisement", wire: "public_advertisment", topLevel: true},
+		{desc: "top-level list block", corrected: "advertised_service", wire: "advertised_sevice", topLevel: true},
+		{desc: "nested list block", corrected: "blocked_service", wire: "blocked_sevice"},
+		{desc: "scalar in list element", corrected: "blocked_service_name", wire: "blocked_sevice_name"},
+		{desc: "nested single block", corrected: "source_ip_persistence", wire: "source_ip_persistance"},
+		{desc: "scalar in nested single block", corrected: "persistence_timeout", wire: "persistance_timeout"},
+		{desc: "nested empty marker", corrected: "disable_lb_source_ip_persistence", wire: "disable_lb_source_ip_persistance"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			wireKey := `"` + tc.wire + `"`
+			correctedKey := `"` + tc.corrected + `"`
+
+			// Direction 1: request construction marshals under the wire key.
+			if !strings.Contains(marshal, wireKey) {
+				t.Errorf("marshal must emit the wire key %s; got:\n%s", wireKey, marshal)
+			}
+			if strings.Contains(marshal, correctedKey) {
+				t.Errorf("marshal must NOT emit the corrected name %s as a JSON key (the server silently ignores it); got:\n%s",
+					correctedKey, marshal)
+			}
+
+			// Direction 2: read-back unmarshals from the wire key.
+			if !strings.Contains(unmarshal, wireKey) {
+				t.Errorf("unmarshal must read the wire key %s; got:\n%s", wireKey, unmarshal)
+			}
+			if strings.Contains(unmarshal, correctedKey) {
+				t.Errorf("unmarshal must NOT read the corrected name %s (the API never returns it); got:\n%s",
+					correctedKey, unmarshal)
+			}
+
+			// The Terraform surface keeps the corrected name, and the wire
+			// misspelling never reaches a user-visible identifier.
+			if !strings.Contains(tfSchema, correctedKey) {
+				t.Errorf("Terraform schema/model must present the corrected name %s; got:\n%s", correctedKey, tfSchema)
+			}
+			if strings.Contains(tfSchema, tc.wire) {
+				t.Errorf("Terraform schema/model must not leak the wire misspelling %q; got:\n%s", tc.wire, tfSchema)
+			}
+
+			if tc.topLevel {
+				if !strings.Contains(structFields, `json:"`+tc.wire) {
+					t.Errorf("client struct tag must use the wire key %q; got:\n%s", tc.wire, structFields)
+				}
+				if strings.Contains(structFields, `json:"`+tc.corrected) {
+					t.Errorf("client struct tag must not use the corrected name %q; got:\n%s", tc.corrected, structFields)
+				}
+			}
+		})
+	}
+}
+
+// TestWireNameAbsentOutputUnchanged is the regression guard for the 99% of
+// properties that carry no annotation: the JSON-key-deciding renders must be
+// BYTE-IDENTICAL to what the generator produced before x-f5xc-wire-name existed.
+// The golden was captured from the pre-change generator, so any drift here means
+// the new code path is no longer inert when the annotation is absent.
+func TestWireNameAbsentOutputUnchanged(t *testing.T) {
+	golden := filepath.Join("testdata", "wire_name_absent.golden")
+	want, err := os.ReadFile(golden) // #nosec G304 -- fixed testdata path
+	if err != nil {
+		t.Fatalf("reading golden %s: %v", golden, err)
+	}
+
+	got := wireProbeRenders(wireProbeTemplate(t, false))
+	if got != string(want) {
+		t.Errorf("unannotated output drifted from the pre-change generator (%s).\n--- got ---\n%s\n--- want ---\n%s",
+			golden, got, want)
+	}
+}
+
+// TestWireNameResourceCompiles is the compile-level guard (#1271's lesson: the
+// substring assertions above cannot catch a generator that emits code which does
+// not build). It runs the full pipeline on the annotated fixture, writes the
+// generated Go into the module tree and runs `go build`.
+//
+// The fixture uses the SYNTHETIC resource name "zz_wire_probe": no such resource
+// exists in the specs, so this guard can never clobber a committed generated file
+// and can never start failing once a real artifact exists.
+//
+// The generated files are written to their REAL destinations (internal/provider
+// and internal/client) and removed on cleanup. A throwaway package under
+// internal/ is not enough: a generated CRUD resource calls package-level helpers
+// that live in internal/provider (filterSystemLabels,
+// filterSystemManagedRrSetGroups, ...), so only compiling it as part of that
+// package proves the output actually builds. Both paths are refused if a file is
+// already there, so the guard can never overwrite committed output.
+func TestWireNameResourceCompiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping go build compile check in -short mode")
+	}
+
+	tmpl := wireProbeTemplate(t, true)
+
+	root := repoRootFromTest(t)
+	provDir := filepath.Join(root, "internal", "provider")
+	clientDir := filepath.Join(root, "internal", "client")
+	resourceFile := filepath.Join(provDir, "zz_wire_probe_resource.go")
+	clientTypes := filepath.Join(clientDir, "zz_wire_probe_types.go")
+	for _, path := range []string{resourceFile, clientTypes} {
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("refusing to clobber existing %s", path)
+		}
+	}
+	t.Cleanup(func() {
+		os.Remove(resourceFile)
+		os.Remove(clientTypes)
+	})
+
+	if err := GenerateResourceFile(tmpl, provDir); err != nil {
+		t.Fatalf("GenerateResourceFile: %v", err)
+	}
+	if err := GenerateClientTypes(tmpl, clientDir); err != nil {
+		t.Fatalf("GenerateClientTypes: %v", err)
+	}
+
+	resBytes, err := os.ReadFile(resourceFile)
+	if err != nil {
+		t.Fatalf("reading generated resource: %v", err)
+	}
+	res := string(resBytes)
+	// The generated file must carry BOTH spellings: the corrected one as the
+	// tfsdk tag and the misspelled one as the wire key.
+	if !strings.Contains(res, `tfsdk:"public_advertisement"`) {
+		t.Errorf("generated resource missing corrected tfsdk tag public_advertisement:\n%s", res)
+	}
+	if !strings.Contains(res, `"public_advertisment"`) {
+		t.Errorf("generated resource missing wire key public_advertisment:\n%s", res)
+	}
+
+	cmd := exec.Command("go", "build", "./internal/provider/", "./internal/client/")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated wire-name resource failed to compile (%v):\n%s", err, out)
+	}
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -114,6 +114,19 @@ type Schema struct {
 	// POST, Read=sibling object Get, Delete=no-op — instead of CRUD. Injected by
 	// api-specs-enriched onto the request schema (schema-level, not operation-level).
 	XF5xcAction string `json:"x-f5xc-action"`
+
+	// XF5xcWireName records the property's ON-THE-WIRE JSON key when it differs
+	// from the property name. F5 ships several misspelled property names
+	// (blocked_sevice, public_advertisment, disable_lb_source_ip_persistance) and
+	// the wire key must stay misspelled — verified live: a PUT with
+	// `blocked_sevice` returns HTTP 200 and round-trips, while `blocked_service`
+	// is silently ignored by the server (#1257). The Terraform attribute name is
+	// ours to choose, so api-specs-enriched presents the CORRECTED spelling as the
+	// property name and records the original key here. Codegen derives the
+	// Terraform attribute, model field and docs from the property name, and uses
+	// this wire name for every marshal AND unmarshal key. Absent, the property
+	// name is the wire key, so the properties without it are unchanged. See #1323.
+	XF5xcWireName string `json:"x-f5xc-wire-name"`
 }
 
 // TerraformAttribute represents an attribute in a Terraform resource schema.
@@ -135,7 +148,7 @@ type TerraformAttribute struct {
 	PlanModifier       string
 	MaxDepth           int    // Track recursion depth to prevent infinite loops
 	IsSpecField        bool   // True if this is a spec field (not metadata)
-	JsonName           string // JSON field name from OpenAPI for API marshaling
+	JsonName           string // On-the-wire JSON key for API marshaling AND unmarshaling: Schema.WireName (x-f5xc-wire-name, else the property name). Never the Terraform name — see TfsdkTag.
 	GoType             string // Go type for client struct generation
 	UseDomainValidator bool   // True if name field should use DomainValidator (for DNS resources)
 
@@ -292,6 +305,26 @@ func (s *Schema) IsRequired(propertyName string) bool {
 // HasProperties returns true if the schema has properties defined.
 func (s *Schema) HasProperties() bool {
 	return len(s.Properties) > 0
+}
+
+// WireName returns the JSON key this property must use ON THE WIRE: the
+// x-f5xc-wire-name override when present, otherwise propName itself.
+//
+// It exists so codegen can split the two names that used to be one. The
+// Terraform attribute, model field and docs come from propName (which the buffer
+// zone spells correctly); every marshal and unmarshal key comes from this, so a
+// property F5 misspells keeps round-tripping. Both sides must use it: if only the
+// request used the wire key, the read-back would look up a key the API never
+// returns and the field would silently drift. See XF5xcWireName and #1323.
+//
+// The annotation is a fact about the PROPERTY, not about a component it $refs, so
+// callers must read it from the property schema before resolving any $ref — a
+// shared component must not rename every property that references it.
+func (s *Schema) WireName(propName string) string {
+	if s.XF5xcWireName != "" {
+		return s.XF5xcWireName
+	}
+	return propName
 }
 
 // =============================================================================

--- a/tools/pkg/schema/convert.go
+++ b/tools/pkg/schema/convert.go
@@ -167,6 +167,13 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 	validationRules := schema.XVesValidationRules
 	complexity := schema.XF5XCComplexity
 	useCases := schema.XF5XCUseCases
+	// Resolved BEFORE any $ref resolution: x-f5xc-wire-name describes THIS property's
+	// on-the-wire key, so it must never be inherited from a referenced component (a
+	// shared component carrying it would otherwise rename every property that $refs
+	// it). Property-level annotations sit as siblings of $ref / allOf, so reading it
+	// here also covers the allOf-wrapped shape the real annotated properties use
+	// (e.g. advanced_options.disable_lb_source_ip_persistance). See #1323.
+	jsonName := schema.WireName(name)
 
 	// Handle allOf-wrapped $ref (OAS3 pattern for preserving sibling extensions alongside $ref)
 	if schema.Ref == "" && len(schema.AllOf) > 0 {
@@ -234,8 +241,8 @@ func ConvertToTerraformAttributeWithDepth(name string, schema openapi.Schema, re
 		Optional:      !required,
 		OneOfGroup:    oneOfGroup,
 		MaxDepth:      depth,
-		IsSpecField:   true, // Attributes from OpenAPI spec are spec fields
-		JsonName:      name, // Original OpenAPI property name for JSON marshaling
+		IsSpecField:   true,     // Attributes from OpenAPI spec are spec fields
+		JsonName:      jsonName, // Wire key for JSON marshaling (x-f5xc-wire-name, else the property name)
 		ServerDefault: schema.XF5XCServerDefault,
 		Default:       schema.Default, // Store actual default value for metadata
 		// Enhanced metadata from enriched API specs

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -448,7 +448,7 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 			GoName:      naming.ToResourceTypeName(name),
 			TfsdkTag:    naming.ToSnakeCaseTerraform(name),
 			Type:        "string",
-			JsonName:    name,
+			JsonName:    prop.WireName(name), // x-f5xc-wire-name override, else the property name (#1323)
 			IsSpecField: true,
 		}
 		switch name {

--- a/tools/pkg/schema/wire_name_test.go
+++ b/tools/pkg/schema/wire_name_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/openapi"
+)
+
+// Tests for x-f5xc-wire-name (#1323).
+//
+// F5 ships several misspelled property names (blocked_sevice,
+// public_advertisment, disable_lb_source_ip_persistance). The wire key must stay
+// misspelled — verified live: a PUT with `blocked_sevice` returns HTTP 200 and
+// round-trips, while `blocked_service` is silently ignored by the server (#1257).
+// The buffer zone therefore presents the CORRECTED spelling as the property name
+// and records the original key in x-f5xc-wire-name. Extraction must keep the
+// Terraform-facing names (Name/TfsdkTag/GoName) on the corrected spelling while
+// JsonName — the key every marshal/unmarshal emitter uses — carries the wire key.
+
+// wireNameRefSpec provides the ioschemaEmpty component the empty-marker fixtures
+// $ref, mirroring the real origin_pool advanced_options shape.
+func wireNameRefSpec() *openapi.Spec {
+	return &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"ioschemaEmpty": {Type: "object"},
+			},
+		},
+	}
+}
+
+// TestWireNameDrivesJSONNameOnly asserts that x-f5xc-wire-name changes ONLY the
+// JSON key, across every property shape the real annotated properties use:
+// a plain scalar (public_advertisment), an allOf-wrapped $ref empty marker
+// (disable_lb_source_ip_persistance) and an array of objects (blocked_sevice).
+func TestWireNameDrivesJSONNameOnly(t *testing.T) {
+	spec := wireNameRefSpec()
+
+	cases := []struct {
+		desc     string
+		prop     string
+		schema   openapi.Schema
+		wantJSON string
+		wantGo   string
+	}{
+		{
+			desc:     "scalar bool (public_advertisment)",
+			prop:     "public_advertisement",
+			schema:   openapi.Schema{Type: "boolean", XF5xcWireName: "public_advertisment"},
+			wantJSON: "public_advertisment",
+			wantGo:   "PublicAdvertisement",
+		},
+		{
+			desc: "allOf-wrapped $ref empty marker (disable_lb_source_ip_persistance)",
+			prop: "disable_lb_source_ip_persistence",
+			schema: openapi.Schema{
+				AllOf:         []openapi.Schema{{Ref: "#/components/schemas/ioschemaEmpty"}},
+				XF5xcWireName: "disable_lb_source_ip_persistance",
+			},
+			wantJSON: "disable_lb_source_ip_persistance",
+			wantGo:   "DisableLBSourceIPPersistence",
+		},
+		{
+			desc: "array of objects (blocked_sevice)",
+			prop: "blocked_service",
+			schema: openapi.Schema{
+				Type:          "array",
+				XF5xcWireName: "blocked_sevice",
+				Items: &openapi.Schema{
+					Type:       "object",
+					Properties: map[string]openapi.Schema{"network_type": {Type: "string"}},
+				},
+			},
+			wantJSON: "blocked_sevice",
+			wantGo:   "BlockedService",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			attr := ConvertToTerraformAttribute(tc.prop, tc.schema, false, "", spec)
+
+			if attr.JsonName != tc.wantJSON {
+				t.Errorf("JsonName = %q, want the wire key %q", attr.JsonName, tc.wantJSON)
+			}
+			// Terraform-facing identity stays on the CORRECTED property name.
+			if attr.Name != tc.prop {
+				t.Errorf("Name = %q, want the corrected property name %q", attr.Name, tc.prop)
+			}
+			if attr.TfsdkTag != tc.prop {
+				t.Errorf("TfsdkTag = %q, want the corrected property name %q", attr.TfsdkTag, tc.prop)
+			}
+			if attr.GoName != tc.wantGo {
+				t.Errorf("GoName = %q, want %q (derived from the corrected name)", attr.GoName, tc.wantGo)
+			}
+		})
+	}
+}
+
+// TestWireNameAbsentFallsBackToPropertyName pins the 99% path: with no
+// annotation, JsonName is the property name exactly as before.
+func TestWireNameAbsentFallsBackToPropertyName(t *testing.T) {
+	spec := wireNameRefSpec()
+
+	for _, prop := range []string{"blocked_services", "public_advertisment", "advanced_options"} {
+		attr := ConvertToTerraformAttribute(prop, openapi.Schema{Type: "string"}, false, "", spec)
+		if attr.JsonName != prop {
+			t.Errorf("unannotated %q: JsonName = %q, want %q", prop, attr.JsonName, prop)
+		}
+	}
+}
+
+// TestWireNameIsPropertyLevelOnly asserts the annotation is never inherited from
+// a $ref TARGET. The wire key is a fact about the property that points at a
+// component, not about the component itself: a shared component carrying the
+// annotation must not rename every property that references it.
+func TestWireNameIsPropertyLevelOnly(t *testing.T) {
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"sharedThing": {Type: "string", XF5xcWireName: "not_my_wire_name"},
+			},
+		},
+	}
+
+	attr := ConvertToTerraformAttribute(
+		"my_property",
+		openapi.Schema{Ref: "#/components/schemas/sharedThing"},
+		false, "", spec,
+	)
+	if attr.JsonName != "my_property" {
+		t.Errorf("JsonName = %q, want %q: x-f5xc-wire-name on a $ref target must not be inherited",
+			attr.JsonName, "my_property")
+	}
+}
+
+// TestWireNameOnNestedProperties asserts the annotation is honoured at nesting
+// depth, mirroring the real shape: fleetBlockedServicesListType.blocked_sevice is
+// a list-typed child INSIDE a block, and advanced_options
+// .disable_lb_source_ip_persistance is an empty-marker child inside a block.
+func TestWireNameOnNestedProperties(t *testing.T) {
+	spec := wireNameRefSpec()
+
+	parent := openapi.Schema{
+		Type: "object",
+		Properties: map[string]openapi.Schema{
+			"blocked_service": {
+				Type:          "array",
+				XF5xcWireName: "blocked_sevice",
+				Items: &openapi.Schema{
+					Type: "object",
+					Properties: map[string]openapi.Schema{
+						"blocked_service_name": {Type: "string", XF5xcWireName: "blocked_sevice_name"},
+					},
+				},
+			},
+			"disable_lb_source_ip_persistence": {
+				AllOf:         []openapi.Schema{{Ref: "#/components/schemas/ioschemaEmpty"}},
+				XF5xcWireName: "disable_lb_source_ip_persistance",
+			},
+			"plain_child": {Type: "string"},
+		},
+	}
+
+	attr := ConvertToTerraformAttribute("blocked_services", parent, false, "", spec)
+	if attr.JsonName != "blocked_services" {
+		t.Fatalf("parent JsonName = %q, want %q", attr.JsonName, "blocked_services")
+	}
+
+	byTag := map[string]openapi.TerraformAttribute{}
+	for _, child := range attr.NestedAttributes {
+		byTag[child.TfsdkTag] = child
+	}
+
+	want := map[string]string{
+		"blocked_service":                  "blocked_sevice",
+		"disable_lb_source_ip_persistence": "disable_lb_source_ip_persistance",
+		"plain_child":                      "plain_child",
+	}
+	for tag, wantJSON := range want {
+		child, ok := byTag[tag]
+		if !ok {
+			t.Fatalf("nested attribute %q missing; got %v", tag, byTag)
+		}
+		if child.JsonName != wantJSON {
+			t.Errorf("nested %q: JsonName = %q, want %q", tag, child.JsonName, wantJSON)
+		}
+	}
+
+	// One level deeper: a scalar inside the list element.
+	elem := byTag["blocked_service"]
+	var found bool
+	for _, grandchild := range elem.NestedAttributes {
+		if grandchild.TfsdkTag == "blocked_service_name" {
+			found = true
+			if grandchild.JsonName != "blocked_sevice_name" {
+				t.Errorf("list-element scalar JsonName = %q, want %q",
+					grandchild.JsonName, "blocked_sevice_name")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("list-element scalar blocked_service_name missing; got %+v", elem.NestedAttributes)
+	}
+}


### PR DESCRIPTION
## What
Teaches codegen to honour `x-f5xc-wire-name`, so Terraform can present **corrected** property names while requests keep F5's actual (misspelled) wire keys.

F5 ships misspelled property names — `blocked_sevice`, `public_advertisment`, `disable_lb_source_ip_persistance` and six more. The wire key genuinely must stay misspelled: a `PUT` with `blocked_sevice` returns HTTP 200 and round-trips, while `blocked_service` is **silently ignored** by the server. But the Terraform attribute name is our choice, and today it is derived from the spec property name — so users must write F5's typos in their HCL forever.

The buffer zone (`f5-sales-demo/api-specs` #686) now renames the presented property and records the wire key on it:

```json
"blocked_service": { "x-f5xc-wire-name": "blocked_sevice", ... }
```

This PR makes the provider consume that: the Terraform attribute, model field and docs use the corrected name; **marshal and unmarshal use the wire key**.

## Implementation — 5 lines, not ten render sites
`TerraformAttribute.JsonName` turned out to already be the single value every marshal/unmarshal emitter keys on, so the production change is 5 lines in `tools/pkg/schema/convert.go`, resolving the wire name **before** `$ref`/`allOf` resolution (it is a property-level fact, so it must be captured before the property is replaced by its target).

**Every emission path verified to carry the wire key**, on real generated output from a hand-crafted annotated spec: top-level scalar (marshal, unmarshal, computed read-back), top-level single block, top-level list block, nested single block (non-empty), nested single block empty-marker (`allOf`/`$ref`), nested list block, scalar inside a list element, client struct JSON tag, action-resource client struct, and the read-only data-source read-back. **No path is left on the corrected name.**

That audit also surfaced a **latent bug**: the read-only data-source template was the one JSON-key site not keyed on `JsonName`. Fixed here, and proven a byte-level no-op today — it would also have mis-keyed the existing `disable` → `disable_spec` rename.

## Tests (all failing-first)
1. **`TestWireNameRoundTripsInBothDirections`** — 7 subtests; all failed pre-implementation, e.g. `marshal must emit the wire key "public_advertisment"; got Spec["public_advertisement"]`. Covers both directions and the real nesting shape (a list-typed child inside a block, as `blocked_services.blocked_sevice` actually is).
2. **`TestWireNameAbsentOutputUnchanged`** — golden captured from the pre-change generator, so it passes before and after by design. Proven non-vacuous by mutating `WireName` to append `_MUTANT`, which made it fail; mutation reverted.
3. **`TestWireNameResourceCompiles`** — compile-level (generate → `go build`), using a **synthetic non-colliding** name (`zz_wire_probe`) so it can never clobber a real generated file nor self-destruct once one exists — the lesson from #1271.

## No regression for the 99% without the annotation
Generated the full released bundle twice — base `tools/` versus this branch — and `diff -rq` reports **identical** output (130 resources, 12 read-only data sources, `provider.go`, client types). While no spec carries the annotation, this change is inert.

`go test ./internal/... ./tools/...` all 24 packages ok · `make build` · `golangci-lint` 0 issues on both `./tools/...` and `./internal/... .` · `gofmt`/`codespell` clean. Only `tools/**` changed; `internal/` untouched.

## Sequencing
This lands **before** the spec change on purpose. If renamed specs reached a generator that ignores the annotation, the provider would emit `blocked_service` and F5 would silently discard it — recreating #1257, the bug this whole effort exists to prevent. Landing the consumer first is harmless because the path is inert until a spec carries an annotation.

## Note for future suppression entries
Suppression and meaningful-zero lookups key on `JsonName`, so for annotated properties they now key on the **wire** key. No collision exists today (none of the nine names appear in those data files in either spelling), and it is arguably the correct key since that data is discovered from live API responses — but a future suppression entry for one of these fields must use the misspelled key.

Part of the S9 effort. Upstream: f5-sales-demo/api-specs#686 (draft PR #689). Related: #1257, #1271, #1287, #1291.

Closes #1323
