### PR TITLE
fix: send the registration's own passport with the approve action

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/pkcs12"
@@ -428,6 +429,44 @@ func (c *Client) GetLenient(ctx context.Context, path string, result interface{}
 		return json.Unmarshal(sanitizeControlChars(body), result)
 	}
 	return nil
+}
+
+// LookupNestedField walks a decoded JSON object along each dotted path in turn
+// and returns the first value present, together with whether one was found. The
+// value is returned exactly as decoded so it can be marshaled back to the API
+// byte-for-byte.
+//
+// Action resources use it to lift server-derived request fields out of the
+// object being acted on — the registration passport an approve must echo back
+// (#1355). Several paths are accepted because the same value appears at more
+// than one depth depending on the read: object.spec.gc_spec.passport is the
+// canonical object shape and spec.passport the flattened projection of the very
+// same registration. Ordering is significant: the first path that resolves wins.
+func LookupNestedField(obj map[string]interface{}, dottedPaths ...string) (interface{}, bool) {
+	for _, dotted := range dottedPaths {
+		if dotted == "" {
+			continue
+		}
+		var current interface{} = obj
+		resolved := true
+		for _, segment := range strings.Split(dotted, ".") {
+			node, ok := current.(map[string]interface{})
+			if !ok {
+				resolved = false
+				break
+			}
+			value, present := node[segment]
+			if !present || value == nil {
+				resolved = false
+				break
+			}
+			current = value
+		}
+		if resolved {
+			return current, true
+		}
+	}
+	return nil, false
 }
 
 // Post performs a POST request

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -319,6 +319,120 @@ func TestGetLenient_StripsRawControlChars(t *testing.T) {
 	}
 }
 
+// A CE registration read is the source of the passport the approve action must
+// echo back (#1355), and those payloads embed raw control bytes — the machine_id
+// carries a trailing newline and the infra blob has carried others. Reading the
+// passport therefore has to survive a lenient parse: this exercises the whole
+// path (GetLenient over a control-char body, then LookupNestedField down to
+// spec.gc_spec.passport) and asserts the object comes out intact and unmodified.
+func TestGetLenientRegistrationPassportSurvivesControlChars(t *testing.T) {
+	// \x01 and \x1f inside string values are invalid strict JSON; the passport
+	// itself sits behind them so a strict decode never reaches it.
+	rawBody := "{\"object\":{\"spec\":{\"gc_spec\":{" +
+		"\"infra\":{\"hostname\":\"ce\x01node\",\"machine_id\":\"36a6\x1f8825\"}," +
+		"\"passport\":{\"cluster_name\":\"ar-bgp-eastus03\",\"cluster_type\":\"ce\"," +
+		"\"cluster_size\":1,\"latitude\":36.66,\"longitude\":-78.38," +
+		"\"vpm_version\":\"gcr.download.volterra.io/volterraio/vpm@sha256:abc\"," +
+		"\"private_network_name\":\"\"}}}}}"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(rawBody))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+
+	// A strict Get cannot read this registration at all.
+	var strict map[string]interface{}
+	if err := client.Get(context.Background(), "/registrations/r-1", &strict); err == nil {
+		t.Fatal("expected a strict Get to fail on the raw control characters in a registration payload")
+	}
+
+	var obj map[string]interface{}
+	if err := client.GetLenient(context.Background(), "/registrations/r-1", &obj); err != nil {
+		t.Fatalf("GetLenient() error = %v", err)
+	}
+
+	got, ok := LookupNestedField(obj, "object.spec.gc_spec.passport")
+	if !ok {
+		t.Fatalf("passport not found in the leniently parsed registration: %+v", obj)
+	}
+	passport, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("passport must decode as an object, got %T", got)
+	}
+	if passport["cluster_name"] != "ar-bgp-eastus03" {
+		t.Errorf("passport cluster_name = %v, want ar-bgp-eastus03", passport["cluster_name"])
+	}
+	if passport["cluster_size"] != float64(1) {
+		t.Errorf("passport cluster_size = %v (%T), want 1", passport["cluster_size"], passport["cluster_size"])
+	}
+	if passport["latitude"] != 36.66 {
+		t.Errorf("passport latitude = %v, want 36.66", passport["latitude"])
+	}
+	// The API accepts only its own passport echoed back, so every key it sent
+	// must survive — including the empty-string one that is easy to drop.
+	for _, key := range []string{"cluster_name", "cluster_type", "cluster_size", "latitude", "longitude", "vpm_version", "private_network_name"} {
+		if _, present := passport[key]; !present {
+			t.Errorf("passport lost key %q; the approve API rejects anything but its own object verbatim", key)
+		}
+	}
+}
+
+func TestLookupNestedField(t *testing.T) {
+	obj := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"passport": map[string]interface{}{"cluster_name": "flat"},
+		},
+		"object": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"gc_spec": map[string]interface{}{
+					"passport": map[string]interface{}{"cluster_name": "nested"},
+				},
+			},
+		},
+		"scalar": "not-an-object",
+	}
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  interface{}
+		found bool
+	}{
+		{"nested path", []string{"object.spec.gc_spec.passport"}, map[string]interface{}{"cluster_name": "nested"}, true},
+		{"flat path", []string{"spec.passport"}, map[string]interface{}{"cluster_name": "flat"}, true},
+		{"first candidate wins", []string{"object.spec.gc_spec.passport", "spec.passport"}, map[string]interface{}{"cluster_name": "nested"}, true},
+		{"falls through to the next candidate", []string{"spec.gc_spec.passport", "spec.passport"}, map[string]interface{}{"cluster_name": "flat"}, true},
+		{"absent everywhere", []string{"spec.gc_spec.passport", "nope.passport"}, nil, false},
+		{"traversal through a scalar", []string{"scalar.passport"}, nil, false},
+		{"no paths", nil, nil, false},
+		{"empty path", []string{""}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := LookupNestedField(obj, tt.paths...)
+			if ok != tt.found {
+				t.Fatalf("LookupNestedField(%v) found = %v, want %v", tt.paths, ok, tt.found)
+			}
+			if !tt.found {
+				return
+			}
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(tt.want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("LookupNestedField(%v) = %s, want %s", tt.paths, gotJSON, wantJSON)
+			}
+		})
+	}
+
+	if _, ok := LookupNestedField(nil, "spec.passport"); ok {
+		t.Error("LookupNestedField(nil) must report not-found")
+	}
+}
+
 func TestPostSuccess(t *testing.T) {
 	requestData := testResponse{Name: "new-resource"}
 	expectedResponse := testResponse{ID: "456", Name: "new-resource"}

--- a/tools/action-derived-fields.json
+++ b/tools/action-derived-fields.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Action-resource request-body fields the API requires but will only accept as the value it already holds, so they are read off the object being acted on instead of being exposed as Terraform attributes. Keyed by resource TitleCase; see tools/pkg/openapi/action_derived_fields.go and openapi.ActionDerivedField. `sources` are dotted paths into the leniently parsed sibling object read, tried in order with the first hit winning.",
+  "RegistrationApproval": [
+    {
+      "field": "passport",
+      "sources": [
+        "object.spec.gc_spec.passport",
+        "spec.gc_spec.passport",
+        "spec.passport"
+      ]
+    }
+  ]
+}

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -1406,6 +1406,145 @@ func TestActionResourceApprove(t *testing.T) {
 	}
 }
 
+// The approve POST must carry the registration's own passport: without it F5
+// answers HTTP 500 "Validation approval: Passport is required" and the resource
+// can never create (#1355). This drives the WHOLE pipeline — the real approve
+// spec shape through ExtractActionResourceSchema into the generated Go — so it
+// covers the extractor, the server-derived declaration and both templates.
+func TestActionResourceCreateSendsServerDerivedPassport(t *testing.T) {
+	spec, extractAPIPath := actionApproveSpecForCodegen()
+
+	tmpl, err := schema.ExtractActionResourceSchema(spec, "registration_approval", extractAPIPath)
+	if err != nil {
+		t.Fatalf("ExtractActionResourceSchema: %v", err)
+	}
+
+	outDir := t.TempDir()
+	clientDir := t.TempDir()
+	if err := GenerateActionResource(tmpl, outDir, clientDir); err != nil {
+		t.Fatalf("GenerateActionResource error: %v", err)
+	}
+	resBytes, err := os.ReadFile(filepath.Join(outDir, "registration_approval_resource.go"))
+	if err != nil {
+		t.Fatalf("reading resource file: %v", err)
+	}
+	res := string(resBytes)
+	typeBytes, err := os.ReadFile(filepath.Join(clientDir, "registration_approval_types.go"))
+	if err != nil {
+		t.Fatalf("reading types file: %v", err)
+	}
+	types := string(typeBytes)
+
+	// The request struct must be able to carry the passport, and must carry it
+	// as an opaque value: the server accepts only its own object echoed back, so
+	// it may not be flattened into a string.
+	if !regexp.MustCompile(`\bPassport\s+interface\{\}`).MatchString(types) {
+		t.Errorf("request struct must carry Passport as an opaque interface{} value; got:\n%s", types)
+	}
+	if !strings.Contains(types, `json:"passport,omitempty"`) {
+		t.Errorf("request struct Passport must marshal to the wire key \"passport\"; got:\n%s", types)
+	}
+
+	// Create must read the sibling registration and assign the passport from it.
+	create := funcBody(t, res, "Create")
+	for _, want := range []string{
+		"r.client.GetLenient(ctx,",
+		"/api/register/namespaces/%s/registrations/%s",
+		"client.LookupNestedField(",
+		"body.Passport =",
+	} {
+		if !strings.Contains(create, want) {
+			t.Errorf("Create missing server-derived passport marker %q; got:\n%s", want, create)
+		}
+	}
+	// At least one declared lookup path must address the registration's passport.
+	if !regexp.MustCompile(`"[a-z_.]*\.passport"`).MatchString(create) {
+		t.Errorf("Create must look the passport up by path in the registration read; got:\n%s", create)
+	}
+	// Order matters: the read has to happen BEFORE the approve POST.
+	readAt := strings.Index(create, "r.client.GetLenient(ctx,")
+	postAt := strings.Index(create, "r.client.Post(ctx,")
+	if readAt < 0 || postAt < 0 || readAt > postAt {
+		t.Errorf("Create must read the registration before POSTing the approve (readAt=%d postAt=%d); got:\n%s", readAt, postAt, create)
+	}
+	// A missing passport must fail loudly rather than repeat the silent 500.
+	if !strings.Contains(create, "resp.Diagnostics.AddError") || !strings.Contains(create, "passport") {
+		t.Errorf("Create must raise a diagnostic naming the passport when it cannot be derived; got:\n%s", create)
+	}
+
+	// Server-derived is not user input: no passport attribute, no model field.
+	if strings.Contains(res, `"passport": schema.StringAttribute`) {
+		t.Errorf("passport must not be exposed as a user-settable attribute; got:\n%s", res)
+	}
+	if regexp.MustCompile(`\bPassport\s+types\.String\b`).MatchString(res) {
+		t.Errorf("passport must not be a Terraform model field; got:\n%s", res)
+	}
+}
+
+// funcBody returns the source of the named method on the generated resource,
+// from its `func (r *…) <name>(` line to the next top-level `func ` line.
+func funcBody(t *testing.T, src, name string) string {
+	t.Helper()
+	start := regexp.MustCompile(`(?m)^func \(r \*[A-Za-z]+Resource\) ` + name + `\(`).FindStringIndex(src)
+	if start == nil {
+		t.Fatalf("method %s not found in generated source:\n%s", name, src)
+	}
+	rest := src[start[1]:]
+	if next := regexp.MustCompile(`(?m)^func `).FindStringIndex(rest); next != nil {
+		return rest[:next[0]]
+	}
+	return rest
+}
+
+// actionApproveSpecForCodegen mirrors the REAL registration approve request: a
+// camelCase "registrationApprovalReq" carrying x-f5xc-action, scalar string
+// props, object props (annotations, labels), non-enum $ref props (passport,
+// tunnel_type) and a $ref-enum state, plus the approve POST path and the plural
+// sibling GET path.
+func actionApproveSpecForCodegen() (*openapi.Spec, func(*openapi.Spec, string) (string, string, bool)) {
+	spec := &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"registrationApprovalReq": {
+					Type:        "object",
+					XF5xcAction: "approve",
+					Properties: map[string]openapi.Schema{
+						"name":                    {Type: "string"},
+						"backup_connected_region": {Type: "string"},
+						"connected_region":        {Type: "string"},
+						"preferred_active_re":     {Type: "string"},
+						"annotations":             {Type: "object"},
+						"labels":                  {Type: "object"},
+						"passport":                {AllOf: []openapi.Schema{{Ref: "#/components/schemas/registrationPassport"}}},
+						"tunnel_type":             {AllOf: []openapi.Schema{{Ref: "#/components/schemas/schemaSiteToSiteTunnelType"}}},
+						"state":                   {Ref: "#/components/schemas/registrationObjectState"},
+					},
+				},
+			},
+		},
+		Paths: map[string]interface{}{
+			"/api/register/namespaces/{namespace}/registration/{name}/approve": map[string]interface{}{
+				"post": map[string]interface{}{
+					"requestBody": map[string]interface{}{
+						"content": map[string]interface{}{
+							"application/json": map[string]interface{}{
+								"schema": map[string]interface{}{
+									"$ref": "#/components/schemas/registrationApprovalReq",
+								},
+							},
+						},
+					},
+				},
+			},
+			"/api/register/namespaces/{namespace}/registrations/{name}": map[string]interface{}{
+				"get": map[string]interface{}{},
+			},
+		},
+	}
+	extractAPIPath := func(*openapi.Spec, string) (string, string, bool) { return "", "", true }
+	return spec, extractAPIPath
+}
+
 // repoRootFromTest returns the module root by walking up from this test file's
 // location (…/tools/pkg/codegen/codegen_test.go -> module root).
 func repoRootFromTest(t *testing.T) string {

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -1267,6 +1267,35 @@ func (r *{{.TitleCase}}Resource) Create(ctx context.Context, req resource.Create
 	}
 {{- end}}
 {{- end}}
+{{- if .ActionDerivedFields}}
+
+	// The action requires fields that are facts about the object being acted on,
+	// not user input, and the API accepts only the value it already holds — a
+	// registration approve without its own passport is rejected with HTTP 500
+	// "Validation approval: Passport is required" (#1355). Read the sibling
+	// object first and echo the values back verbatim. The read is lenient because
+	// these payloads embed raw control characters that break a strict decoder.
+	sourcePath := fmt.Sprintf("{{.ReadObjectPath}}", data.Namespace.ValueString(), data.Name.ValueString())
+	var sourceObj map[string]interface{}
+	if err := r.client.GetLenient(ctx, sourcePath, &sourceObj); err != nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to read %s to derive the fields the {{.TitleCase}} action requires: %s", sourcePath, err),
+		)
+		return
+	}
+{{- range .ActionDerivedFields}}
+	if derived, ok := client.LookupNestedField(sourceObj{{range .Sources}}, "{{.}}"{{end}}); ok {
+		body.{{.GoName}} = derived
+	} else {
+		resp.Diagnostics.AddError(
+			"Missing Server-Derived Field",
+			fmt.Sprintf("The {{$.TitleCase}} action requires the {{.Field}} of the object at %s, but the response carries no {{.Field}}. It is derived from the object, not configurable, so this indicates the object is not in a state the action can be performed on.", sourcePath),
+		)
+		return
+	}
+{{- end}}
+{{- end}}
 
 	actionPath := fmt.Sprintf("{{.ActionPath}}", data.Namespace.ValueString(), data.Name.ValueString())
 	if err := r.client.Post(ctx, actionPath, body, nil); err != nil {
@@ -1363,6 +1392,12 @@ package client
 type {{.TitleCase}} struct {
 {{- range .Attributes}}
 	{{.GoName}} string ` + "`" + `json:"{{.JsonName}},omitempty"` + "`" + `
+{{- end}}
+{{- range .ActionDerivedFields}}
+	// {{.GoName}} is server-derived: Create reads it off the object being acted
+	// on and echoes it back unchanged. interface{} keeps the value exactly as the
+	// API returned it — the server rejects a re-typed or partial copy.
+	{{.GoName}} interface{} ` + "`" + `json:"{{.JSONName}},omitempty"` + "`" + `
 {{- end}}
 }
 `

--- a/tools/pkg/openapi/action_derived_fields.go
+++ b/tools/pkg/openapi/action_derived_fields.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// An action request body can require a field that is a fact about the object
+// being acted on rather than user input — the F5 XC registration approve is
+// rejected with "Validation approval: Passport is required" unless it carries
+// the registration's own passport, and the API accepts only that exact object
+// echoed back (#1355). tools/action-derived-fields.json (keyed by resource
+// TitleCase) declares those fields and where to read them from; the codegen
+// emits a Create that reads the sibling object and fills them in. See
+// LoadImportIDFields / LoadExposeUID for the sibling data-driven codegen
+// patterns.
+//
+// Unlike those siblings this loader FAILS LOUDLY. A missing or malformed data
+// file silently degrading to "no derived fields" would regenerate exactly the
+// broken resource #1355 is about, and the resulting 500 surfaces only against a
+// live tenant.
+
+var (
+	actionDerivedOnce sync.Once
+	actionDerivedMap  map[string][]ActionDerivedField
+	actionDerivedErr  error
+)
+
+// actionDerivedFieldsPath resolves tools/action-derived-fields.json relative to
+// THIS source file, so it is found no matter which package's directory `go test`
+// or the generator happens to run in.
+func actionDerivedFieldsPath() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("cannot resolve the action-derived-fields.json location: runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "action-derived-fields.json"), nil
+}
+
+func loadActionDerivedFields() {
+	actionDerivedMap = map[string][]ActionDerivedField{}
+
+	jsonPath, err := actionDerivedFieldsPath()
+	if err != nil {
+		actionDerivedErr = err
+		return
+	}
+	data, err := os.ReadFile(jsonPath) // #nosec G304 -- path derived from this source file, not user input
+	if err != nil {
+		actionDerivedErr = fmt.Errorf("reading %s: %w", jsonPath, err)
+		return
+	}
+	parsed, err := parseActionDerivedFieldsJSON(data)
+	if err != nil {
+		actionDerivedErr = fmt.Errorf("parsing %s: %w", jsonPath, err)
+		return
+	}
+	actionDerivedMap = parsed
+}
+
+// parseActionDerivedFieldsJSON decodes the data file into resource TitleCase ->
+// derived fields, skipping the string "_comment" documentation key, and derives
+// each field's Go and wire names. Every entry is validated: a typo that produced
+// an empty field name or a pathless source would generate code that cannot
+// supply the value the API requires.
+func parseActionDerivedFieldsJSON(data []byte) (map[string][]ActionDerivedField, error) {
+	out := map[string][]ActionDerivedField{}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	for resource, rawFields := range raw {
+		if resource == "_comment" {
+			continue
+		}
+		var fields []ActionDerivedField
+		if err := json.Unmarshal(rawFields, &fields); err != nil {
+			return nil, fmt.Errorf("resource %s: %w", resource, err)
+		}
+		for i := range fields {
+			if fields[i].Field == "" {
+				return nil, fmt.Errorf("resource %s: entry %d has an empty \"field\"", resource, i)
+			}
+			if len(fields[i].Sources) == 0 {
+				return nil, fmt.Errorf("resource %s: field %q declares no \"sources\" to read it from", resource, fields[i].Field)
+			}
+			for _, src := range fields[i].Sources {
+				if strings.TrimSpace(src) == "" {
+					return nil, fmt.Errorf("resource %s: field %q has an empty source path", resource, fields[i].Field)
+				}
+			}
+			fields[i].GoName = toGoFieldName(fields[i].Field)
+			fields[i].JSONName = fields[i].Field
+		}
+		out[resource] = fields
+	}
+	return out, nil
+}
+
+// toGoFieldName converts a snake_case wire property name to an exported Go field
+// name (passport -> Passport, long_term_token -> LongTermToken).
+func toGoFieldName(name string) string {
+	parts := strings.Split(name, "_")
+	var b strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(p[:1]))
+		b.WriteString(p[1:])
+	}
+	return b.String()
+}
+
+// LoadActionDerivedFields returns the server-derived request-body fields declared
+// for the action resource (by TitleCase), or nil if it declares none. An
+// unreadable or malformed data file is an error, never an empty result.
+func LoadActionDerivedFields(resourceTitleCase string) ([]ActionDerivedField, error) {
+	actionDerivedOnce.Do(loadActionDerivedFields)
+	if actionDerivedErr != nil {
+		return nil, actionDerivedErr
+	}
+	return actionDerivedMap[resourceTitleCase], nil
+}

--- a/tools/pkg/openapi/types.go
+++ b/tools/pkg/openapi/types.go
@@ -244,6 +244,35 @@ type ResourceTemplate struct {
 	ActionPath     string // %s-substituted singular action POST path
 	ActionState    string // constant state the action applies (e.g. "APPROVED")
 	ReadObjectPath string // %s-substituted sibling object GET path (pluralized)
+
+	// ActionDerivedFields are request-body fields the action REQUIRES but that
+	// are facts about the object being acted on rather than user input. The
+	// generated Create reads the sibling object (ReadObjectPath, leniently) and
+	// echoes each value back verbatim. Loaded from tools/action-derived-fields.json.
+	ActionDerivedFields []ActionDerivedField
+}
+
+// ActionDerivedField declares one server-derived field of an action request
+// body: a value the API demands but will only accept as the exact object it
+// already holds, so it can never be a Terraform attribute.
+//
+// The F5 XC registration approve is the motivating case (#1355): the POST is
+// rejected with HTTP 500 "Validation approval: Passport is required" unless it
+// carries the registration's own spec.gc_spec.passport, and the API accepts only
+// that object echoed back. Exposing it as an attribute would let a practitioner
+// supply a passport the server refuses; omitting it made the resource incapable
+// of ever creating. Reading it off the object closes both.
+//
+// Sources are dotted lookup paths into the leniently parsed sibling read,
+// evaluated in order with the first hit winning: the read wraps the same value
+// at more than one depth (object.spec.gc_spec.passport is the canonical object
+// shape, spec.passport the flattened projection), and which wrappers appear
+// varies with the endpoint.
+type ActionDerivedField struct {
+	Field    string   `json:"field"`   // request-body property name, e.g. "passport"
+	Sources  []string `json:"sources"` // dotted paths into the sibling read; first hit wins
+	GoName   string   `json:"-"`       // request-struct field name, e.g. "Passport" (derived)
+	JSONName string   `json:"-"`       // wire key for the request body (derived)
 }
 
 // RequirementPreflight is one apply-time prerequisite the provider verifies

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -389,16 +389,28 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 // request-body schema carrying a schema-level x-f5xc-action. Unlike a CRUD
 // resource it has no CreateSpecType/GetSpecType: its attributes derive directly
 // from the flat action request body. Only scalar string props (plus the `state`
-// enum) become attributes; object props (annotations, labels) and non-enum $ref
-// props (passport, tunnel_type) are skipped because they are not representable as
-// plain string attributes. `namespace` is a path parameter (not a body property)
-// and is injected so the generated model carries a Namespace field for the
-// action/read path Sprintf. The singular action POST path and the pluralized
-// sibling object GET path are captured for Create/Read, `state`
-// constant-defaults to APPROVED, and every user-settable field forces replace
-// (there is no in-place update). extractAPIPath is accepted for signature parity
-// with the CRUD extractor but unused — action paths come from the discovered
-// x-f5xc-action.
+// enum) become attributes; decorative object props (annotations, labels) and
+// non-enum $ref props (tunnel_type) are skipped because they are not
+// representable as plain string attributes.
+//
+// A skipped prop the action REQUIRES is a different matter, and dropping one is
+// how #1355 shipped: the filter keyed on the Go type, so the required `passport`
+// object vanished and every approve POST came back 500 "Validation approval:
+// Passport is required" with no user workaround. Two things now prevent that.
+// Props declared in tools/action-derived-fields.json are carried as
+// ActionDerivedFields — read off the object being acted on at Create rather than
+// exposed as attributes, because the API accepts only the value it already
+// holds. And any remaining REQUIRED prop that is neither an attribute nor a
+// declared derived field fails extraction outright, so the class cannot recur
+// silently for a different action.
+//
+// `namespace` is a path parameter (not a body property) and is injected so the
+// generated model carries a Namespace field for the action/read path Sprintf.
+// The singular action POST path and the pluralized sibling object GET path are
+// captured for Create/Read, `state` constant-defaults to APPROVED, and every
+// user-settable field forces replace (there is no in-place update).
+// extractAPIPath is accepted for signature parity with the CRUD extractor but
+// unused — action paths come from the discovered x-f5xc-action.
 func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func(spec *openapi.Spec, resourceName string) (string, string, bool)) (*openapi.ResourceTemplate, error) {
 	// Locate the action for this resource among the spec's discovered actions.
 	var action *openapi.ResourcePath
@@ -425,19 +437,39 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 	}
 	sort.Strings(propNames)
 
+	titleCase := naming.ToResourceTypeName(resourceName)
+
+	// Fields the action requires but that are facts about the object being acted
+	// on: read at Create off the sibling object, never exposed as attributes.
+	derived, err := openapi.LoadActionDerivedFields(titleCase)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", resourceName, err)
+	}
+	isDerived := make(map[string]bool, len(derived))
+	for _, d := range derived {
+		if _, ok := reqSchema.Properties[d.Field]; !ok {
+			return nil, fmt.Errorf("%s: action-derived-fields.json declares %q, which the %s request body does not define", resourceName, d.Field, action.SchemaName)
+		}
+		isDerived[d.Field] = true
+	}
+
 	// The action model is rendered as a flat set of string attributes. Only
 	// scalar string props (plus the `state` enum $ref, special-cased below) map
 	// cleanly to a StringAttribute. Object props (annotations, labels) and
 	// non-enum $ref props (passport, tunnel_type) are structured values that must
-	// NOT be emitted as strings, so they are skipped entirely.
+	// NOT be emitted as strings, so they are skipped as attributes — a required
+	// one is picked up by the derived-field declaration or the guard below.
 	var attributes []openapi.TerraformAttribute
 	haveNamespace := false
 	for _, name := range propNames {
 		prop := reqSchema.Properties[name]
 		isState := name == "state"
 		if prop.Type != "string" && !isState {
-			// Skip object / non-enum $ref props (annotations, labels, passport,
-			// tunnel_type): they are not representable as a plain string attribute.
+			continue
+		}
+		if isDerived[name] {
+			// Server-derived: the API accepts only its own value, so it must not
+			// become user input even when it would render as a string.
 			continue
 		}
 		if name == "namespace" {
@@ -485,6 +517,27 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 		}}, attributes...)
 	}
 
+	// Guard (#1355): a property the action REQUIRES must reach the request body,
+	// as an attribute or as a declared server-derived field. Silently skipping
+	// one produces a resource that can never create, and the failure surfaces
+	// only as an opaque server error against a live tenant — so fail generation
+	// here instead, naming the property and both ways to resolve it.
+	covered := make(map[string]bool, len(attributes)+len(derived))
+	for _, a := range attributes {
+		covered[a.Name] = true
+	}
+	for name := range isDerived {
+		covered[name] = true
+	}
+	for _, name := range propNames {
+		if covered[name] || !actionPropIsRequired(reqSchema, name) {
+			continue
+		}
+		return nil, fmt.Errorf(
+			"%s: request property %q is required by the %s action but reaches neither a Terraform attribute nor the request body; declare it in tools/action-derived-fields.json if the API derives it from the object, or make it representable as an attribute",
+			resourceName, name, action.ActionValue)
+	}
+
 	// An action has no PUT/update endpoint, so force every settable field to
 	// replace. ForceReplaceForCreateDeleteOnly skips Computed attributes, but the
 	// Optional+Computed `state` must force replace too, so backfill afterwards.
@@ -493,19 +546,38 @@ func ExtractActionResourceSchema(spec *openapi.Spec, resourceName string, _ func
 		attributes[i].PlanModifier = "RequiresReplace"
 	}
 
-	titleCase := naming.ToResourceTypeName(resourceName)
 	return &openapi.ResourceTemplate{
-		Name:               resourceName,
-		TitleCase:          titleCase,
-		Description:        description.TransformResourceDescription(resourceName, reqSchema.Description),
-		Attributes:         attributes,
-		HasNamespaceInPath: true,
-		HasStringDefaults:  true,
-		IsAction:           true,
-		ActionPath:         action.ActionPath,
-		ActionState:        "APPROVED",
-		ReadObjectPath:     action.ReadObjectPath,
+		Name:                resourceName,
+		TitleCase:           titleCase,
+		Description:         description.TransformResourceDescription(resourceName, reqSchema.Description),
+		Attributes:          attributes,
+		HasNamespaceInPath:  true,
+		HasStringDefaults:   true,
+		IsAction:            true,
+		ActionPath:          action.ActionPath,
+		ActionState:         "APPROVED",
+		ReadObjectPath:      action.ReadObjectPath,
+		ActionDerivedFields: derived,
 	}, nil
+}
+
+// actionPropIsRequired reports whether the action request body requires the
+// property. F5 expresses that three different ways across the spec pipeline —
+// the OpenAPI `required` list, the enrichment's x-f5xc-required-for.create, and
+// the upstream x-ves-required marker — and any of them is enough to make an
+// omitted field a server-side rejection. x-f5xc-minimum-configuration
+// .required_fields is deliberately NOT consulted: on the approve schema it lists
+// every property including the decorative annotations and labels, so it does not
+// distinguish what the API actually enforces.
+func actionPropIsRequired(reqSchema openapi.Schema, name string) bool {
+	if reqSchema.IsRequired(name) {
+		return true
+	}
+	prop, ok := reqSchema.Properties[name]
+	if !ok {
+		return false
+	}
+	return prop.XF5XCRequiredFor.Create || strings.EqualFold(prop.XVesRequired, "true")
 }
 
 // ResolvePreflightGoFields binds each preflight's declared trigger field (WhenField,

--- a/tools/pkg/schema/extract_test.go
+++ b/tools/pkg/schema/extract_test.go
@@ -3,6 +3,7 @@
 package schema
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/f5-sales-demo/terraform-provider-xcsh/tools/pkg/namespace"
@@ -377,6 +378,158 @@ func TestActionResourceApprove(t *testing.T) {
 		if !wantAttrs[a.TfsdkTag] {
 			t.Errorf("unexpected attribute %q in action model", a.TfsdkTag)
 		}
+	}
+}
+
+// The approve API rejects a request that omits the registration's passport
+// ("Validation approval: Passport is required", HTTP 500 — #1355). The passport
+// is a fact about the registration, not user input: F5 accepts only the value it
+// already holds. So it must be extracted as a SERVER-DERIVED field — carried on
+// the request body and read back off the sibling object — and must NOT appear as
+// a user-settable Terraform attribute.
+func TestActionResourceDerivesPassportFromTheRegistration(t *testing.T) {
+	spec, extractAPIPath := actionApproveSpec()
+
+	result, err := ExtractActionResourceSchema(spec, "registration_approval", extractAPIPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var passport *openapi.ActionDerivedField
+	for i := range result.ActionDerivedFields {
+		if result.ActionDerivedFields[i].Field == "passport" {
+			passport = &result.ActionDerivedFields[i]
+		}
+	}
+	if passport == nil {
+		t.Fatalf("passport must be a server-derived action field; got %+v", result.ActionDerivedFields)
+	}
+	if passport.GoName != "Passport" {
+		t.Errorf("passport GoName = %q, want Passport", passport.GoName)
+	}
+	if passport.JSONName != "passport" {
+		t.Errorf("passport JSONName = %q, want passport", passport.JSONName)
+	}
+	if len(passport.Sources) == 0 {
+		t.Fatal("passport must declare at least one lookup path into the sibling registration object")
+	}
+	// Every declared source must address the passport of the registration read.
+	for _, src := range passport.Sources {
+		if !strings.HasSuffix(src, ".passport") {
+			t.Errorf("passport source %q must address the object's passport field", src)
+		}
+	}
+
+	// Server-derived means NOT user input: no Terraform attribute, so no
+	// practitioner can supply a passport the API would reject.
+	if a := findAttr(result.Attributes, "passport"); a != nil {
+		t.Errorf("passport must not be a user-settable attribute; got %+v", a)
+	}
+}
+
+// A property the action request REQUIRES must never be silently discarded by the
+// attribute extractor. Dropping one is precisely how #1355 shipped: the filter
+// keyed on the Go type ("not a string, skip") rather than on whether the API
+// needs the field, so a required object vanished and every approve POSTed a 500.
+// The extractor now fails generation instead — loudly, at build time — unless the
+// required property is either a Terraform attribute or a declared server-derived
+// field.
+func TestActionResourceRequiredPropertyIsNeverSilentlyDropped(t *testing.T) {
+	// A required non-string property that is neither an attribute nor declared
+	// server-derived: generation must fail.
+	spec := actionGuardSpec(map[string]openapi.Schema{
+		"name": {Type: "string"},
+		"credentials": {
+			AllOf: []openapi.Schema{{Ref: "#/components/schemas/someCredentials"}},
+		},
+	}, []string{"name", "credentials"})
+
+	stub := func(*openapi.Spec, string) (string, string, bool) { return "", "", true }
+	_, err := ExtractActionResourceSchema(spec, "zz_guard_probe", stub)
+	if err == nil {
+		t.Fatal("expected an error: the required object property 'credentials' is not representable as an attribute and is not declared server-derived")
+	}
+	if !strings.Contains(err.Error(), "credentials") {
+		t.Errorf("error must name the dropped required property; got: %v", err)
+	}
+
+	// Positive control: with the same shape but the property NOT required, the
+	// existing skip is correct and generation succeeds. Without this the guard
+	// could be a blanket failure and the test above would be unfalsifiable.
+	ok := actionGuardSpec(map[string]openapi.Schema{
+		"name": {Type: "string"},
+		"credentials": {
+			AllOf: []openapi.Schema{{Ref: "#/components/schemas/someCredentials"}},
+		},
+	}, []string{"name"})
+	if _, err := ExtractActionResourceSchema(ok, "zz_guard_probe", stub); err != nil {
+		t.Fatalf("a non-required object property must still be skipped without error; got: %v", err)
+	}
+
+	// The spec also marks required with x-f5xc-required-for.create and
+	// x-ves-required rather than a `required` list, so both must trip the guard.
+	forCreate := actionGuardSpec(map[string]openapi.Schema{
+		"name": {Type: "string"},
+		"credentials": {
+			AllOf:            []openapi.Schema{{Ref: "#/components/schemas/someCredentials"}},
+			XF5XCRequiredFor: openapi.RequiredFor{Create: true},
+		},
+	}, nil)
+	if _, err := ExtractActionResourceSchema(forCreate, "zz_guard_probe", stub); err == nil {
+		t.Error("x-f5xc-required-for.create=true must trip the dropped-required-property guard")
+	}
+
+	vesRequired := actionGuardSpec(map[string]openapi.Schema{
+		"name": {Type: "string"},
+		"credentials": {
+			AllOf:        []openapi.Schema{{Ref: "#/components/schemas/someCredentials"}},
+			XVesRequired: "true",
+		},
+	}, nil)
+	if _, err := ExtractActionResourceSchema(vesRequired, "zz_guard_probe", stub); err == nil {
+		t.Error("x-ves-required=true must trip the dropped-required-property guard")
+	}
+}
+
+// The real registration approve request marks nothing required, so the guard must
+// not fire on it — the passport is covered by its server-derived declaration.
+func TestActionResourceGuardAcceptsTheRealApproveSchema(t *testing.T) {
+	spec, extractAPIPath := actionApproveSpec()
+	if _, err := ExtractActionResourceSchema(spec, "registration_approval", extractAPIPath); err != nil {
+		t.Fatalf("the real approve schema must extract cleanly; got: %v", err)
+	}
+}
+
+// actionGuardSpec builds a minimal action spec with the supplied request-body
+// properties and `required` list, under a synthetic resource name that can never
+// collide with a real one.
+func actionGuardSpec(props map[string]openapi.Schema, required []string) *openapi.Spec {
+	return &openapi.Spec{
+		Components: openapi.Components{
+			Schemas: map[string]openapi.Schema{
+				"zzGuardProbeReq": {
+					Type:        "object",
+					XF5xcAction: "approve",
+					Required:    required,
+					Properties:  props,
+				},
+			},
+		},
+		Paths: map[string]interface{}{
+			"/api/register/namespaces/{namespace}/guard_probe/{name}/approve": map[string]interface{}{
+				"post": map[string]interface{}{
+					"requestBody": map[string]interface{}{
+						"content": map[string]interface{}{
+							"application/json": map[string]interface{}{
+								"schema": map[string]interface{}{
+									"$ref": "#/components/schemas/zzGuardProbeReq",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Problem

`xcsh_registration_approval` could never create. Every approve POSTed
`{"namespace","name","state":"APPROVED"}` and F5 answered HTTP 500
`"Validation approval: Passport is required"`. Reproduced by hand on three
registrations of a freshly rebuilt N=3 demo: 500 without the passport, 200 with
it, and all three sites then moved `WAITING_FOR_REGISTRATION` → `PROVISIONING`
(evidence in f5-sales-demo/mcn#636).

## Root cause

`tools/pkg/schema/extract.go` kept an action request property only when
`prop.Type == "string"`, so every object-typed property was dropped. Right for
the decorative ones (`annotations`, `labels`, `tunnel_type`); wrong for
`passport`, which the action requires — the generated resource had no way to
send it and no user workaround existed.

Not a regression: the create path was never capable of succeeding. It stayed
hidden because the resource was live-verified by `terraform import` of an
already-approved registration plus a 0-change plan, so the approve POST itself
was never exercised against a fresh CE.

## Fix

`passport` does not become an attribute — its value is a fact about the
registration and F5 accepts only the object it already holds, so a user-settable
one could only ever be wrong. It is now a **server-derived** field: Create reads
the sibling registration with the same lenient GET the Read path uses (these
payloads embed raw control bytes) and echoes the value back verbatim as an
opaque `interface{}`, so the object reaches the wire byte-for-byte.

Declaration is data, not code — `tools/action-derived-fields.json` names the
field and the dotted paths to read it from, tried in order because the same
value appears at more than one depth depending on the read shape
(`object.spec.gc_spec.passport` canonical, `spec.passport` flattened; both
verified against a live registration). Unlike its sibling loaders this one
**fails loudly**: silently degrading to "no derived fields" would regenerate
exactly this bug, and the 500 only surfaces against a live tenant.

**Generalised so the class cannot recur (AC2):** extraction now FAILS when any
property the action requires reaches neither an attribute nor a declared derived
field. Required is read from all three places F5 expresses it — the OpenAPI
`required` list, `x-f5xc-required-for.create`, and `x-ves-required`.
`x-f5xc-minimum-configuration.required_fields` is deliberately not consulted: on
the approve schema it lists every property, including `annotations` and `labels`.

All changes are in `tools/` plus one hand-written client helper
(`client.LookupNestedField`). No generated code was hand-edited.

## Generated result

```go
sourcePath := fmt.Sprintf("/api/register/namespaces/%s/registrations/%s", ...)
var sourceObj map[string]interface{}
if err := r.client.GetLenient(ctx, sourcePath, &sourceObj); err != nil { ... }
if derived, ok := client.LookupNestedField(sourceObj,
    "object.spec.gc_spec.passport", "spec.gc_spec.passport", "spec.passport"); ok {
    body.Passport = derived
} else { /* named diagnostic, no silent 500 */ }
```

## TDD — RED → GREEN, proven non-vacuous

Tests were written first and fail against `main`:

| Mutation | Effect |
| --- | --- |
| strip the derived-field block from `ActionResourceTemplate` | 9 assertions fail in `TestActionResourceCreateSendsServerDerivedPassport` |
| delete the required-property guard from `extract.go` | `TestActionResourceRequiredPropertyIsNeverSilentlyDropped` fails |
| neuter `LookupNestedField`'s traversal | `TestGetLenientRegistrationPassportSurvivesControlChars` + all 8 table cases fail |
| remove `RegistrationApproval` from `action-derived-fields.json` | extractor and codegen tests fail |
| drop `sanitizeControlChars` from `GetLenient` | control-char test fails with `invalid character '\x01' in string literal` |

The guard test carries a positive control (same shape, property not required →
must still extract cleanly) so a blanket failure cannot pass for a real one.

## Acceptance criteria

- [x] 1 — failing-first codegen test; the generated Create body sources
      `passport` from the registration read
- [x] 2 — a required action property can never again be silently discarded
- [x] 3 — `passport` is not a user-settable attribute (no schema entry, no model field)
- [x] 4 — lenient parsing exercised with raw control characters around the passport
- [x] 5 — `go build ./...`, `go vet ./...`, `go test ./... -count=1` all green
- [x] 6 — live approve of a genuinely fresh CE registration (see below)

## Live verification

**Done — approved a genuinely fresh CE end to end.**

The three demo registrations are already APPROVED and cannot re-prove the create
path, so a disposable single-node CE was stood up for this (own RG
`rg-xcsh1355verify` in `eastus2`, own site `xcsh1355-verify`, own token — the
`ar-bgp-eastus0N` demo, its RG and its namespaces were never touched). It has
since been fully destroyed.

Fresh registration `r-e55f579e-d2dd-47d8-9cb3-01fdb92ef198`, state `PENDING`,
site `WAITING_FOR_REGISTRATION`.

**1. Control — the pre-fix request body, on this very registration:**

```
POST /api/register/namespaces/system/registration/r-e55f579e-.../approve
     {"namespace":"system","name":"r-e55f579e-...","state":"APPROVED"}
{"code":13,"details":[{"code":"UNKNOWN",
 "details":"Validation approval: Passport is required", ...}]}
HTTP=500
```

**2. The fixed provider, via `terraform apply` (`dev_overrides`, no manual API call):**

```
xcsh_registration_approval.this: Creating...
xcsh_registration_approval.this: Creation complete after 1s [id=r-e55f579e-...]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

`client.doRequest` returns an error for every non-2xx, so a clean create is a
2xx. Captured explicitly through a local logging reverse proxy, the provider's
own traffic is:

```
GET  /api/register/namespaces/system/registrations/r-e55f579e-...        -> HTTP 200
POST /api/register/namespaces/system/registration/r-e55f579e-.../approve
     body_keys=name,namespace,passport,state
```

— the passport is now on the wire, read from the registration the provider
itself just fetched.

**3. The site advanced, on the approve alone:**

| moment | registration | site |
| --- | --- | --- |
| before | `PENDING` / `WAITING_FOR_REGISTRATION` | `WAITING_FOR_REGISTRATION` |
| +5 s | `ADMITTED` / `PROVISIONING` | `PROVISIONING` |
| settled | `ONLINE` / `ONLINE` | `UPGRADING` → online |

**4. Import + re-plan** on the same live approval: `No changes. Your
infrastructure matches the configuration.`

A later re-approve of the now-ONLINE registration returns HTTP 500
`"Registration state transition ONLINE to APPROVED is forbidden"` — a different,
already-known condition (#1278), and the clearest confirmation that
`"Passport is required"` is gone.

**Teardown verified:** Azure RG absent, XC site / token / registration all 404,
and `ar-bgp-eastus01/02/03` still `ONLINE`.

Closes #1355
