### PR TITLE
The action guard must fail the run, not delete the resource

### DIFF
--- a/tools/generate-all-schemas.go
+++ b/tools/generate-all-schemas.go
@@ -152,7 +152,13 @@ func main() {
 	if !dryRun {
 		generatedNames := make(map[string]bool)
 		for _, r := range results {
-			if r.Success {
+			// #1406: a resource that failed this run is not an orphan — it is a
+			// resource whose regeneration broke. Deleting its committed files turns
+			// a generation error into a missing Terraform resource type, surfacing
+			// as an "Invalid resource type" in a different repository. Only a run
+			// that legitimately no longer produces a resource may remove it, and a
+			// failed run is not that.
+			if r.Success || r.Error != "" {
 				generatedNames[r.ResourceName] = true
 			}
 		}
@@ -161,6 +167,14 @@ func main() {
 			generatedNames[core] = true
 		}
 		registration.CleanOrphanGeneratedFiles(outputDir, clientDir, generatedNames)
+	}
+
+	if failCount > 0 {
+		// #1406: printing a failure count and exiting 0 means CI, the pre-commit
+		// hook and a human all read the run as successful. A generator that could
+		// not generate has failed.
+		fmt.Printf("\n❌ Generation failed: %d resource(s) could not be generated.\n", failCount)
+		os.Exit(1)
 	}
 
 	fmt.Println("\n🎉 Batch generation complete!")
@@ -371,10 +385,13 @@ func processV2Action(domainFile string, act openapi.ResourcePath) GenerationResu
 
 	tmpl, err := schema.ExtractActionResourceSchema(spec, act.ResourceName, extractAPIPath)
 	if err != nil {
-		if verbose {
-			fmt.Printf("  ⏭️  Skipping action %s: %v\n", act.ResourceName, err)
-		}
-		return GenerationResult{ResourceName: act.ResourceName, Success: false}
+		// #1406: this used to print only under -verbose and return an EMPTY Error,
+		// so the result was counted as neither success nor failure, the run exited
+		// 0, and the orphan sweep then deleted the resource's committed files. The
+		// #1355 guard whose whole purpose is to fail loudly was reduced to silently
+		// removing a resource that mcn depends on. Report it like any other failure.
+		fmt.Printf("❌ %s: %v\n", act.ResourceName, err)
+		return GenerationResult{ResourceName: act.ResourceName, Success: false, Error: err.Error()}
 	}
 
 	if !dryRun {


### PR DESCRIPTION
Closes #1406.

## What the guard was supposed to do

`ExtractActionResourceSchema` carries a guard added for #1355, and its own comment states
the intent:

> Silently skipping one produces a resource that can never create, and the failure
> surfaces only as an opaque server error against a live tenant — so **fail generation
> here instead**, naming the property and both ways to resolve it.

## What actually happened

The caller discarded it three times over:

| | |
| --- | --- |
| the message | printed only under `-verbose` |
| the result | `Success:false` with an **empty** `Error` — and aggregation counts a failure only when `Error != ""`, so it landed in "Skipped (no schema)" and `❌ Failed` stayed **0** |
| the exit code | nothing tied `failCount` to it, so the run exited **0** |
| the orphan sweep | keys off `r.Success`, so it then **deleted the resource's committed files** |

Net effect: a guard designed to stop the build instead removed
`xcsh_registration_approval` and reported success.

`mcn` declares that resource — it is how a Customer Edge is approved without an operator
clicking Approve in the console. The generation error would have surfaced as an "Invalid
resource type" at plan time, in a different repository, with nothing in the provider's
own output pointing at the cause.

## Four changes

Any one alone leaves the failure invisible:

- the guard's error prints unconditionally
- the result carries `Error`, so it counts as a failure and is listed
- `failCount > 0` exits `1`
- the orphan sweep treats a resource that **failed** this run as present, not orphaned.
  Only a run that legitimately no longer produces a resource may remove it, and a failed
  run is not that.

## Verified by driving the guard

api-specs-enriched#1142 marks `registrationApprovalReq.passport` required — which the API
enforces (`500 "Validation approval: Passport is required"`) — so removing the
`RegistrationApproval` entry from `action-derived-fields.json` makes the guard fire.

**Before:**
```
❌ Failed: 0
🗑️  Removing orphan: registration_approval_resource.go
🗑️  Removing orphan: registration_approval_types.go
exit 0
```

**After:**
```
❌ registration_approval: request property "passport" is required by the approve action
   but reaches neither a Terraform attribute nor the request body; declare it in
   tools/action-derived-fields.json if the API derives it from the object, or make it
   representable as an attribute
❌ Generation failed: 1 resource(s) could not be generated.
exit 1
```

Both files still present. A healthy run is unaffected — entry restored, exit 0, resource
generates.

## Why it had never been seen firing

Before the spec correction, `passport` was unmarked, `actionPropIsRequired` returned
false, and the guard was **inert**: deleting the derived-fields entry produced a resource
that would 500 against a live tenant, with no complaint at all. The spec fix armed it;
this makes it audible.

## Verification

```
golangci-lint    0 issues
go test          24 packages ok, 0 failures
```

`tools/generate-all-schemas.go` is `//go:build ignore`, so it has no unit-test surface —
the verification above is behavioural, driving the real generator against real specs.
Giving that file a testable seam is worth doing separately; it is the same file as
#1397.