### PR TITLE
Download the spec bundle before generating docs, and refuse to generate without it

### DIFF
--- a/.github/actions/download-api-specs/action.yml
+++ b/.github/actions/download-api-specs/action.yml
@@ -50,13 +50,23 @@ runs:
         # pipefail, so the same line was harmless there.
         mkdir -p "${SPEC_DIR}"
 
-        SPEC_COUNT=$(find "${SPEC_DIR}" -name '*.json' -type f | wc -l)
-        if [ "$SPEC_COUNT" -gt 0 ]; then
-          echo "Found ${SPEC_COUNT} existing spec files in ${SPEC_DIR}"
+        # complete() must agree with openapi.RequireSpecs, which the generators call.
+        # "Some JSON is present" is not the test: an index.json alone, or an index
+        # beside an empty domains/, is a truncated unzip that the generators reject —
+        # and if this step short-circuited on it, the download that would repair it
+        # would never run.
+        complete() {
+          [ -f "${SPEC_DIR}/index.json" ] || return 1
+          [ -d "${SPEC_DIR}/domains" ] || return 1
+          [ -n "$(find "${SPEC_DIR}/domains" -name '*.json' -type f -print -quit)" ]
+        }
+
+        if complete; then
+          echo "Found $(find "${SPEC_DIR}" -name '*.json' -type f | wc -l) existing spec files in ${SPEC_DIR}"
           exit 0
         fi
 
-        echo "Specs not in tree (gitignored) — downloading latest from ${ENRICHED_REPO}"
+        echo "No complete bundle in ${SPEC_DIR} — downloading latest from ${ENRICHED_REPO}"
 
         ASSET_ID=$(gh api "repos/${ENRICHED_REPO}/releases" --jq \
           '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
@@ -91,7 +101,7 @@ runs:
           echo "::error::Spec asset unpacked to no JSON files in ${SPEC_DIR}"
           exit 1
         fi
-        if [ ! -f "${SPEC_DIR}/index.json" ] || [ ! -d "${SPEC_DIR}/domains" ]; then
-          echo "::error::Incomplete bundle in ${SPEC_DIR}: index.json and domains/ are both required"
+        if ! complete; then
+          echo "::error::Incomplete bundle in ${SPEC_DIR}: index.json plus at least one domains/*.json are required"
           exit 1
         fi

--- a/.github/actions/download-api-specs/action.yml
+++ b/.github/actions/download-api-specs/action.yml
@@ -1,0 +1,90 @@
+---
+# Fetch the enriched OpenAPI spec bundle that every generator in this repo reads.
+#
+# The bundle is gitignored, so a fresh checkout has none. Any job that runs
+# generate-all-schemas.go, transform-docs.go or generate-llms-txt.go without it
+# produces output that looks successful and is silently degraded: measured on a
+# spec-less checkout, transform-docs.go rewrote 256 files, removing 1548 lines of
+# API reference links, dependency notes and danger callouts, and exited 0.
+#
+# This action existed as three divergent copies (_build-test.yml,
+# _generate-provider.yml, on-merge.yml) and was simply absent from the two doc
+# paths. The copies also disagreed on failure: one errored, two emitted
+# `::warning::Could not find spec asset` and carried on. Carrying on is the defect,
+# so this single implementation always fails.
+name: Download API specs
+description: Download the enriched F5 XC OpenAPI spec bundle into the gitignored spec directory.
+
+inputs:
+  token:
+    description: Token used to read releases from the enriched specs repository.
+    required: true
+  spec-dir:
+    description: Directory the bundle is unpacked into.
+    required: false
+    default: docs/specifications/api
+  enriched-repo:
+    description: Repository publishing the spec bundle releases.
+    required: false
+    default: f5-sales-demo/api-specs-enriched
+
+runs:
+  using: composite
+  steps:
+    - name: Download API specs
+      shell: bash
+      # Inputs reach the shell through env: — an ${{ }} expansion inside run: is a
+      # code-injection sink (zizmor template-injection). Shell-quoted at each use.
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ENRICHED_REPO: ${{ inputs.enriched-repo }}
+        SPEC_DIR: ${{ inputs.spec-dir }}
+      run: |
+        set -euo pipefail
+
+        SPEC_COUNT=$(find "${SPEC_DIR}" -name '*.json' -type f 2>/dev/null | wc -l)
+        if [ "$SPEC_COUNT" -gt 0 ]; then
+          echo "Found ${SPEC_COUNT} existing spec files in ${SPEC_DIR}"
+          exit 0
+        fi
+
+        echo "Specs not in tree (gitignored) — downloading latest from ${ENRICHED_REPO}"
+        mkdir -p "${SPEC_DIR}"
+
+        ASSET_ID=$(gh api "repos/${ENRICHED_REPO}/releases" --jq \
+          '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
+        if [ -z "$ASSET_ID" ] || [ "$ASSET_ID" = "null" ]; then
+          echo "::error::No spec bundle asset in the latest ${ENRICHED_REPO} release. Generators cannot run without it."
+          exit 1
+        fi
+
+        gh api "repos/${ENRICHED_REPO}/releases/assets/${ASSET_ID}" \
+          -H "Accept: application/octet-stream" > /tmp/specs.zip
+        unzip -q -o /tmp/specs.zip -d "${SPEC_DIR}"
+        rm -f /tmp/specs.zip
+
+        # Companion assets published alongside the bundle rather than inside it.
+        # `make download-specs` fetches both, so CI that skips them generates
+        # different output from a local run — a determinism gap in its own right.
+        for asset in api-catalog.json minimal-export-defaults.json; do
+          AID=$(gh api "repos/${ENRICHED_REPO}/releases" --jq \
+            "[.[0].assets[] | select(.name==\"${asset}\")] | .[0].id")
+          if [ -n "$AID" ] && [ "$AID" != "null" ]; then
+            gh api "repos/${ENRICHED_REPO}/releases/assets/${AID}" \
+              -H "Accept: application/octet-stream" > "${SPEC_DIR}/${asset}"
+            echo "Downloaded ${asset}"
+          else
+            echo "::notice::${asset} not published in the latest release"
+          fi
+        done
+
+        SPEC_COUNT=$(find "${SPEC_DIR}" -name '*.json' -type f | wc -l)
+        echo "Downloaded ${SPEC_COUNT} spec files"
+        if [ "$SPEC_COUNT" -eq 0 ]; then
+          echo "::error::Spec asset unpacked to no JSON files in ${SPEC_DIR}"
+          exit 1
+        fi
+        if [ ! -f "${SPEC_DIR}/index.json" ] || [ ! -d "${SPEC_DIR}/domains" ]; then
+          echo "::error::Incomplete bundle in ${SPEC_DIR}: index.json and domains/ are both required"
+          exit 1
+        fi

--- a/.github/actions/download-api-specs/action.yml
+++ b/.github/actions/download-api-specs/action.yml
@@ -42,14 +42,21 @@ runs:
       run: |
         set -euo pipefail
 
-        SPEC_COUNT=$(find "${SPEC_DIR}" -name '*.json' -type f 2>/dev/null | wc -l)
+        # Create the directory before probing it. `shell: bash` in a composite action
+        # runs with -eo pipefail, so `find` on a missing path returns 1 through the
+        # pipe and would kill the step here — on every clean runner, since the spec
+        # directory is gitignored and never exists after checkout. The workflow `run:`
+        # blocks this action replaces used the default `bash -e {0}`, which has no
+        # pipefail, so the same line was harmless there.
+        mkdir -p "${SPEC_DIR}"
+
+        SPEC_COUNT=$(find "${SPEC_DIR}" -name '*.json' -type f | wc -l)
         if [ "$SPEC_COUNT" -gt 0 ]; then
           echo "Found ${SPEC_COUNT} existing spec files in ${SPEC_DIR}"
           exit 0
         fi
 
         echo "Specs not in tree (gitignored) — downloading latest from ${ENRICHED_REPO}"
-        mkdir -p "${SPEC_DIR}"
 
         ASSET_ID=$(gh api "repos/${ENRICHED_REPO}/releases" --jq \
           '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -44,48 +44,16 @@ jobs:
         # compares tools/codespell-corrections.json against real API property
         # names, so it needs the released spec bundle. This job is the ONLY place
         # the guard can block a bad correction key BEFORE merge: the
-        # _generate-provider.yml copy of this download runs post-merge (on-merge.yml
-        # triggers on push: main), so without this step a collision could merge
-        # and would only be caught on its way to a release.
+        # _generate-provider.yml download runs post-merge (on-merge.yml triggers
+        # on push: main), so without this step a collision could merge and would
+        # only be caught on its way to a release.
         #
         # f5-sales-demo/api-specs-enriched is public, so github.token with the
         # inherited contents: read is sufficient — no extra permission needed.
-        # A fetch failure is a HARD failure: degrading to a skipped guard is the
-        # exact defect class #1257 is about. The bundle is one ~9 MB zip and is
-        # skipped entirely when the specs are already in the tree.
-        #
-        # SPEC_DIR reaches the shell through env: — an ${{ }} expansion inside
-        # run: is a code-injection sink (zizmor template-injection). Shell-quoted
-        # at each use below.
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ENRICHED_REPO: f5-sales-demo/api-specs-enriched
-        run: |
-          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
-          if [ "$SPEC_COUNT" -gt "0" ]; then
-            echo "Found $SPEC_COUNT existing spec files in ${SPEC_DIR}"
-            exit 0
-          fi
-
-          echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
-          mkdir -p "${SPEC_DIR}"
-          ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
-            '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
-          if [ -z "$ASSET_ID" ] || [ "$ASSET_ID" = "null" ]; then
-            echo "::error::No spec asset found in the latest $ENRICHED_REPO release; the #1257 codespell collision guard cannot run without it"
-            exit 1
-          fi
-          gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
-            -H "Accept: application/octet-stream" > /tmp/specs.zip
-          unzip -q -o /tmp/specs.zip -d "${SPEC_DIR}"
-          rm /tmp/specs.zip
-
-          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f | wc -l)
-          echo "Downloaded $SPEC_COUNT spec files"
-          if [ "$SPEC_COUNT" -eq "0" ]; then
-            echo "::error::Spec asset unpacked to no JSON specs in ${SPEC_DIR}"
-            exit 1
-          fi
+        uses: ./.github/actions/download-api-specs
+        with:
+          token: ${{ github.token }}
+          spec-dir: ${{ env.SPEC_DIR }}
 
       - name: Set up Go
         uses: actions/setup-go@v7

--- a/.github/workflows/_generate-docs.yml
+++ b/.github/workflows/_generate-docs.yml
@@ -27,6 +27,16 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
+      # This job had no spec download at all, so transform-docs.go always stripped
+      # the spec-derived enrichment and the "Check for changes" step below always
+      # saw a dirty tree. Its `changed` output gates create-regeneration-pr in
+      # on-merge.yml, so every qualifying push opened a regeneration PR for a diff
+      # that only existed because the bundle was missing.
+      - name: Download API specs
+        uses: ./.github/actions/download-api-specs
+        with:
+          token: ${{ github.token }}
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -31,58 +31,26 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
-      - name: Download specs if not present
-        # inputs.spec-dir reaches the shell through env: — an ${{ }} expansion
-        # inside run: is a code-injection sink (zizmor template-injection).
-        # Shell-quoted at each use below.
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ENRICHED_REPO: f5-sales-demo/api-specs-enriched
-          SPEC_DIR: ${{ inputs.spec-dir }}
-        run: |
-          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
-          if [ "$SPEC_COUNT" -eq "0" ]; then
-            echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
-            mkdir -p "${SPEC_DIR}"
-            ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
-              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
-            if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
-              gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
-                -H "Accept: application/octet-stream" > /tmp/specs.zip
-              unzip -o /tmp/specs.zip -d "${SPEC_DIR}"
-              rm /tmp/specs.zip
-              SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f | wc -l)
-              echo "Downloaded $SPEC_COUNT spec files"
-            else
-              echo "::warning::Could not find spec asset in latest release"
-            fi
-          else
-            echo "Found $SPEC_COUNT existing spec files"
-          fi
-
-      - name: Verify specs exist
-        id: verify
-        env:
-          SPEC_DIR: ${{ inputs.spec-dir }}
-        run: |
-          SPEC_COUNT=$(find "${SPEC_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
-          echo "Found ${SPEC_COUNT} OpenAPI spec files in ${SPEC_DIR}"
-          if [ "$SPEC_COUNT" -eq "0" ]; then
-            echo "No spec files found - skipping generation"
-            echo "has_specs=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_specs=true" >> "$GITHUB_OUTPUT"
-          fi
+      # The download used to warn on a missing asset, and a "Verify specs exist"
+      # step then set has_specs=false, which every subsequent step was conditional
+      # on — so the whole regeneration was skipped and the run went green having
+      # generated nothing. A release built that way carries whatever the previous
+      # run happened to leave behind. The shared action fails on a missing bundle,
+      # which makes that condition unreachable, so it and its six `if:` guards are
+      # gone rather than left as a branch that can never be taken.
+      - name: Download API specs
+        uses: ./.github/actions/download-api-specs
+        with:
+          token: ${{ github.token }}
+          spec-dir: ${{ inputs.spec-dir }}
 
       - name: Set up Go
-        if: steps.verify.outputs.has_specs == 'true'
         uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Run code generator
-        if: steps.verify.outputs.has_specs == 'true'
         env:
           SPEC_DIR: ${{ inputs.spec-dir }}
         run: |
@@ -90,23 +58,19 @@ jobs:
           go run tools/generate-all-schemas.go --spec-dir="${SPEC_DIR}"
 
       - name: Run go mod tidy
-        if: steps.verify.outputs.has_specs == 'true'
         run: scripts/go-retry.sh 3 go mod tidy
 
       - name: Build to verify
-        if: steps.verify.outputs.has_specs == 'true'
         # ./... so hand-written packages the root binary does not import — above
         # all internal/acctest — are compiled against the freshly regenerated
         # code. See #1351: `go build .` verified nothing about them.
         run: scripts/go-retry.sh 3 go build -v ./...
 
       - name: Vet to verify
-        if: steps.verify.outputs.has_specs == 'true'
         # Type-checks _test.go files, which go build skips (#1351).
         run: scripts/go-retry.sh 3 go vet ./...
 
       - name: Run tests
-        if: steps.verify.outputs.has_specs == 'true'
         # ./tools/... runs here as well as in _build-test.yml so the freshly
         # regenerated tree is re-tested against the specs it was generated from.
         # XCSH_SPEC_DIR makes TestCodespellCorrectionsDoNotCollideWithSpecPropertyNames

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,16 @@ jobs:
             echo "needs_validation=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # transform-docs.go enriches every page from this bundle. Without it the job
+      # regenerated stripped-down docs and then diffed them against the correct
+      # committed ones, so the assertion added in #1415 failed on its own PR. The
+      # assertion was right; the job was missing an input.
+      - name: Download API specs
+        if: steps.check.outputs.needs_validation == 'true'
+        uses: ./.github/actions/download-api-specs
+        with:
+          token: ${{ github.token }}
+
       - name: Set up Go
         if: steps.check.outputs.needs_validation == 'true'
         uses: actions/setup-go@v7

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -293,31 +293,13 @@ jobs:
           token: ${{ secrets.AUTO_MERGE_TOKEN }}
           persist-credentials: false
 
-      - name: Download specs if not present
-        env:
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
-          ENRICHED_REPO: f5-sales-demo/api-specs-enriched
-        run: |
-          SPEC_DIR="docs/specifications/api"
-          SPEC_COUNT=$(find "$SPEC_DIR" -name "*.json" -type f 2>/dev/null | wc -l)
-          if [ "$SPEC_COUNT" -eq "0" ]; then
-            echo "Specs not in tree (gitignored) — downloading latest from $ENRICHED_REPO"
-            mkdir -p "$SPEC_DIR"
-            ASSET_ID=$(gh api "repos/$ENRICHED_REPO/releases" --jq \
-              '[.[0].assets[] | select(.name | startswith("xcsh-api-specs") or startswith("f5xc-api-specs"))] | .[0].id')
-            if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
-              gh api "repos/$ENRICHED_REPO/releases/assets/$ASSET_ID" \
-                -H "Accept: application/octet-stream" > /tmp/specs.zip
-              unzip -o /tmp/specs.zip -d "$SPEC_DIR"
-              rm /tmp/specs.zip
-              SPEC_COUNT=$(find "$SPEC_DIR" -name "*.json" -type f | wc -l)
-              echo "Downloaded $SPEC_COUNT spec files"
-            else
-              echo "::warning::Could not find spec asset in latest release"
-            fi
-          else
-            echo "Found $SPEC_COUNT existing spec files"
-          fi
+      # This step used to warn and continue when the asset was missing, which meant
+      # the regeneration below could commit documentation stripped of every
+      # spec-derived enrichment. The shared action fails instead.
+      - name: Download API specs
+        uses: ./.github/actions/download-api-specs
+        with:
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v7

--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ packages/typescript-edit-benchmark/runs/
 # Verified-review working artifacts (findings and verification evidence).
 # No trailing slash, so a symlink of this name is matched too.
 .codex-review
+
+# Codex second-opinion review artifacts (quote source; must not be reviewable work)
+.codex-review/

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	golang.org/x/net v0.51.0
 	golang.org/x/text v0.34.0
 	golang.org/x/tools v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/internal/acctest/download_specs_action_test.go
+++ b/internal/acctest/download_specs_action_test.go
@@ -77,7 +77,10 @@ func TestDownloadSpecsActionSkipsWhenBundlePresent(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(specDir, "domains"), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(specDir, "index.json"), []byte(`{}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(specDir, "index.json"), []byte(`{"specifications":[{"name":"sites"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "domains", "sites.json"), []byte(`{"paths":{}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -105,6 +108,51 @@ func TestDownloadSpecsActionSkipsWhenBundlePresent(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "existing spec files") {
 		t.Errorf("expected the short-circuit message, got:\n%s", out)
+	}
+}
+
+// A truncated unzip leaves index.json with an empty domains/. That is JSON in the
+// directory, so a "some spec files are present" probe short-circuits on it and the
+// download that would repair it never runs — while openapi.RequireSpecs rejects the
+// same tree downstream. Measured before this was fixed: such a bundle let
+// transform-docs.go exit 0 and rewrite 277 files. The action's completeness test has
+// to agree with the guard the generators use.
+func TestDownloadSpecsActionRedownloadsTruncatedBundle(t *testing.T) {
+	script := extractActionScript(t)
+
+	tmp := t.TempDir()
+	specDir := filepath.Join(tmp, "specs")
+	if err := os.MkdirAll(filepath.Join(specDir, "domains"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// index.json present, domains/ empty — the truncated shape.
+	if err := os.WriteFile(filepath.Join(specDir, "index.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(tmp, "gh-was-called")
+	stub := "#!/usr/bin/env bash\ntouch " + marker + "\nexit 7\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(stub), 0o700); err != nil { //nolint:gosec // test stub must be executable
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SPEC_DIR="+specDir,
+		"ENRICHED_REPO=f5-sales-demo/api-specs-enriched",
+		"GH_TOKEN=stub",
+	)
+	out, _ := cmd.CombinedOutput()
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("action treated a truncated bundle (index.json, empty domains/) as complete "+
+			"and never attempted a download.\noutput:\n%s", out)
 	}
 }
 

--- a/internal/acctest/download_specs_action_test.go
+++ b/internal/acctest/download_specs_action_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package acctest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The download-api-specs composite action probes for an existing bundle before
+// downloading. Its target directory is gitignored, so on a hosted runner it does not
+// exist — which is precisely the case the probe has to survive.
+//
+// It did not. A composite action's `shell: bash` runs as `bash --noprofile --norc -eo
+// pipefail`, so `find "$missing" | wc -l` returns 1 through pipefail and `set -e`
+// killed the step before mkdir or any download ran. The three hand-rolled copies this
+// action replaced were not affected: a workflow `run:` with no `shell:` key uses
+// `bash -e {0}` WITHOUT pipefail, so the same line was harmless there. Consolidating
+// them is what exposed it.
+//
+// This test extracts the action's script and runs it against an absent directory with
+// a stub `gh` on PATH, asserting it reaches the download rather than dying at the
+// probe.
+func TestDownloadSpecsActionSurvivesAbsentSpecDir(t *testing.T) {
+	script := extractActionScript(t)
+
+	tmp := t.TempDir()
+
+	// A stub `gh` that records it was called and then fails. Reaching it is the
+	// assertion; what it returns afterwards is not this test's concern.
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(tmp, "gh-was-called")
+	stub := "#!/usr/bin/env bash\ntouch " + marker + "\nexit 7\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(stub), 0o700); err != nil { //nolint:gosec // test stub must be executable
+		t.Fatal(err)
+	}
+
+	absent := filepath.Join(tmp, "no", "such", "spec", "dir")
+
+	cmd := exec.Command("bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SPEC_DIR="+absent,
+		"ENRICHED_REPO=f5-sales-demo/api-specs-enriched",
+		"GH_TOKEN=stub",
+	)
+	out, err := cmd.CombinedOutput()
+
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("action exited before attempting the download against an absent %s.\n"+
+			"The probe must not kill the step on a clean checkout.\nerr: %v\noutput:\n%s",
+			absent, err, out)
+	}
+
+	if _, statErr := os.Stat(absent); statErr != nil {
+		t.Errorf("action did not create %s before downloading into it: %v", absent, statErr)
+	}
+}
+
+// A bundle already in the tree must short-circuit: re-downloading on every job is
+// waste, and the local development flow depends on `make download-specs` output being
+// honoured rather than silently replaced.
+func TestDownloadSpecsActionSkipsWhenBundlePresent(t *testing.T) {
+	script := extractActionScript(t)
+
+	tmp := t.TempDir()
+	specDir := filepath.Join(tmp, "specs")
+	if err := os.MkdirAll(filepath.Join(specDir, "domains"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "index.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Any invocation of gh is a failure here: the bundle is already present.
+	stub := "#!/usr/bin/env bash\necho 'gh must not be called when specs are present' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(stub), 0o700); err != nil { //nolint:gosec // test stub must be executable
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SPEC_DIR="+specDir,
+		"ENRICHED_REPO=f5-sales-demo/api-specs-enriched",
+		"GH_TOKEN=stub",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("action failed on a spec directory that already holds a bundle: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "existing spec files") {
+		t.Errorf("expected the short-circuit message, got:\n%s", out)
+	}
+}
+
+// extractActionScript returns the shell body of the composite action's single step,
+// with GitHub's ${{ }} input expansions resolved to the environment variables the
+// tests set. Reading the real file means the test cannot drift from what CI runs.
+func extractActionScript(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join("..", "..", ".github", "actions", "download-api-specs", "action.yml")
+	data, err := os.ReadFile(path) //nolint:gosec // fixed repo-relative path
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	var action struct {
+		Runs struct {
+			Steps []struct {
+				Run string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"runs"`
+	}
+	if err := yaml.Unmarshal(data, &action); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	if len(action.Runs.Steps) != 1 {
+		t.Fatalf("expected exactly one step in the composite action, found %d", len(action.Runs.Steps))
+	}
+
+	script := action.Runs.Steps[0].Run
+	if script == "" {
+		t.Fatal("composite action step has an empty run body")
+	}
+	return script
+}

--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -91,6 +91,25 @@ func IsV2SpecDirectory(specDir string) bool {
 	return GetSpecVersion(specDir) == SpecVersionV2
 }
 
+// RequireSpecs returns an error unless specDir holds a complete v2 spec bundle.
+//
+// Callers that enrich generated output from the specs must use this instead of
+// treating SpecVersionUnknown as "carry on without enrichment". Silently degrading
+// makes a missing download indistinguishable from a successful run: transform-docs.go
+// did exactly that, and on a spec-less checkout emitted 256 files with 1548 lines of
+// API links, dependency notes and danger callouts removed — while exiting 0.
+func RequireSpecs(specDir string) error {
+	if GetSpecVersion(specDir) == SpecVersionV2 {
+		return nil
+	}
+	return fmt.Errorf(
+		"no OpenAPI spec bundle in %q: expected index.json and a domains/ directory. "+
+			"The bundle is gitignored, so a fresh checkout has none — run 'make download-specs' "+
+			"(or add the spec download step to this CI job) before generating",
+		specDir,
+	)
+}
+
 // ParseIndex reads and parses the index.json manifest file.
 func ParseIndex(path string) (*Index, error) {
 	data, err := os.ReadFile(path)

--- a/tools/pkg/openapi/parser.go
+++ b/tools/pkg/openapi/parser.go
@@ -91,23 +91,47 @@ func IsV2SpecDirectory(specDir string) bool {
 	return GetSpecVersion(specDir) == SpecVersionV2
 }
 
-// RequireSpecs returns an error unless specDir holds a complete v2 spec bundle.
+// RequireSpecs returns an error unless specDir holds a v2 spec bundle with usable
+// content in it.
 //
 // Callers that enrich generated output from the specs must use this instead of
 // treating SpecVersionUnknown as "carry on without enrichment". Silently degrading
 // makes a missing download indistinguishable from a successful run: transform-docs.go
 // did exactly that, and on a spec-less checkout emitted 256 files with 1548 lines of
 // API links, dependency notes and danger callouts removed — while exiting 0.
+//
+// Checking that index.json and domains/ merely EXIST is not enough, and the first
+// version of this guard made that mistake. A directory holding `{}` and an empty
+// domains/ satisfied it, and transform-docs.go then loaded zero resources, exited 0
+// and rewrote 277 files — the same failure, reached through a truncated unzip instead
+// of an absent one. Both loaders downstream swallow their errors (a domain that fails
+// to parse contributes no metadata; an unreadable index is skipped by an `err == nil`
+// guard), so the emptiness has to be rejected here or it is never reported at all.
 func RequireSpecs(specDir string) error {
-	if GetSpecVersion(specDir) == SpecVersionV2 {
-		return nil
+	const remedy = "The bundle is gitignored, so a fresh checkout has none — run 'make download-specs' " +
+		"(or add the spec download step to this CI job) before generating"
+
+	if GetSpecVersion(specDir) != SpecVersionV2 {
+		return fmt.Errorf("no OpenAPI spec bundle in %q: expected index.json and a domains/ directory. %s", specDir, remedy)
 	}
-	return fmt.Errorf(
-		"no OpenAPI spec bundle in %q: expected index.json and a domains/ directory. "+
-			"The bundle is gitignored, so a fresh checkout has none — run 'make download-specs' "+
-			"(or add the spec download step to this CI job) before generating",
-		specDir,
-	)
+
+	domains, err := filepath.Glob(filepath.Join(specDir, "domains", "*.json"))
+	if err != nil {
+		return fmt.Errorf("scanning %q for domain specs: %w", specDir, err)
+	}
+	if len(domains) == 0 {
+		return fmt.Errorf("spec bundle in %q has an empty domains/ directory — a truncated download. %s", specDir, remedy)
+	}
+
+	index, err := ParseIndexFromDir(specDir)
+	if err != nil {
+		return fmt.Errorf("spec bundle in %q has an unreadable index.json: %w. %s", specDir, err, remedy)
+	}
+	if len(index.Specifications) == 0 {
+		return fmt.Errorf("spec bundle in %q has an index.json listing no specifications. %s", specDir, remedy)
+	}
+
+	return nil
 }
 
 // ParseIndex reads and parses the index.json manifest file.

--- a/tools/pkg/openapi/require_specs_test.go
+++ b/tools/pkg/openapi/require_specs_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package openapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// RequireSpecs exists because a missing spec directory used to be a *note*, not an
+// error. transform-docs.go printed "No OpenAPI specs found" and carried on, emitting
+// documentation stripped of every spec-derived enrichment — per-domain API reference
+// links, dependency notes and danger-level callouts. Measured on a spec-less checkout
+// of the commit that added the CI diff assertion: 256 files changed, 1548 deletions,
+// exit code 0.
+//
+// That is the defect this guard closes: a missing INPUT must not look like a
+// successful RUN.
+func TestRequireSpecsRejectsMissingDirectory(t *testing.T) {
+	err := RequireSpecs(filepath.Join(t.TempDir(), "definitely-not-here"))
+	if err == nil {
+		t.Fatal("RequireSpecs accepted a directory that does not exist; a missing spec bundle must be an error, not a note")
+	}
+	if !strings.Contains(err.Error(), "download-specs") {
+		t.Errorf("error must tell the caller how to recover, got: %v", err)
+	}
+}
+
+// An empty directory is the shape CI actually produced: the checkout creates nothing,
+// and `mkdir -p` in an unrelated step can leave the path present but bare. Presence of
+// the path is not presence of the specs.
+func TestRequireSpecsRejectsEmptyDirectory(t *testing.T) {
+	if err := RequireSpecs(t.TempDir()); err == nil {
+		t.Fatal("RequireSpecs accepted an empty directory; index.json and domains/ are both required")
+	}
+}
+
+// index.json without domains/ is a partial unzip — a truncated download that would
+// otherwise parse far enough to look usable.
+func TestRequireSpecsRejectsPartialBundle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte(`{"specifications":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RequireSpecs(dir); err == nil {
+		t.Fatal("RequireSpecs accepted index.json with no domains/ directory")
+	}
+}
+
+func TestRequireSpecsAcceptsCompleteBundle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte(`{"specifications":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "domains"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := RequireSpecs(dir); err != nil {
+		t.Fatalf("RequireSpecs rejected a complete v2 bundle: %v", err)
+	}
+}

--- a/tools/pkg/openapi/require_specs_test.go
+++ b/tools/pkg/openapi/require_specs_test.go
@@ -49,15 +49,57 @@ func TestRequireSpecsRejectsPartialBundle(t *testing.T) {
 	}
 }
 
+// Checking only that index.json and domains/ EXIST is not enough, and the first
+// version of this guard made exactly that mistake. Measured: a directory holding
+// `{}` and an empty domains/ passed the guard, transform-docs.go loaded zero
+// resources, exited 0, and rewrote 277 files — the identical failure the guard was
+// added to prevent. Presence of the path is not presence of the specs.
+func TestRequireSpecsRejectsEmptyDomainsDirectory(t *testing.T) {
+	dir := newBundle(t, `{"specifications":[{"name":"sites"}]}`)
+	if err := RequireSpecs(dir); err == nil {
+		t.Fatal("RequireSpecs accepted a bundle whose domains/ holds no specs")
+	}
+}
+
+func TestRequireSpecsRejectsEmptyIndex(t *testing.T) {
+	dir := newBundle(t, `{}`)
+	writeDomain(t, dir, "sites.json")
+	if err := RequireSpecs(dir); err == nil {
+		t.Fatal("RequireSpecs accepted an index listing no specifications")
+	}
+}
+
+func TestRequireSpecsRejectsUnparseableIndex(t *testing.T) {
+	dir := newBundle(t, `{"specifications": [`)
+	writeDomain(t, dir, "sites.json")
+	if err := RequireSpecs(dir); err == nil {
+		t.Fatal("RequireSpecs accepted an index that does not parse")
+	}
+}
+
 func TestRequireSpecsAcceptsCompleteBundle(t *testing.T) {
+	dir := newBundle(t, `{"specifications":[{"name":"sites"}]}`)
+	writeDomain(t, dir, "sites.json")
+	if err := RequireSpecs(dir); err != nil {
+		t.Fatalf("RequireSpecs rejected a complete v2 bundle: %v", err)
+	}
+}
+
+func newBundle(t *testing.T, index string) string {
+	t.Helper()
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte(`{"specifications":[]}`), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "index.json"), []byte(index), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Mkdir(filepath.Join(dir, "domains"), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := RequireSpecs(dir); err != nil {
-		t.Fatalf("RequireSpecs rejected a complete v2 bundle: %v", err)
+	return dir
+}
+
+func writeDomain(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "domains", name), []byte(`{"paths":{}}`), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -14,6 +14,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -84,14 +85,16 @@ var v2MetadataCache = make(map[string]V2ResourceMetadata)
 func loadV2SpecMetadata() {
 	specDir := "docs/specifications/api"
 
-	specVersion := openapi.GetSpecVersion(specDir)
-	if specVersion == openapi.SpecVersionUnknown {
-		fmt.Printf("Note: No OpenAPI specs found in %s for v2 metadata loading\n", specDir)
-		return
+	// Missing specs used to print a note and return, which produced documentation
+	// with every spec-derived enrichment silently removed while the tool exited 0.
+	// The CI diff assertion added in #1415 caught it only because it compared the
+	// output; the generator itself reported success. Refuse to run instead.
+	if err := openapi.RequireSpecs(specDir); err != nil {
+		log.Fatalf("cannot transform documentation: %v", err)
 	}
 
 	var count int
-	switch specVersion {
+	switch openapi.GetSpecVersion(specDir) {
 	case openapi.SpecVersionV2:
 		count = loadV2MetadataFromDomains(specDir)
 	}


### PR DESCRIPTION
`Validate Docs Generation` failed on #1415 — the PR that added the diff assertion — and #1415 merged anyway. The assertion was right. The job was missing an input.

## What was measured

`tools/transform-docs.go` enriches every generated page from the spec bundle at `docs/specifications/api`. That directory is gitignored, so a fresh checkout has none, and the job never downloaded it.

On a clean worktree at 8800c8de:

| input | result |
| --- | --- |
| no bundle | 256 files changed, 1548 deletions, **exit 0**, announced only as `Note: No OpenAPI specs found` |
| `{}` index.json + empty `domains/` | 277 files of drift, **exit 0** |
| the real bundle | **0 files of drift** |

`generate-examples.go` is schema-driven and drifts 0 files either way, so the whole diff came from the doc transform. The committed tree has always been correct.

## Changes

- **`transform-docs.go` refuses to run** without a usable bundle, before writing anything. `openapi.RequireSpecs` requires index.json, at least one `domains/*.json`, and an index that parses and lists at least one specification. Existence alone is not enough — both loaders downstream swallow their errors, so an empty bundle would otherwise never be reported.
- **`validate-docs-generation` and `_generate-docs.yml` download the bundle.** `_generate-docs.yml` had none at all, so its `git status` change detector was always dirty and fired a spurious regeneration PR through `on-merge.yml` on every qualifying push.
- **One composite action replaces three divergent copies.** They disagreed on failure: `_build-test.yml` errored, the other two emitted `::warning::Could not find spec asset` and continued. In `_generate-provider.yml` that set `has_specs=false`, which six later steps were conditional on — so the run went green having generated nothing. That branch is now unreachable and is deleted rather than left in place.
- The action also fetches `api-catalog.json` and `minimal-export-defaults.json`, which `make download-specs` already fetched. CI and local runs were reading different inputs.

## Second opinion

Two rounds of `codex:verified-code-review`, both **CONFIRMED by measurement**, both genuine defects I would have shipped:

1. A composite action's `shell: bash` runs with `-eo pipefail`, so `find` on the absent (gitignored) spec directory returned 1 and `set -e` killed the step before any download. Every workflow using the action would have failed on a clean runner. The three copies it replaced were unaffected — a workflow `run:` with no `shell:` key uses `bash -e {0}`, no pipefail — so consolidating them is what exposed it.
2. The first guard checked only that index.json and `domains/` existed, which the 277-file case above passes.

Nothing was dismissed as refuted. Gate: `done: true`, `findingsClear: true`, suite pass.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green
- `golangci-lint run` — 0 issues
- `zizmor` on the new action — no findings
- Full CI recipe re-run with the bundle present — **0 files differ**
- 6 new tests, each red before its fix

Closes #1420