### PR TITLE
Let a configuration own a ves.io/-prefixed label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
             "^docs/index\.md$"
             "^examples/resources/.*\.tf$"
             "^examples/data-sources/.*\.tf$"
+            "^internal/provider/.*_resource\.go$"
+            "^internal/provider/.*_data_source\.go$"
           )
 
           # Helper function to check if file is manually maintained

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,12 @@ jobs:
           # change — and no generator changed, because the generators were already
           # right. The check had no category for that and blocked the fix.
           GENERATOR_TOOLS_MODIFIED=false
-          if echo "$CHANGED_FILES" | grep -qE "^tools/transform-docs\.go$|^tools/generate-|^templates/|^Makefile$|^\.github/workflows/ci\.yml$"; then
+          # tools/pkg/codegen/ is where the resource, data-source and example templates
+          # actually live, so a change there regenerates internal/provider/*_resource.go
+          # by definition. It was missing from this list, which meant the one edit that
+          # most obviously justifies regenerated output — editing the template — was the
+          # one the check refused to accept (#1398 hit exactly that).
+          if echo "$CHANGED_FILES" | grep -qE "^tools/transform-docs\.go$|^tools/generate-|^tools/pkg/codegen/|^templates/|^Makefile$|^\.github/workflows/ci\.yml$"; then
             echo "Generator tools modified - docs/examples changes are allowed"
             GENERATOR_TOOLS_MODIFIED=true
           fi

--- a/internal/acctest/constitution_workflow_test.go
+++ b/internal/acctest/constitution_workflow_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package acctest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConstitutionAllowsRegeneratedProviderFilesWithGeneratorChange(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", ".github", "workflows", "ci.yml")
+	workflow, err := os.ReadFile(workflowPath) //nolint:gosec // fixed repository path
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(workflow)
+	for _, pattern := range []string{
+		`"^internal/provider/.*_resource\.go$"`,
+		`"^internal/provider/.*_data_source\.go$"`,
+	} {
+		if strings.Count(text, pattern) < 2 {
+			t.Fatalf("generated provider pattern %s must be both protected and allowed when its generator changes", pattern)
+		}
+	}
+}

--- a/internal/provider/address_allocator_resource.go
+++ b/internal/provider/address_allocator_resource.go
@@ -275,6 +275,27 @@ func (r *AddressAllocatorResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -442,9 +463,18 @@ func (r *AddressAllocatorResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -576,6 +606,29 @@ func (r *AddressAllocatorResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/address_allocator_resource.go
+++ b/internal/provider/address_allocator_resource.go
@@ -682,6 +682,13 @@ func (r *AddressAllocatorResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/address_allocator_resource.go
+++ b/internal/provider/address_allocator_resource.go
@@ -275,25 +275,24 @@ func (r *AddressAllocatorResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -333,6 +332,15 @@ func (r *AddressAllocatorResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateAddressAllocator(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AddressAllocator: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -608,27 +616,24 @@ func (r *AddressAllocatorResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -668,6 +673,17 @@ func (r *AddressAllocatorResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateAddressAllocator(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AddressAllocator: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/advertise_policy_resource.go
+++ b/internal/provider/advertise_policy_resource.go
@@ -936,6 +936,27 @@ func (r *AdvertisePolicyResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1948,9 +1969,18 @@ func (r *AdvertisePolicyResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2640,6 +2670,29 @@ func (r *AdvertisePolicyResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/advertise_policy_resource.go
+++ b/internal/provider/advertise_policy_resource.go
@@ -3033,6 +3033,13 @@ func (r *AdvertisePolicyResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/advertise_policy_resource.go
+++ b/internal/provider/advertise_policy_resource.go
@@ -936,25 +936,24 @@ func (r *AdvertisePolicyResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1281,6 +1280,15 @@ func (r *AdvertisePolicyResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateAdvertisePolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AdvertisePolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2672,27 +2680,24 @@ func (r *AdvertisePolicyResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3019,6 +3024,17 @@ func (r *AdvertisePolicyResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateAdvertisePolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AdvertisePolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/alert_gen_policy_resource.go
+++ b/internal/provider/alert_gen_policy_resource.go
@@ -270,6 +270,27 @@ func (r *AlertGenPolicyResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -418,9 +439,18 @@ func (r *AlertGenPolicyResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -537,6 +567,29 @@ func (r *AlertGenPolicyResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/alert_gen_policy_resource.go
+++ b/internal/provider/alert_gen_policy_resource.go
@@ -639,6 +639,13 @@ func (r *AlertGenPolicyResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alert_gen_policy_resource.go
+++ b/internal/provider/alert_gen_policy_resource.go
@@ -270,25 +270,24 @@ func (r *AlertGenPolicyResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -324,6 +323,15 @@ func (r *AlertGenPolicyResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateAlertGenPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AlertGenPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -569,27 +577,24 @@ func (r *AlertGenPolicyResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -625,6 +630,17 @@ func (r *AlertGenPolicyResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateAlertGenPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AlertGenPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -615,25 +615,24 @@ func (r *AlertPolicyResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -831,6 +830,15 @@ func (r *AlertPolicyResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateAlertPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AlertPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1778,27 +1786,24 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1996,6 +2001,17 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateAlertPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AlertPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -2010,6 +2010,13 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -615,6 +615,27 @@ func (r *AlertPolicyResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1276,9 +1297,18 @@ func (r *AlertPolicyResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1746,6 +1776,29 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/alert_receiver_resource.go
+++ b/internal/provider/alert_receiver_resource.go
@@ -1135,25 +1135,24 @@ func (r *AlertReceiverResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1485,6 +1484,15 @@ func (r *AlertReceiverResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateAlertReceiver(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AlertReceiver: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2966,27 +2974,24 @@ func (r *AlertReceiverResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3318,6 +3323,17 @@ func (r *AlertReceiverResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateAlertReceiver(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AlertReceiver: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/alert_receiver_resource.go
+++ b/internal/provider/alert_receiver_resource.go
@@ -3332,6 +3332,13 @@ func (r *AlertReceiverResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alert_receiver_resource.go
+++ b/internal/provider/alert_receiver_resource.go
@@ -1135,6 +1135,27 @@ func (r *AlertReceiverResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2197,9 +2218,18 @@ func (r *AlertReceiverResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2934,6 +2964,29 @@ func (r *AlertReceiverResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/alert_template_resource.go
+++ b/internal/provider/alert_template_resource.go
@@ -568,6 +568,13 @@ func (r *AlertTemplateResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/alert_template_resource.go
+++ b/internal/provider/alert_template_resource.go
@@ -239,6 +239,27 @@ func (r *AlertTemplateResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -367,9 +388,18 @@ func (r *AlertTemplateResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -473,6 +503,29 @@ func (r *AlertTemplateResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/alert_template_resource.go
+++ b/internal/provider/alert_template_resource.go
@@ -239,25 +239,24 @@ func (r *AlertTemplateResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -286,6 +285,15 @@ func (r *AlertTemplateResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateAlertTemplate(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AlertTemplate: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -505,27 +513,24 @@ func (r *AlertTemplateResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -554,6 +559,17 @@ func (r *AlertTemplateResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateAlertTemplate(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AlertTemplate: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/allowed_domain_resource.go
+++ b/internal/provider/allowed_domain_resource.go
@@ -516,6 +516,13 @@ func (r *AllowedDomainResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/allowed_domain_resource.go
+++ b/internal/provider/allowed_domain_resource.go
@@ -235,25 +235,24 @@ func (r *AllowedDomainResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -273,6 +272,15 @@ func (r *AllowedDomainResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateAllowedDomain(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AllowedDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -462,27 +470,24 @@ func (r *AllowedDomainResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -502,6 +507,17 @@ func (r *AllowedDomainResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateAllowedDomain(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AllowedDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/allowed_domain_resource.go
+++ b/internal/provider/allowed_domain_resource.go
@@ -235,6 +235,27 @@ func (r *AllowedDomainResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -339,9 +360,18 @@ func (r *AllowedDomainResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -430,6 +460,29 @@ func (r *AllowedDomainResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/api_crawler_resource.go
+++ b/internal/provider/api_crawler_resource.go
@@ -919,6 +919,13 @@ func (r *APICrawlerResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/api_crawler_resource.go
+++ b/internal/provider/api_crawler_resource.go
@@ -350,6 +350,27 @@ func (r *APICrawlerResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -598,9 +619,18 @@ func (r *APICrawlerResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -786,6 +816,29 @@ func (r *APICrawlerResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/api_crawler_resource.go
+++ b/internal/provider/api_crawler_resource.go
@@ -350,25 +350,24 @@ func (r *APICrawlerResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -435,6 +434,15 @@ func (r *APICrawlerResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateAPICrawler(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create APICrawler: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -818,27 +826,24 @@ func (r *APICrawlerResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -905,6 +910,17 @@ func (r *APICrawlerResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateAPICrawler(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update APICrawler: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/api_definition_resource.go
+++ b/internal/provider/api_definition_resource.go
@@ -991,6 +991,13 @@ func (r *APIDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/api_definition_resource.go
+++ b/internal/provider/api_definition_resource.go
@@ -340,6 +340,27 @@ func (r *APIDefinitionResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -629,9 +650,18 @@ func (r *APIDefinitionResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -838,6 +868,29 @@ func (r *APIDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/api_definition_resource.go
+++ b/internal/provider/api_definition_resource.go
@@ -340,25 +340,24 @@ func (r *APIDefinitionResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -445,6 +444,15 @@ func (r *APIDefinitionResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateAPIDefinition(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create APIDefinition: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -870,27 +878,24 @@ func (r *APIDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -977,6 +982,17 @@ func (r *APIDefinitionResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateAPIDefinition(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update APIDefinition: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/api_discovery_resource.go
+++ b/internal/provider/api_discovery_resource.go
@@ -459,25 +459,24 @@ func (r *APIDiscoveryResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -592,6 +591,15 @@ func (r *APIDiscoveryResource) Create(ctx context.Context, req resource.CreateRe
 	apiResource, err := r.client.CreateAPIDiscovery(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create APIDiscovery: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1191,27 +1199,24 @@ func (r *APIDiscoveryResource) Update(ctx context.Context, req resource.UpdateRe
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1326,6 +1331,17 @@ func (r *APIDiscoveryResource) Update(ctx context.Context, req resource.UpdateRe
 	_, err := r.client.UpdateAPIDiscovery(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update APIDiscovery: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/api_discovery_resource.go
+++ b/internal/provider/api_discovery_resource.go
@@ -1340,6 +1340,13 @@ func (r *APIDiscoveryResource) Update(ctx context.Context, req resource.UpdateRe
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/api_discovery_resource.go
+++ b/internal/provider/api_discovery_resource.go
@@ -459,6 +459,27 @@ func (r *APIDiscoveryResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -863,9 +884,18 @@ func (r *APIDiscoveryResource) Read(ctx context.Context, req resource.ReadReques
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1159,6 +1189,29 @@ func (r *APIDiscoveryResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/api_testing_resource.go
+++ b/internal/provider/api_testing_resource.go
@@ -743,6 +743,27 @@ func (r *APITestingResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1423,9 +1444,18 @@ func (r *APITestingResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1901,6 +1931,29 @@ func (r *APITestingResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/api_testing_resource.go
+++ b/internal/provider/api_testing_resource.go
@@ -2176,6 +2176,13 @@ func (r *APITestingResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/api_testing_resource.go
+++ b/internal/provider/api_testing_resource.go
@@ -743,25 +743,24 @@ func (r *APITestingResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -970,6 +969,15 @@ func (r *APITestingResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateAPITesting(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create APITesting: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1933,27 +1941,24 @@ func (r *APITestingResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2162,6 +2167,17 @@ func (r *APITestingResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateAPITesting(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update APITesting: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/app_api_group_resource.go
+++ b/internal/provider/app_api_group_resource.go
@@ -434,25 +434,24 @@ func (r *AppAPIGroupResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -543,6 +542,15 @@ func (r *AppAPIGroupResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateAppAPIGroup(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AppAPIGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -980,27 +988,24 @@ func (r *AppAPIGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1091,6 +1096,17 @@ func (r *AppAPIGroupResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateAppAPIGroup(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AppAPIGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/app_api_group_resource.go
+++ b/internal/provider/app_api_group_resource.go
@@ -434,6 +434,27 @@ func (r *AppAPIGroupResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -733,9 +754,18 @@ func (r *AppAPIGroupResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -948,6 +978,29 @@ func (r *AppAPIGroupResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/app_api_group_resource.go
+++ b/internal/provider/app_api_group_resource.go
@@ -1105,6 +1105,13 @@ func (r *AppAPIGroupResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/app_firewall_resource.go
+++ b/internal/provider/app_firewall_resource.go
@@ -2347,6 +2347,13 @@ func (r *AppFirewallResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/app_firewall_resource.go
+++ b/internal/provider/app_firewall_resource.go
@@ -756,6 +756,27 @@ func (r *AppFirewallResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1515,9 +1536,18 @@ func (r *AppFirewallResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2037,6 +2067,29 @@ func (r *AppFirewallResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/app_firewall_resource.go
+++ b/internal/provider/app_firewall_resource.go
@@ -756,25 +756,24 @@ func (r *AppFirewallResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1018,6 +1017,15 @@ func (r *AppFirewallResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateAppFirewall(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AppFirewall: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2069,27 +2077,24 @@ func (r *AppFirewallResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2333,6 +2338,17 @@ func (r *AppFirewallResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateAppFirewall(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AppFirewall: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/app_setting_resource.go
+++ b/internal/provider/app_setting_resource.go
@@ -2015,6 +2015,13 @@ func (r *AppSettingResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/app_setting_resource.go
+++ b/internal/provider/app_setting_resource.go
@@ -584,25 +584,24 @@ func (r *AppSettingResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -790,6 +789,15 @@ func (r *AppSettingResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateAppSetting(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AppSetting: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1793,27 +1801,24 @@ func (r *AppSettingResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2001,6 +2006,17 @@ func (r *AppSettingResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateAppSetting(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AppSetting: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/app_setting_resource.go
+++ b/internal/provider/app_setting_resource.go
@@ -584,6 +584,27 @@ func (r *AppSettingResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1263,9 +1284,18 @@ func (r *AppSettingResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1761,6 +1791,29 @@ func (r *AppSettingResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/app_type_resource.go
+++ b/internal/provider/app_type_resource.go
@@ -761,6 +761,13 @@ func (r *AppTypeResource) Update(ctx context.Context, req resource.UpdateRequest
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/app_type_resource.go
+++ b/internal/provider/app_type_resource.go
@@ -290,6 +290,27 @@ func (r *AppTypeResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -489,9 +510,18 @@ func (r *AppTypeResource) Read(ctx context.Context, req resource.ReadRequest, re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -645,6 +675,29 @@ func (r *AppTypeResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/app_type_resource.go
+++ b/internal/provider/app_type_resource.go
@@ -290,25 +290,24 @@ func (r *AppTypeResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -358,6 +357,15 @@ func (r *AppTypeResource) Create(ctx context.Context, req resource.CreateRequest
 	apiResource, err := r.client.CreateAppType(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AppType: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -677,27 +685,24 @@ func (r *AppTypeResource) Update(ctx context.Context, req resource.UpdateRequest
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -747,6 +752,17 @@ func (r *AppTypeResource) Update(ctx context.Context, req resource.UpdateRequest
 	_, err := r.client.UpdateAppType(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AppType: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/application_profiles_resource.go
+++ b/internal/provider/application_profiles_resource.go
@@ -13559,6 +13559,13 @@ func (r *ApplicationProfilesResource) Update(ctx context.Context, req resource.U
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/application_profiles_resource.go
+++ b/internal/provider/application_profiles_resource.go
@@ -3630,25 +3630,24 @@ func (r *ApplicationProfilesResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -5308,6 +5307,15 @@ func (r *ApplicationProfilesResource) Create(ctx context.Context, req resource.C
 	apiResource, err := r.client.CreateApplicationProfiles(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ApplicationProfiles: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -11865,27 +11873,24 @@ func (r *ApplicationProfilesResource) Update(ctx context.Context, req resource.U
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -13545,6 +13550,17 @@ func (r *ApplicationProfilesResource) Update(ctx context.Context, req resource.U
 	_, err := r.client.UpdateApplicationProfiles(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ApplicationProfiles: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/application_profiles_resource.go
+++ b/internal/provider/application_profiles_resource.go
@@ -3630,6 +3630,27 @@ func (r *ApplicationProfilesResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -8558,9 +8579,18 @@ func (r *ApplicationProfilesResource) Read(ctx context.Context, req resource.Rea
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -11833,6 +11863,29 @@ func (r *ApplicationProfilesResource) Update(ctx context.Context, req resource.U
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/authentication_resource.go
+++ b/internal/provider/authentication_resource.go
@@ -1712,6 +1712,13 @@ func (r *AuthenticationResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/authentication_resource.go
+++ b/internal/provider/authentication_resource.go
@@ -615,6 +615,27 @@ func (r *AuthenticationResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1127,9 +1148,18 @@ func (r *AuthenticationResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1499,6 +1529,29 @@ func (r *AuthenticationResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/authentication_resource.go
+++ b/internal/provider/authentication_resource.go
@@ -615,25 +615,24 @@ func (r *AuthenticationResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -780,6 +779,15 @@ func (r *AuthenticationResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateAuthentication(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Authentication: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1531,27 +1539,24 @@ func (r *AuthenticationResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1698,6 +1703,17 @@ func (r *AuthenticationResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateAuthentication(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Authentication: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/authorization_server_resource.go
+++ b/internal/provider/authorization_server_resource.go
@@ -499,6 +499,13 @@ func (r *AuthorizationServerResource) Update(ctx context.Context, req resource.U
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/authorization_server_resource.go
+++ b/internal/provider/authorization_server_resource.go
@@ -218,6 +218,27 @@ func (r *AuthorizationServerResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -322,9 +343,18 @@ func (r *AuthorizationServerResource) Read(ctx context.Context, req resource.Rea
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -413,6 +443,29 @@ func (r *AuthorizationServerResource) Update(ctx context.Context, req resource.U
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/authorization_server_resource.go
+++ b/internal/provider/authorization_server_resource.go
@@ -218,25 +218,24 @@ func (r *AuthorizationServerResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -256,6 +255,15 @@ func (r *AuthorizationServerResource) Create(ctx context.Context, req resource.C
 	apiResource, err := r.client.CreateAuthorizationServer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AuthorizationServer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -445,27 +453,24 @@ func (r *AuthorizationServerResource) Update(ctx context.Context, req resource.U
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -485,6 +490,17 @@ func (r *AuthorizationServerResource) Update(ctx context.Context, req resource.U
 	_, err := r.client.UpdateAuthorizationServer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AuthorizationServer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/aws_tgw_site_resource.go
+++ b/internal/provider/aws_tgw_site_resource.go
@@ -9131,6 +9131,13 @@ func (r *AWSTGWSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/aws_tgw_site_resource.go
+++ b/internal/provider/aws_tgw_site_resource.go
@@ -2817,25 +2817,24 @@ func (r *AWSTGWSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -3836,6 +3835,15 @@ func (r *AWSTGWSiteResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateAWSTGWSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AWSTGWSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -8075,27 +8083,24 @@ func (r *AWSTGWSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -9117,6 +9122,17 @@ func (r *AWSTGWSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateAWSTGWSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AWSTGWSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/aws_tgw_site_resource.go
+++ b/internal/provider/aws_tgw_site_resource.go
@@ -2817,6 +2817,27 @@ func (r *AWSTGWSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -5927,9 +5948,18 @@ func (r *AWSTGWSiteResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -8043,6 +8073,29 @@ func (r *AWSTGWSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/aws_vpc_site_resource.go
+++ b/internal/provider/aws_vpc_site_resource.go
@@ -3867,6 +3867,27 @@ func (r *AWSVPCSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -8122,9 +8143,18 @@ func (r *AWSVPCSiteResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -10981,6 +11011,29 @@ func (r *AWSVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/aws_vpc_site_resource.go
+++ b/internal/provider/aws_vpc_site_resource.go
@@ -3867,25 +3867,24 @@ func (r *AWSVPCSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -5288,6 +5287,15 @@ func (r *AWSVPCSiteResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateAWSVPCSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AWSVPCSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -11013,27 +11021,24 @@ func (r *AWSVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -12457,6 +12462,17 @@ func (r *AWSVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateAWSVPCSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AWSVPCSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/aws_vpc_site_resource.go
+++ b/internal/provider/aws_vpc_site_resource.go
@@ -12471,6 +12471,13 @@ func (r *AWSVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/azure_vnet_site_resource.go
+++ b/internal/provider/azure_vnet_site_resource.go
@@ -7267,25 +7267,24 @@ func (r *AzureVNETSiteResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -9932,6 +9931,15 @@ func (r *AzureVNETSiteResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateAzureVNETSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AzureVNETSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -21153,27 +21161,24 @@ func (r *AzureVNETSiteResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -23841,6 +23846,17 @@ func (r *AzureVNETSiteResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateAzureVNETSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AzureVNETSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/azure_vnet_site_resource.go
+++ b/internal/provider/azure_vnet_site_resource.go
@@ -23855,6 +23855,13 @@ func (r *AzureVNETSiteResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/azure_vnet_site_resource.go
+++ b/internal/provider/azure_vnet_site_resource.go
@@ -7267,6 +7267,27 @@ func (r *AzureVNETSiteResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -15514,9 +15535,18 @@ func (r *AzureVNETSiteResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -21121,6 +21151,29 @@ func (r *AzureVNETSiteResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/bgp_asn_set_resource.go
+++ b/internal/provider/bgp_asn_set_resource.go
@@ -528,6 +528,13 @@ func (r *BGPAsnSetResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/bgp_asn_set_resource.go
+++ b/internal/provider/bgp_asn_set_resource.go
@@ -219,6 +219,27 @@ func (r *BGPAsnSetResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -337,9 +358,18 @@ func (r *BGPAsnSetResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -438,6 +468,29 @@ func (r *BGPAsnSetResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/bgp_asn_set_resource.go
+++ b/internal/provider/bgp_asn_set_resource.go
@@ -219,25 +219,24 @@ func (r *BGPAsnSetResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -261,6 +260,15 @@ func (r *BGPAsnSetResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateBGPAsnSet(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create BGPAsnSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -470,27 +478,24 @@ func (r *BGPAsnSetResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -514,6 +519,17 @@ func (r *BGPAsnSetResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateBGPAsnSet(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update BGPAsnSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bgp_resource.go
+++ b/internal/provider/bgp_resource.go
@@ -1037,6 +1037,27 @@ func (r *BGPResource) Create(ctx context.Context, req resource.CreateRequest, re
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2252,9 +2273,18 @@ func (r *BGPResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3102,6 +3132,29 @@ func (r *BGPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/bgp_resource.go
+++ b/internal/provider/bgp_resource.go
@@ -1037,25 +1037,24 @@ func (r *BGPResource) Create(ctx context.Context, req resource.CreateRequest, re
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1427,6 +1426,15 @@ func (r *BGPResource) Create(ctx context.Context, req resource.CreateRequest, re
 	apiResource, err := r.client.CreateBGP(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create BGP: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3134,27 +3142,24 @@ func (r *BGPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3526,6 +3531,17 @@ func (r *BGPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	_, err := r.client.UpdateBGP(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update BGP: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bgp_resource.go
+++ b/internal/provider/bgp_resource.go
@@ -3540,6 +3540,13 @@ func (r *BGPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/bgp_routing_policy_resource.go
+++ b/internal/provider/bgp_routing_policy_resource.go
@@ -1248,6 +1248,13 @@ func (r *BGPRoutingPolicyResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/bgp_routing_policy_resource.go
+++ b/internal/provider/bgp_routing_policy_resource.go
@@ -411,6 +411,27 @@ func (r *BGPRoutingPolicyResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -793,9 +814,18 @@ func (r *BGPRoutingPolicyResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1075,6 +1105,29 @@ func (r *BGPRoutingPolicyResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/bgp_routing_policy_resource.go
+++ b/internal/provider/bgp_routing_policy_resource.go
@@ -411,25 +411,24 @@ func (r *BGPRoutingPolicyResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -536,6 +535,15 @@ func (r *BGPRoutingPolicyResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateBGPRoutingPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create BGPRoutingPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1107,27 +1115,24 @@ func (r *BGPRoutingPolicyResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1234,6 +1239,17 @@ func (r *BGPRoutingPolicyResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateBGPRoutingPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update BGPRoutingPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bigip_http_proxy_resource.go
+++ b/internal/provider/bigip_http_proxy_resource.go
@@ -3055,25 +3055,24 @@ func (r *BigIPHTTPProxyResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4111,6 +4110,15 @@ func (r *BigIPHTTPProxyResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateBigIPHTTPProxy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create BigIPHTTPProxy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -8774,27 +8782,24 @@ func (r *BigIPHTTPProxyResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -9832,6 +9837,17 @@ func (r *BigIPHTTPProxyResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateBigIPHTTPProxy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update BigIPHTTPProxy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bigip_http_proxy_resource.go
+++ b/internal/provider/bigip_http_proxy_resource.go
@@ -3055,6 +3055,27 @@ func (r *BigIPHTTPProxyResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6414,9 +6435,18 @@ func (r *BigIPHTTPProxyResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -8742,6 +8772,29 @@ func (r *BigIPHTTPProxyResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/bigip_http_proxy_resource.go
+++ b/internal/provider/bigip_http_proxy_resource.go
@@ -9846,6 +9846,13 @@ func (r *BigIPHTTPProxyResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/bot_defense_app_infrastructure_resource.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource.go
@@ -461,6 +461,27 @@ func (r *BotDefenseAppInfrastructureResource) Create(ctx context.Context, req re
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -855,9 +876,18 @@ func (r *BotDefenseAppInfrastructureResource) Read(ctx context.Context, req reso
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1131,6 +1161,29 @@ func (r *BotDefenseAppInfrastructureResource) Update(ctx context.Context, req re
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/bot_defense_app_infrastructure_resource.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource.go
@@ -461,25 +461,24 @@ func (r *BotDefenseAppInfrastructureResource) Create(ctx context.Context, req re
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -604,6 +603,15 @@ func (r *BotDefenseAppInfrastructureResource) Create(ctx context.Context, req re
 	apiResource, err := r.client.CreateBotDefenseAppInfrastructure(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create BotDefenseAppInfrastructure: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1163,27 +1171,24 @@ func (r *BotDefenseAppInfrastructureResource) Update(ctx context.Context, req re
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1308,6 +1313,17 @@ func (r *BotDefenseAppInfrastructureResource) Update(ctx context.Context, req re
 	_, err := r.client.UpdateBotDefenseAppInfrastructure(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update BotDefenseAppInfrastructure: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bot_defense_app_infrastructure_resource.go
+++ b/internal/provider/bot_defense_app_infrastructure_resource.go
@@ -1322,6 +1322,13 @@ func (r *BotDefenseAppInfrastructureResource) Update(ctx context.Context, req re
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/bot_infrastructure_resource.go
+++ b/internal/provider/bot_infrastructure_resource.go
@@ -741,6 +741,13 @@ func (r *BotInfrastructureResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/bot_infrastructure_resource.go
+++ b/internal/provider/bot_infrastructure_resource.go
@@ -294,25 +294,24 @@ func (r *BotInfrastructureResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -360,6 +359,15 @@ func (r *BotInfrastructureResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateBotInfrastructure(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create BotInfrastructure: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -659,27 +667,24 @@ func (r *BotInfrastructureResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -727,6 +732,17 @@ func (r *BotInfrastructureResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateBotInfrastructure(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update BotInfrastructure: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bot_infrastructure_resource.go
+++ b/internal/provider/bot_infrastructure_resource.go
@@ -294,6 +294,27 @@ func (r *BotInfrastructureResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -481,9 +502,18 @@ func (r *BotInfrastructureResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -627,6 +657,29 @@ func (r *BotInfrastructureResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cdn_cache_rule_resource.go
+++ b/internal/provider/cdn_cache_rule_resource.go
@@ -761,25 +761,24 @@ func (r *CDNCacheRuleResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1041,6 +1040,15 @@ func (r *CDNCacheRuleResource) Create(ctx context.Context, req resource.CreateRe
 	apiResource, err := r.client.CreateCDNCacheRule(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CDNCacheRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2190,27 +2198,24 @@ func (r *CDNCacheRuleResource) Update(ctx context.Context, req resource.UpdateRe
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2472,6 +2477,17 @@ func (r *CDNCacheRuleResource) Update(ctx context.Context, req resource.UpdateRe
 	_, err := r.client.UpdateCDNCacheRule(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CDNCacheRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cdn_cache_rule_resource.go
+++ b/internal/provider/cdn_cache_rule_resource.go
@@ -2486,6 +2486,13 @@ func (r *CDNCacheRuleResource) Update(ctx context.Context, req resource.UpdateRe
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cdn_cache_rule_resource.go
+++ b/internal/provider/cdn_cache_rule_resource.go
@@ -761,6 +761,27 @@ func (r *CDNCacheRuleResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1587,9 +1608,18 @@ func (r *CDNCacheRuleResource) Read(ctx context.Context, req resource.ReadReques
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2158,6 +2188,29 @@ func (r *CDNCacheRuleResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cdn_loadbalancer_resource.go
+++ b/internal/provider/cdn_loadbalancer_resource.go
@@ -12043,25 +12043,24 @@ func (r *CDNLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -17118,6 +17117,15 @@ func (r *CDNLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateCDNLoadBalancer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CDNLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -38217,27 +38225,24 @@ func (r *CDNLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -43294,6 +43299,17 @@ func (r *CDNLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateCDNLoadBalancer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CDNLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cdn_loadbalancer_resource.go
+++ b/internal/provider/cdn_loadbalancer_resource.go
@@ -12043,6 +12043,27 @@ func (r *CDNLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -27639,9 +27660,18 @@ func (r *CDNLoadBalancerResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -38185,6 +38215,29 @@ func (r *CDNLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cdn_loadbalancer_resource.go
+++ b/internal/provider/cdn_loadbalancer_resource.go
@@ -43308,6 +43308,13 @@ func (r *CDNLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cdn_purge_command_resource.go
+++ b/internal/provider/cdn_purge_command_resource.go
@@ -327,6 +327,27 @@ func (r *CDNPurgeCommandResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -500,9 +521,18 @@ func (r *CDNPurgeCommandResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -632,6 +662,29 @@ func (r *CDNPurgeCommandResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cdn_purge_command_resource.go
+++ b/internal/provider/cdn_purge_command_resource.go
@@ -746,6 +746,13 @@ func (r *CDNPurgeCommandResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cdn_purge_command_resource.go
+++ b/internal/provider/cdn_purge_command_resource.go
@@ -327,25 +327,24 @@ func (r *CDNPurgeCommandResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -393,6 +392,15 @@ func (r *CDNPurgeCommandResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateCDNPurgeCommand(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CDNPurgeCommand: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -664,27 +672,24 @@ func (r *CDNPurgeCommandResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -732,6 +737,17 @@ func (r *CDNPurgeCommandResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateCDNPurgeCommand(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CDNPurgeCommand: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/certificate_chain_resource.go
+++ b/internal/provider/certificate_chain_resource.go
@@ -218,6 +218,27 @@ func (r *CertificateChainResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -322,9 +343,18 @@ func (r *CertificateChainResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -413,6 +443,29 @@ func (r *CertificateChainResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/certificate_chain_resource.go
+++ b/internal/provider/certificate_chain_resource.go
@@ -499,6 +499,13 @@ func (r *CertificateChainResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/certificate_chain_resource.go
+++ b/internal/provider/certificate_chain_resource.go
@@ -218,25 +218,24 @@ func (r *CertificateChainResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -256,6 +255,15 @@ func (r *CertificateChainResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateCertificateChain(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CertificateChain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -445,27 +453,24 @@ func (r *CertificateChainResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -485,6 +490,17 @@ func (r *CertificateChainResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateCertificateChain(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CertificateChain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/certificate_resource.go
+++ b/internal/provider/certificate_resource.go
@@ -382,25 +382,24 @@ func (r *CertificateResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -477,6 +476,15 @@ func (r *CertificateResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateCertificate(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Certificate: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -864,27 +872,24 @@ func (r *CertificateResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -961,6 +966,17 @@ func (r *CertificateResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateCertificate(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Certificate: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/certificate_resource.go
+++ b/internal/provider/certificate_resource.go
@@ -382,6 +382,27 @@ func (r *CertificateResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -642,9 +663,18 @@ func (r *CertificateResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -832,6 +862,29 @@ func (r *CertificateResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/certificate_resource.go
+++ b/internal/provider/certificate_resource.go
@@ -975,6 +975,13 @@ func (r *CertificateResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_connect_resource.go
+++ b/internal/provider/cloud_connect_resource.go
@@ -752,6 +752,27 @@ func (r *CloudConnectResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1461,9 +1482,18 @@ func (r *CloudConnectResource) Read(ctx context.Context, req resource.ReadReques
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1951,6 +1981,29 @@ func (r *CloudConnectResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cloud_connect_resource.go
+++ b/internal/provider/cloud_connect_resource.go
@@ -752,25 +752,24 @@ func (r *CloudConnectResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -996,6 +995,15 @@ func (r *CloudConnectResource) Create(ctx context.Context, req resource.CreateRe
 	apiResource, err := r.client.CreateCloudConnect(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CloudConnect: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1983,27 +1991,24 @@ func (r *CloudConnectResource) Update(ctx context.Context, req resource.UpdateRe
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2229,6 +2234,17 @@ func (r *CloudConnectResource) Update(ctx context.Context, req resource.UpdateRe
 	_, err := r.client.UpdateCloudConnect(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CloudConnect: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cloud_connect_resource.go
+++ b/internal/provider/cloud_connect_resource.go
@@ -2243,6 +2243,13 @@ func (r *CloudConnectResource) Update(ctx context.Context, req resource.UpdateRe
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_credentials_resource.go
+++ b/internal/provider/cloud_credentials_resource.go
@@ -746,6 +746,27 @@ func (r *CloudCredentialsResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1377,9 +1398,18 @@ func (r *CloudCredentialsResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1825,6 +1855,29 @@ func (r *CloudCredentialsResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cloud_credentials_resource.go
+++ b/internal/provider/cloud_credentials_resource.go
@@ -746,25 +746,24 @@ func (r *CloudCredentialsResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -954,6 +953,15 @@ func (r *CloudCredentialsResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateCloudCredentials(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CloudCredentials: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1857,27 +1865,24 @@ func (r *CloudCredentialsResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2067,6 +2072,17 @@ func (r *CloudCredentialsResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateCloudCredentials(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CloudCredentials: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cloud_credentials_resource.go
+++ b/internal/provider/cloud_credentials_resource.go
@@ -2081,6 +2081,13 @@ func (r *CloudCredentialsResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_elastic_ip_resource.go
+++ b/internal/provider/cloud_elastic_ip_resource.go
@@ -280,6 +280,27 @@ func (r *CloudElasticIPResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -465,9 +486,18 @@ func (r *CloudElasticIPResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -609,6 +639,29 @@ func (r *CloudElasticIPResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cloud_elastic_ip_resource.go
+++ b/internal/provider/cloud_elastic_ip_resource.go
@@ -723,6 +723,13 @@ func (r *CloudElasticIPResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_elastic_ip_resource.go
+++ b/internal/provider/cloud_elastic_ip_resource.go
@@ -280,25 +280,24 @@ func (r *CloudElasticIPResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -346,6 +345,15 @@ func (r *CloudElasticIPResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateCloudElasticIP(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CloudElasticIP: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -641,27 +649,24 @@ func (r *CloudElasticIPResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -709,6 +714,17 @@ func (r *CloudElasticIPResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateCloudElasticIP(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CloudElasticIP: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cloud_link_resource.go
+++ b/internal/provider/cloud_link_resource.go
@@ -716,25 +716,24 @@ func (r *CloudLinkResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -925,6 +924,15 @@ func (r *CloudLinkResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateCloudLink(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CloudLink: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1782,27 +1790,24 @@ func (r *CloudLinkResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1993,6 +1998,17 @@ func (r *CloudLinkResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateCloudLink(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CloudLink: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cloud_link_resource.go
+++ b/internal/provider/cloud_link_resource.go
@@ -2007,6 +2007,13 @@ func (r *CloudLinkResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cloud_link_resource.go
+++ b/internal/provider/cloud_link_resource.go
@@ -716,6 +716,27 @@ func (r *CloudLinkResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1325,9 +1346,18 @@ func (r *CloudLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1750,6 +1780,29 @@ func (r *CloudLinkResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -4097,6 +4097,13 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -1224,6 +1224,27 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2624,9 +2645,18 @@ func (r *ClusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3576,6 +3606,29 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -1224,25 +1224,24 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1697,6 +1696,15 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 	apiResource, err := r.client.CreateCluster(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Cluster: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3608,27 +3616,24 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4083,6 +4088,17 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	_, err := r.client.UpdateCluster(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Cluster: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cminstance_resource.go
+++ b/internal/provider/cminstance_resource.go
@@ -418,25 +418,24 @@ func (r *CminstanceResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -520,6 +519,15 @@ func (r *CminstanceResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateCminstance(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Cminstance: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -955,27 +963,24 @@ func (r *CminstanceResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1059,6 +1064,17 @@ func (r *CminstanceResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateCminstance(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Cminstance: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/cminstance_resource.go
+++ b/internal/provider/cminstance_resource.go
@@ -418,6 +418,27 @@ func (r *CminstanceResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -709,9 +730,18 @@ func (r *CminstanceResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -923,6 +953,29 @@ func (r *CminstanceResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/cminstance_resource.go
+++ b/internal/provider/cminstance_resource.go
@@ -1073,6 +1073,13 @@ func (r *CminstanceResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/code_base_integration_resource.go
+++ b/internal/provider/code_base_integration_resource.go
@@ -2858,6 +2858,13 @@ func (r *CodeBaseIntegrationResource) Update(ctx context.Context, req resource.U
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/code_base_integration_resource.go
+++ b/internal/provider/code_base_integration_resource.go
@@ -989,25 +989,24 @@ func (r *CodeBaseIntegrationResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1272,6 +1271,15 @@ func (r *CodeBaseIntegrationResource) Create(ctx context.Context, req resource.C
 	apiResource, err := r.client.CreateCodeBaseIntegration(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CodeBaseIntegration: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2559,27 +2567,24 @@ func (r *CodeBaseIntegrationResource) Update(ctx context.Context, req resource.U
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2844,6 +2849,17 @@ func (r *CodeBaseIntegrationResource) Update(ctx context.Context, req resource.U
 	_, err := r.client.UpdateCodeBaseIntegration(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CodeBaseIntegration: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/code_base_integration_resource.go
+++ b/internal/provider/code_base_integration_resource.go
@@ -989,6 +989,27 @@ func (r *CodeBaseIntegrationResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1887,9 +1908,18 @@ func (r *CodeBaseIntegrationResource) Read(ctx context.Context, req resource.Rea
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2527,6 +2557,29 @@ func (r *CodeBaseIntegrationResource) Update(ctx context.Context, req resource.U
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/container_registry_resource.go
+++ b/internal/provider/container_registry_resource.go
@@ -320,6 +320,27 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -521,9 +542,18 @@ func (r *ContainerRegistryResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -676,6 +706,29 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/container_registry_resource.go
+++ b/internal/provider/container_registry_resource.go
@@ -320,25 +320,24 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -391,6 +390,15 @@ func (r *ContainerRegistryResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateContainerRegistry(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ContainerRegistry: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -708,27 +716,24 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -781,6 +786,17 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateContainerRegistry(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ContainerRegistry: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/container_registry_resource.go
+++ b/internal/provider/container_registry_resource.go
@@ -795,6 +795,13 @@ func (r *ContainerRegistryResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/crl_resource.go
+++ b/internal/provider/crl_resource.go
@@ -271,6 +271,27 @@ func (r *CRLResource) Create(ctx context.Context, req resource.CreateRequest, re
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -416,9 +437,18 @@ func (r *CRLResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -532,6 +562,29 @@ func (r *CRLResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/crl_resource.go
+++ b/internal/provider/crl_resource.go
@@ -271,25 +271,24 @@ func (r *CRLResource) Create(ctx context.Context, req resource.CreateRequest, re
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -325,6 +324,15 @@ func (r *CRLResource) Create(ctx context.Context, req resource.CreateRequest, re
 	apiResource, err := r.client.CreateCRL(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create CRL: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -564,27 +572,24 @@ func (r *CRLResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -620,6 +625,17 @@ func (r *CRLResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	_, err := r.client.UpdateCRL(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update CRL: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/crl_resource.go
+++ b/internal/provider/crl_resource.go
@@ -634,6 +634,13 @@ func (r *CRLResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_group_resource.go
+++ b/internal/provider/data_group_resource.go
@@ -274,6 +274,27 @@ func (r *DataGroupResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -430,9 +451,18 @@ func (r *DataGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -555,6 +585,29 @@ func (r *DataGroupResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/data_group_resource.go
+++ b/internal/provider/data_group_resource.go
@@ -274,25 +274,24 @@ func (r *DataGroupResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -330,6 +329,15 @@ func (r *DataGroupResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateDataGroup(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DataGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -587,27 +595,24 @@ func (r *DataGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -645,6 +650,17 @@ func (r *DataGroupResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateDataGroup(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DataGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/data_group_resource.go
+++ b/internal/provider/data_group_resource.go
@@ -659,6 +659,13 @@ func (r *DataGroupResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_type_resource.go
+++ b/internal/provider/data_type_resource.go
@@ -1447,6 +1447,13 @@ func (r *DataTypeResource) Update(ctx context.Context, req resource.UpdateReques
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_type_resource.go
+++ b/internal/provider/data_type_resource.go
@@ -496,25 +496,24 @@ func (r *DataTypeResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -645,6 +644,15 @@ func (r *DataTypeResource) Create(ctx context.Context, req resource.CreateReques
 	apiResource, err := r.client.CreateDataType(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DataType: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1282,27 +1290,24 @@ func (r *DataTypeResource) Update(ctx context.Context, req resource.UpdateReques
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1433,6 +1438,17 @@ func (r *DataTypeResource) Update(ctx context.Context, req resource.UpdateReques
 	_, err := r.client.UpdateDataType(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DataType: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/data_type_resource.go
+++ b/internal/provider/data_type_resource.go
@@ -496,6 +496,27 @@ func (r *DataTypeResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -935,9 +956,18 @@ func (r *DataTypeResource) Read(ctx context.Context, req resource.ReadRequest, r
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1250,6 +1280,29 @@ func (r *DataTypeResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dc_cluster_group_resource.go
+++ b/internal/provider/dc_cluster_group_resource.go
@@ -573,6 +573,13 @@ func (r *DcClusterGroupResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dc_cluster_group_resource.go
+++ b/internal/provider/dc_cluster_group_resource.go
@@ -244,6 +244,27 @@ func (r *DcClusterGroupResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -372,9 +393,18 @@ func (r *DcClusterGroupResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -480,6 +510,29 @@ func (r *DcClusterGroupResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dc_cluster_group_resource.go
+++ b/internal/provider/dc_cluster_group_resource.go
@@ -244,25 +244,24 @@ func (r *DcClusterGroupResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -289,6 +288,15 @@ func (r *DcClusterGroupResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateDcClusterGroup(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DcClusterGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -512,27 +520,24 @@ func (r *DcClusterGroupResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -559,6 +564,17 @@ func (r *DcClusterGroupResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateDcClusterGroup(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DcClusterGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/discovery_resource.go
+++ b/internal/provider/discovery_resource.go
@@ -1241,6 +1241,27 @@ func (r *DiscoveryResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2475,9 +2496,18 @@ func (r *DiscoveryResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3335,6 +3365,29 @@ func (r *DiscoveryResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/discovery_resource.go
+++ b/internal/provider/discovery_resource.go
@@ -1241,25 +1241,24 @@ func (r *DiscoveryResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1640,6 +1639,15 @@ func (r *DiscoveryResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateDiscovery(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Discovery: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3367,27 +3375,24 @@ func (r *DiscoveryResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3768,6 +3773,17 @@ func (r *DiscoveryResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateDiscovery(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Discovery: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/discovery_resource.go
+++ b/internal/provider/discovery_resource.go
@@ -3782,6 +3782,13 @@ func (r *DiscoveryResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_compliance_checks_resource.go
+++ b/internal/provider/dns_compliance_checks_resource.go
@@ -237,25 +237,24 @@ func (r *DNSComplianceChecksResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -293,6 +292,15 @@ func (r *DNSComplianceChecksResource) Create(ctx context.Context, req resource.C
 	apiResource, err := r.client.CreateDNSComplianceChecks(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSComplianceChecks: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -562,27 +570,24 @@ func (r *DNSComplianceChecksResource) Update(ctx context.Context, req resource.U
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -620,6 +625,17 @@ func (r *DNSComplianceChecksResource) Update(ctx context.Context, req resource.U
 	_, err := r.client.UpdateDNSComplianceChecks(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSComplianceChecks: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/dns_compliance_checks_resource.go
+++ b/internal/provider/dns_compliance_checks_resource.go
@@ -237,6 +237,27 @@ func (r *DNSComplianceChecksResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -399,9 +420,18 @@ func (r *DNSComplianceChecksResource) Read(ctx context.Context, req resource.Rea
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -530,6 +560,29 @@ func (r *DNSComplianceChecksResource) Update(ctx context.Context, req resource.U
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_compliance_checks_resource.go
+++ b/internal/provider/dns_compliance_checks_resource.go
@@ -634,6 +634,13 @@ func (r *DNSComplianceChecksResource) Update(ctx context.Context, req resource.U
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_domain_resource.go
+++ b/internal/provider/dns_domain_resource.go
@@ -230,6 +230,27 @@ func (r *DNSDomainResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -340,9 +361,18 @@ func (r *DNSDomainResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -434,6 +464,29 @@ func (r *DNSDomainResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_domain_resource.go
+++ b/internal/provider/dns_domain_resource.go
@@ -523,6 +523,13 @@ func (r *DNSDomainResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_domain_resource.go
+++ b/internal/provider/dns_domain_resource.go
@@ -230,25 +230,24 @@ func (r *DNSDomainResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -271,6 +270,15 @@ func (r *DNSDomainResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateDNSDomain(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -466,27 +474,24 @@ func (r *DNSDomainResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -509,6 +514,17 @@ func (r *DNSDomainResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateDNSDomain(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/dns_lb_health_check_resource.go
+++ b/internal/provider/dns_lb_health_check_resource.go
@@ -506,6 +506,27 @@ func (r *DNSLBHealthCheckResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -900,9 +921,18 @@ func (r *DNSLBHealthCheckResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1189,6 +1219,29 @@ func (r *DNSLBHealthCheckResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_lb_health_check_resource.go
+++ b/internal/provider/dns_lb_health_check_resource.go
@@ -506,25 +506,24 @@ func (r *DNSLBHealthCheckResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -636,6 +635,15 @@ func (r *DNSLBHealthCheckResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateDNSLBHealthCheck(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSLBHealthCheck: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1221,27 +1229,24 @@ func (r *DNSLBHealthCheckResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1353,6 +1358,17 @@ func (r *DNSLBHealthCheckResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateDNSLBHealthCheck(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSLBHealthCheck: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/dns_lb_health_check_resource.go
+++ b/internal/provider/dns_lb_health_check_resource.go
@@ -1367,6 +1367,13 @@ func (r *DNSLBHealthCheckResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_lb_pool_resource.go
+++ b/internal/provider/dns_lb_pool_resource.go
@@ -771,25 +771,24 @@ func (r *DNSLBPoolResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1022,6 +1021,15 @@ func (r *DNSLBPoolResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateDNSLBPool(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSLBPool: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2007,27 +2015,24 @@ func (r *DNSLBPoolResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2260,6 +2265,17 @@ func (r *DNSLBPoolResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateDNSLBPool(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSLBPool: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/dns_lb_pool_resource.go
+++ b/internal/provider/dns_lb_pool_resource.go
@@ -771,6 +771,27 @@ func (r *DNSLBPoolResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1486,9 +1507,18 @@ func (r *DNSLBPoolResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1975,6 +2005,29 @@ func (r *DNSLBPoolResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_lb_pool_resource.go
+++ b/internal/provider/dns_lb_pool_resource.go
@@ -2274,6 +2274,13 @@ func (r *DNSLBPoolResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_load_balancer_resource.go
+++ b/internal/provider/dns_load_balancer_resource.go
@@ -712,6 +712,27 @@ func (r *DNSLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1360,9 +1381,18 @@ func (r *DNSLoadBalancerResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1810,6 +1840,29 @@ func (r *DNSLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_load_balancer_resource.go
+++ b/internal/provider/dns_load_balancer_resource.go
@@ -2081,6 +2081,13 @@ func (r *DNSLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_load_balancer_resource.go
+++ b/internal/provider/dns_load_balancer_resource.go
@@ -712,25 +712,24 @@ func (r *DNSLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -935,6 +934,15 @@ func (r *DNSLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateDNSLoadBalancer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1842,27 +1850,24 @@ func (r *DNSLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2067,6 +2072,17 @@ func (r *DNSLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateDNSLoadBalancer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/dns_proxy_resource.go
+++ b/internal/provider/dns_proxy_resource.go
@@ -4569,6 +4569,13 @@ func (r *DNSProxyResource) Update(ctx context.Context, req resource.UpdateReques
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_proxy_resource.go
+++ b/internal/provider/dns_proxy_resource.go
@@ -1576,6 +1576,27 @@ func (r *DNSProxyResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -3036,9 +3057,18 @@ func (r *DNSProxyResource) Read(ctx context.Context, req resource.ReadRequest, r
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -4032,6 +4062,29 @@ func (r *DNSProxyResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_proxy_resource.go
+++ b/internal/provider/dns_proxy_resource.go
@@ -1576,25 +1576,24 @@ func (r *DNSProxyResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2065,6 +2064,15 @@ func (r *DNSProxyResource) Create(ctx context.Context, req resource.CreateReques
 	apiResource, err := r.client.CreateDNSProxy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSProxy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -4064,27 +4072,24 @@ func (r *DNSProxyResource) Update(ctx context.Context, req resource.UpdateReques
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4555,6 +4560,17 @@ func (r *DNSProxyResource) Update(ctx context.Context, req resource.UpdateReques
 	_, err := r.client.UpdateDNSProxy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSProxy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/dns_zone_resource.go
+++ b/internal/provider/dns_zone_resource.go
@@ -10558,6 +10558,13 @@ func (r *DNSZoneResource) Update(ctx context.Context, req resource.UpdateRequest
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/dns_zone_resource.go
+++ b/internal/provider/dns_zone_resource.go
@@ -3365,6 +3365,27 @@ func (r *DNSZoneResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6925,9 +6946,18 @@ func (r *DNSZoneResource) Read(ctx context.Context, req resource.ReadRequest, re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -9273,6 +9303,29 @@ func (r *DNSZoneResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/dns_zone_resource.go
+++ b/internal/provider/dns_zone_resource.go
@@ -3365,25 +3365,24 @@ func (r *DNSZoneResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4602,6 +4601,15 @@ func (r *DNSZoneResource) Create(ctx context.Context, req resource.CreateRequest
 	apiResource, err := r.client.CreateDNSZone(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create DNSZone: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -9305,27 +9313,24 @@ func (r *DNSZoneResource) Update(ctx context.Context, req resource.UpdateRequest
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -10544,6 +10549,17 @@ func (r *DNSZoneResource) Update(ctx context.Context, req resource.UpdateRequest
 	_, err := r.client.UpdateDNSZone(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update DNSZone: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -499,6 +499,13 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -218,25 +218,24 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -256,6 +255,15 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResource, err := r.client.CreateDomain(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Domain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -445,27 +453,24 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -485,6 +490,17 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	_, err := r.client.UpdateDomain(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Domain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -218,6 +218,27 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -322,9 +343,18 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -413,6 +443,29 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/endpoint_resource.go
+++ b/internal/provider/endpoint_resource.go
@@ -679,6 +679,27 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1305,9 +1326,18 @@ func (r *EndpointResource) Read(ctx context.Context, req resource.ReadRequest, r
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1739,6 +1769,29 @@ func (r *EndpointResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/endpoint_resource.go
+++ b/internal/provider/endpoint_resource.go
@@ -2004,6 +2004,13 @@ func (r *EndpointResource) Update(ctx context.Context, req resource.UpdateReques
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/endpoint_resource.go
+++ b/internal/provider/endpoint_resource.go
@@ -679,25 +679,24 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -896,6 +895,15 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 	apiResource, err := r.client.CreateEndpoint(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Endpoint: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1771,27 +1779,24 @@ func (r *EndpointResource) Update(ctx context.Context, req resource.UpdateReques
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1990,6 +1995,17 @@ func (r *EndpointResource) Update(ctx context.Context, req resource.UpdateReques
 	_, err := r.client.UpdateEndpoint(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Endpoint: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/enhanced_firewall_policy_resource.go
+++ b/internal/provider/enhanced_firewall_policy_resource.go
@@ -912,25 +912,24 @@ func (r *EnhancedFirewallPolicyResource) Create(ctx context.Context, req resourc
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1253,6 +1252,15 @@ func (r *EnhancedFirewallPolicyResource) Create(ctx context.Context, req resourc
 	apiResource, err := r.client.CreateEnhancedFirewallPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create EnhancedFirewallPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2602,27 +2610,24 @@ func (r *EnhancedFirewallPolicyResource) Update(ctx context.Context, req resourc
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2945,6 +2950,17 @@ func (r *EnhancedFirewallPolicyResource) Update(ctx context.Context, req resourc
 	_, err := r.client.UpdateEnhancedFirewallPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update EnhancedFirewallPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/enhanced_firewall_policy_resource.go
+++ b/internal/provider/enhanced_firewall_policy_resource.go
@@ -912,6 +912,27 @@ func (r *EnhancedFirewallPolicyResource) Create(ctx context.Context, req resourc
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1899,9 +1920,18 @@ func (r *EnhancedFirewallPolicyResource) Read(ctx context.Context, req resource.
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2570,6 +2600,29 @@ func (r *EnhancedFirewallPolicyResource) Update(ctx context.Context, req resourc
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/enhanced_firewall_policy_resource.go
+++ b/internal/provider/enhanced_firewall_policy_resource.go
@@ -2959,6 +2959,13 @@ func (r *EnhancedFirewallPolicyResource) Update(ctx context.Context, req resourc
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/external_connector_resource.go
+++ b/internal/provider/external_connector_resource.go
@@ -2672,6 +2672,13 @@ func (r *ExternalConnectorResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/external_connector_resource.go
+++ b/internal/provider/external_connector_resource.go
@@ -875,6 +875,27 @@ func (r *ExternalConnectorResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1737,9 +1758,18 @@ func (r *ExternalConnectorResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2338,6 +2368,29 @@ func (r *ExternalConnectorResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/external_connector_resource.go
+++ b/internal/provider/external_connector_resource.go
@@ -875,25 +875,24 @@ func (r *ExternalConnectorResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1161,6 +1160,15 @@ func (r *ExternalConnectorResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateExternalConnector(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ExternalConnector: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2370,27 +2378,24 @@ func (r *ExternalConnectorResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2658,6 +2663,17 @@ func (r *ExternalConnectorResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateExternalConnector(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ExternalConnector: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/fast_acl_resource.go
+++ b/internal/provider/fast_acl_resource.go
@@ -3639,6 +3639,13 @@ func (r *FastACLResource) Update(ctx context.Context, req resource.UpdateRequest
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/fast_acl_resource.go
+++ b/internal/provider/fast_acl_resource.go
@@ -1110,25 +1110,24 @@ func (r *FastACLResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1534,6 +1533,15 @@ func (r *FastACLResource) Create(ctx context.Context, req resource.CreateRequest
 	apiResource, err := r.client.CreateFastACL(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create FastACL: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3199,27 +3207,24 @@ func (r *FastACLResource) Update(ctx context.Context, req resource.UpdateRequest
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3625,6 +3630,17 @@ func (r *FastACLResource) Update(ctx context.Context, req resource.UpdateRequest
 	_, err := r.client.UpdateFastACL(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update FastACL: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/fast_acl_resource.go
+++ b/internal/provider/fast_acl_resource.go
@@ -1110,6 +1110,27 @@ func (r *FastACLResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2338,9 +2359,18 @@ func (r *FastACLResource) Read(ctx context.Context, req resource.ReadRequest, re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3167,6 +3197,29 @@ func (r *FastACLResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/fast_acl_rule_resource.go
+++ b/internal/provider/fast_acl_rule_resource.go
@@ -521,25 +521,24 @@ func (r *FastACLRuleResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -692,6 +691,15 @@ func (r *FastACLRuleResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateFastACLRule(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create FastACLRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1367,27 +1375,24 @@ func (r *FastACLRuleResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1540,6 +1545,17 @@ func (r *FastACLRuleResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateFastACLRule(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update FastACLRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/fast_acl_rule_resource.go
+++ b/internal/provider/fast_acl_rule_resource.go
@@ -1554,6 +1554,13 @@ func (r *FastACLRuleResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/fast_acl_rule_resource.go
+++ b/internal/provider/fast_acl_rule_resource.go
@@ -521,6 +521,27 @@ func (r *FastACLRuleResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1001,9 +1022,18 @@ func (r *FastACLRuleResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1335,6 +1365,29 @@ func (r *FastACLRuleResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/filter_set_resource.go
+++ b/internal/provider/filter_set_resource.go
@@ -336,25 +336,24 @@ func (r *FilterSetResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -425,6 +424,15 @@ func (r *FilterSetResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateFilterSet(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create FilterSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -808,27 +816,24 @@ func (r *FilterSetResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -899,6 +904,17 @@ func (r *FilterSetResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateFilterSet(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update FilterSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/filter_set_resource.go
+++ b/internal/provider/filter_set_resource.go
@@ -336,6 +336,27 @@ func (r *FilterSetResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -588,9 +609,18 @@ func (r *FilterSetResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -776,6 +806,29 @@ func (r *FilterSetResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/filter_set_resource.go
+++ b/internal/provider/filter_set_resource.go
@@ -913,6 +913,13 @@ func (r *FilterSetResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/fleet_resource.go
+++ b/internal/provider/fleet_resource.go
@@ -3978,25 +3978,24 @@ func (r *FleetResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -5497,6 +5496,15 @@ func (r *FleetResource) Create(ctx context.Context, req resource.CreateRequest, 
 	apiResource, err := r.client.CreateFleet(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Fleet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -11748,27 +11756,24 @@ func (r *FleetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -13269,6 +13274,17 @@ func (r *FleetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	_, err := r.client.UpdateFleet(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Fleet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/fleet_resource.go
+++ b/internal/provider/fleet_resource.go
@@ -3978,6 +3978,27 @@ func (r *FleetResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -8594,9 +8615,18 @@ func (r *FleetResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -11716,6 +11746,29 @@ func (r *FleetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/fleet_resource.go
+++ b/internal/provider/fleet_resource.go
@@ -13283,6 +13283,13 @@ func (r *FleetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/forward_proxy_policy_resource.go
+++ b/internal/provider/forward_proxy_policy_resource.go
@@ -4138,6 +4138,13 @@ func (r *ForwardProxyPolicyResource) Update(ctx context.Context, req resource.Up
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/forward_proxy_policy_resource.go
+++ b/internal/provider/forward_proxy_policy_resource.go
@@ -1257,25 +1257,24 @@ func (r *ForwardProxyPolicyResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1745,6 +1744,15 @@ func (r *ForwardProxyPolicyResource) Create(ctx context.Context, req resource.Cr
 	apiResource, err := r.client.CreateForwardProxyPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ForwardProxyPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3634,27 +3642,24 @@ func (r *ForwardProxyPolicyResource) Update(ctx context.Context, req resource.Up
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4124,6 +4129,17 @@ func (r *ForwardProxyPolicyResource) Update(ctx context.Context, req resource.Up
 	_, err := r.client.UpdateForwardProxyPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ForwardProxyPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/forward_proxy_policy_resource.go
+++ b/internal/provider/forward_proxy_policy_resource.go
@@ -1257,6 +1257,27 @@ func (r *ForwardProxyPolicyResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2661,9 +2682,18 @@ func (r *ForwardProxyPolicyResource) Read(ctx context.Context, req resource.Read
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3602,6 +3632,29 @@ func (r *ForwardProxyPolicyResource) Update(ctx context.Context, req resource.Up
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/forwarding_class_resource.go
+++ b/internal/provider/forwarding_class_resource.go
@@ -334,25 +334,24 @@ func (r *ForwardingClassResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -410,6 +409,15 @@ func (r *ForwardingClassResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateForwardingClass(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ForwardingClass: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -713,27 +721,24 @@ func (r *ForwardingClassResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -791,6 +796,17 @@ func (r *ForwardingClassResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateForwardingClass(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ForwardingClass: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/forwarding_class_resource.go
+++ b/internal/provider/forwarding_class_resource.go
@@ -334,6 +334,27 @@ func (r *ForwardingClassResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -533,9 +554,18 @@ func (r *ForwardingClassResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -681,6 +711,29 @@ func (r *ForwardingClassResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/forwarding_class_resource.go
+++ b/internal/provider/forwarding_class_resource.go
@@ -805,6 +805,13 @@ func (r *ForwardingClassResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/gcp_vpc_site_resource.go
+++ b/internal/provider/gcp_vpc_site_resource.go
@@ -11473,6 +11473,13 @@ func (r *GCPVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/gcp_vpc_site_resource.go
+++ b/internal/provider/gcp_vpc_site_resource.go
@@ -3603,6 +3603,27 @@ func (r *GCPVPCSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -7491,9 +7512,18 @@ func (r *GCPVPCSiteResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -10115,6 +10145,29 @@ func (r *GCPVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/gcp_vpc_site_resource.go
+++ b/internal/provider/gcp_vpc_site_resource.go
@@ -3603,25 +3603,24 @@ func (r *GCPVPCSiteResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -4892,6 +4891,15 @@ func (r *GCPVPCSiteResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateGCPVPCSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create GCPVPCSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -10147,27 +10155,24 @@ func (r *GCPVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -11459,6 +11464,17 @@ func (r *GCPVPCSiteResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateGCPVPCSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update GCPVPCSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/geo_location_set_resource.go
+++ b/internal/provider/geo_location_set_resource.go
@@ -581,6 +581,13 @@ func (r *GeoLocationSetResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/geo_location_set_resource.go
+++ b/internal/provider/geo_location_set_resource.go
@@ -248,25 +248,24 @@ func (r *GeoLocationSetResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -297,6 +296,15 @@ func (r *GeoLocationSetResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateGeoLocationSet(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create GeoLocationSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -516,27 +524,24 @@ func (r *GeoLocationSetResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -567,6 +572,17 @@ func (r *GeoLocationSetResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateGeoLocationSet(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update GeoLocationSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/geo_location_set_resource.go
+++ b/internal/provider/geo_location_set_resource.go
@@ -248,6 +248,27 @@ func (r *GeoLocationSetResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -378,9 +399,18 @@ func (r *GeoLocationSetResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -484,6 +514,29 @@ func (r *GeoLocationSetResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/global_log_receiver_resource.go
+++ b/internal/provider/global_log_receiver_resource.go
@@ -3212,6 +3212,27 @@ func (r *GlobalLogReceiverResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6955,9 +6976,18 @@ func (r *GlobalLogReceiverResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -9613,6 +9643,29 @@ func (r *GlobalLogReceiverResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/global_log_receiver_resource.go
+++ b/internal/provider/global_log_receiver_resource.go
@@ -10771,6 +10771,13 @@ func (r *GlobalLogReceiverResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/global_log_receiver_resource.go
+++ b/internal/provider/global_log_receiver_resource.go
@@ -3212,25 +3212,24 @@ func (r *GlobalLogReceiverResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4322,6 +4321,15 @@ func (r *GlobalLogReceiverResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateGlobalLogReceiver(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create GlobalLogReceiver: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -9645,27 +9653,24 @@ func (r *GlobalLogReceiverResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -10757,6 +10762,17 @@ func (r *GlobalLogReceiverResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateGlobalLogReceiver(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update GlobalLogReceiver: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/healthcheck_resource.go
+++ b/internal/provider/healthcheck_resource.go
@@ -392,25 +392,24 @@ func (r *HealthcheckResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -491,6 +490,15 @@ func (r *HealthcheckResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateHealthcheck(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Healthcheck: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -922,27 +930,24 @@ func (r *HealthcheckResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1023,6 +1028,17 @@ func (r *HealthcheckResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateHealthcheck(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Healthcheck: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/healthcheck_resource.go
+++ b/internal/provider/healthcheck_resource.go
@@ -1037,6 +1037,13 @@ func (r *HealthcheckResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/healthcheck_resource.go
+++ b/internal/provider/healthcheck_resource.go
@@ -392,6 +392,27 @@ func (r *HealthcheckResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -678,9 +699,18 @@ func (r *HealthcheckResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -890,6 +920,29 @@ func (r *HealthcheckResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/http_loadbalancer_resource.go
+++ b/internal/provider/http_loadbalancer_resource.go
@@ -22458,25 +22458,24 @@ func (r *HTTPLoadBalancerResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -31669,6 +31668,15 @@ func (r *HTTPLoadBalancerResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateHTTPLoadBalancer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create HTTPLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -70611,27 +70619,24 @@ func (r *HTTPLoadBalancerResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -79824,6 +79829,17 @@ func (r *HTTPLoadBalancerResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateHTTPLoadBalancer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update HTTPLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/http_loadbalancer_resource.go
+++ b/internal/provider/http_loadbalancer_resource.go
@@ -22458,6 +22458,27 @@ func (r *HTTPLoadBalancerResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -51103,9 +51124,18 @@ func (r *HTTPLoadBalancerResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -70579,6 +70609,29 @@ func (r *HTTPLoadBalancerResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/http_loadbalancer_resource.go
+++ b/internal/provider/http_loadbalancer_resource.go
@@ -79838,6 +79838,13 @@ func (r *HTTPLoadBalancerResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ike1_resource.go
+++ b/internal/provider/ike1_resource.go
@@ -315,25 +315,24 @@ func (r *Ike1Resource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -384,6 +383,15 @@ func (r *Ike1Resource) Create(ctx context.Context, req resource.CreateRequest, r
 	apiResource, err := r.client.CreateIke1(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Ike1: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -679,27 +687,24 @@ func (r *Ike1Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -750,6 +755,17 @@ func (r *Ike1Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 	_, err := r.client.UpdateIke1(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Ike1: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/ike1_resource.go
+++ b/internal/provider/ike1_resource.go
@@ -315,6 +315,27 @@ func (r *Ike1Resource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -503,9 +524,18 @@ func (r *Ike1Resource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -647,6 +677,29 @@ func (r *Ike1Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/ike1_resource.go
+++ b/internal/provider/ike1_resource.go
@@ -764,6 +764,13 @@ func (r *Ike1Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ike2_resource.go
+++ b/internal/provider/ike2_resource.go
@@ -715,6 +715,13 @@ func (r *Ike2Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ike2_resource.go
+++ b/internal/provider/ike2_resource.go
@@ -290,6 +290,27 @@ func (r *Ike2Resource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -466,9 +487,18 @@ func (r *Ike2Resource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -601,6 +631,29 @@ func (r *Ike2Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/ike2_resource.go
+++ b/internal/provider/ike2_resource.go
@@ -290,25 +290,24 @@ func (r *Ike2Resource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -356,6 +355,15 @@ func (r *Ike2Resource) Create(ctx context.Context, req resource.CreateRequest, r
 	apiResource, err := r.client.CreateIke2(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Ike2: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -633,27 +641,24 @@ func (r *Ike2Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -701,6 +706,17 @@ func (r *Ike2Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 	_, err := r.client.UpdateIke2(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Ike2: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/ike_phase1_profile_resource.go
+++ b/internal/provider/ike_phase1_profile_resource.go
@@ -339,25 +339,24 @@ func (r *IKEPhase1ProfileResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -436,6 +435,15 @@ func (r *IKEPhase1ProfileResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateIKEPhase1Profile(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create IKEPhase1Profile: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -851,27 +859,24 @@ func (r *IKEPhase1ProfileResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -950,6 +955,17 @@ func (r *IKEPhase1ProfileResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateIKEPhase1Profile(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update IKEPhase1Profile: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/ike_phase1_profile_resource.go
+++ b/internal/provider/ike_phase1_profile_resource.go
@@ -964,6 +964,13 @@ func (r *IKEPhase1ProfileResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ike_phase1_profile_resource.go
+++ b/internal/provider/ike_phase1_profile_resource.go
@@ -339,6 +339,27 @@ func (r *IKEPhase1ProfileResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -615,9 +636,18 @@ func (r *IKEPhase1ProfileResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -819,6 +849,29 @@ func (r *IKEPhase1ProfileResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/ike_phase2_profile_resource.go
+++ b/internal/provider/ike_phase2_profile_resource.go
@@ -302,25 +302,24 @@ func (r *IKEPhase2ProfileResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -382,6 +381,15 @@ func (r *IKEPhase2ProfileResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateIKEPhase2Profile(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create IKEPhase2Profile: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -719,27 +727,24 @@ func (r *IKEPhase2ProfileResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -801,6 +806,17 @@ func (r *IKEPhase2ProfileResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateIKEPhase2Profile(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update IKEPhase2Profile: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/ike_phase2_profile_resource.go
+++ b/internal/provider/ike_phase2_profile_resource.go
@@ -302,6 +302,27 @@ func (r *IKEPhase2ProfileResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -522,9 +543,18 @@ func (r *IKEPhase2ProfileResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -687,6 +717,29 @@ func (r *IKEPhase2ProfileResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/ike_phase2_profile_resource.go
+++ b/internal/provider/ike_phase2_profile_resource.go
@@ -815,6 +815,13 @@ func (r *IKEPhase2ProfileResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ip_prefix_set_resource.go
+++ b/internal/provider/ip_prefix_set_resource.go
@@ -246,6 +246,27 @@ func (r *IPPrefixSetResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -396,9 +417,18 @@ func (r *IPPrefixSetResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -517,6 +547,29 @@ func (r *IPPrefixSetResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/ip_prefix_set_resource.go
+++ b/internal/provider/ip_prefix_set_resource.go
@@ -246,25 +246,24 @@ func (r *IPPrefixSetResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -300,6 +299,15 @@ func (r *IPPrefixSetResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateIPPrefixSet(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create IPPrefixSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -549,27 +557,24 @@ func (r *IPPrefixSetResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -605,6 +610,17 @@ func (r *IPPrefixSetResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateIPPrefixSet(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update IPPrefixSet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/ip_prefix_set_resource.go
+++ b/internal/provider/ip_prefix_set_resource.go
@@ -619,6 +619,13 @@ func (r *IPPrefixSetResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/irule_resource.go
+++ b/internal/provider/irule_resource.go
@@ -226,6 +226,27 @@ func (r *IruleResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -338,9 +359,18 @@ func (r *IruleResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -434,6 +464,29 @@ func (r *IruleResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/irule_resource.go
+++ b/internal/provider/irule_resource.go
@@ -523,6 +523,13 @@ func (r *IruleResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/irule_resource.go
+++ b/internal/provider/irule_resource.go
@@ -226,25 +226,24 @@ func (r *IruleResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -267,6 +266,15 @@ func (r *IruleResource) Create(ctx context.Context, req resource.CreateRequest, 
 	apiResource, err := r.client.CreateIrule(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Irule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -466,27 +474,24 @@ func (r *IruleResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -509,6 +514,17 @@ func (r *IruleResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	_, err := r.client.UpdateIrule(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Irule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/k8s_cluster_resource.go
+++ b/internal/provider/k8s_cluster_resource.go
@@ -2253,6 +2253,13 @@ func (r *K8SClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/k8s_cluster_resource.go
+++ b/internal/provider/k8s_cluster_resource.go
@@ -756,6 +756,27 @@ func (r *K8SClusterResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1468,9 +1489,18 @@ func (r *K8SClusterResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1946,6 +1976,29 @@ func (r *K8SClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/k8s_cluster_resource.go
+++ b/internal/provider/k8s_cluster_resource.go
@@ -756,25 +756,24 @@ func (r *K8SClusterResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1015,6 +1014,15 @@ func (r *K8SClusterResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateK8SCluster(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create K8SCluster: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1978,27 +1986,24 @@ func (r *K8SClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2239,6 +2244,17 @@ func (r *K8SClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateK8SCluster(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update K8SCluster: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/k8s_cluster_role_binding_resource.go
+++ b/internal/provider/k8s_cluster_role_binding_resource.go
@@ -337,6 +337,27 @@ func (r *K8SClusterRoleBindingResource) Create(ctx context.Context, req resource
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -551,9 +572,18 @@ func (r *K8SClusterRoleBindingResource) Read(ctx context.Context, req resource.R
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -713,6 +743,29 @@ func (r *K8SClusterRoleBindingResource) Update(ctx context.Context, req resource
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/k8s_cluster_role_binding_resource.go
+++ b/internal/provider/k8s_cluster_role_binding_resource.go
@@ -838,6 +838,13 @@ func (r *K8SClusterRoleBindingResource) Update(ctx context.Context, req resource
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/k8s_cluster_role_binding_resource.go
+++ b/internal/provider/k8s_cluster_role_binding_resource.go
@@ -337,25 +337,24 @@ func (r *K8SClusterRoleBindingResource) Create(ctx context.Context, req resource
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -414,6 +413,15 @@ func (r *K8SClusterRoleBindingResource) Create(ctx context.Context, req resource
 	apiResource, err := r.client.CreateK8SClusterRoleBinding(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create K8SClusterRoleBinding: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -745,27 +753,24 @@ func (r *K8SClusterRoleBindingResource) Update(ctx context.Context, req resource
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -824,6 +829,17 @@ func (r *K8SClusterRoleBindingResource) Update(ctx context.Context, req resource
 	_, err := r.client.UpdateK8SClusterRoleBinding(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update K8SClusterRoleBinding: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/k8s_cluster_role_resource.go
+++ b/internal/provider/k8s_cluster_role_resource.go
@@ -379,6 +379,27 @@ func (r *K8SClusterRoleResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -696,9 +717,18 @@ func (r *K8SClusterRoleResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -922,6 +952,29 @@ func (r *K8SClusterRoleResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/k8s_cluster_role_resource.go
+++ b/internal/provider/k8s_cluster_role_resource.go
@@ -1086,6 +1086,13 @@ func (r *K8SClusterRoleResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/k8s_cluster_role_resource.go
+++ b/internal/provider/k8s_cluster_role_resource.go
@@ -379,25 +379,24 @@ func (r *K8SClusterRoleResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -495,6 +494,15 @@ func (r *K8SClusterRoleResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateK8SClusterRole(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create K8SClusterRole: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -954,27 +962,24 @@ func (r *K8SClusterRoleResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1072,6 +1077,17 @@ func (r *K8SClusterRoleResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateK8SClusterRole(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update K8SClusterRole: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/k8s_pod_security_admission_resource.go
+++ b/internal/provider/k8s_pod_security_admission_resource.go
@@ -261,6 +261,27 @@ func (r *K8SPodSecurityAdmissionResource) Create(ctx context.Context, req resour
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -465,9 +486,18 @@ func (r *K8SPodSecurityAdmissionResource) Read(ctx context.Context, req resource
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -628,6 +658,29 @@ func (r *K8SPodSecurityAdmissionResource) Update(ctx context.Context, req resour
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/k8s_pod_security_admission_resource.go
+++ b/internal/provider/k8s_pod_security_admission_resource.go
@@ -742,6 +742,13 @@ func (r *K8SPodSecurityAdmissionResource) Update(ctx context.Context, req resour
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/k8s_pod_security_admission_resource.go
+++ b/internal/provider/k8s_pod_security_admission_resource.go
@@ -261,25 +261,24 @@ func (r *K8SPodSecurityAdmissionResource) Create(ctx context.Context, req resour
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -327,6 +326,15 @@ func (r *K8SPodSecurityAdmissionResource) Create(ctx context.Context, req resour
 	apiResource, err := r.client.CreateK8SPodSecurityAdmission(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create K8SPodSecurityAdmission: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -660,27 +668,24 @@ func (r *K8SPodSecurityAdmissionResource) Update(ctx context.Context, req resour
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -728,6 +733,17 @@ func (r *K8SPodSecurityAdmissionResource) Update(ctx context.Context, req resour
 	_, err := r.client.UpdateK8SPodSecurityAdmission(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update K8SPodSecurityAdmission: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/k8s_pod_security_policy_resource.go
+++ b/internal/provider/k8s_pod_security_policy_resource.go
@@ -749,6 +749,27 @@ func (r *K8SPodSecurityPolicyResource) Create(ctx context.Context, req resource.
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1641,9 +1662,18 @@ func (r *K8SPodSecurityPolicyResource) Read(ctx context.Context, req resource.Re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2267,6 +2297,29 @@ func (r *K8SPodSecurityPolicyResource) Update(ctx context.Context, req resource.
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/k8s_pod_security_policy_resource.go
+++ b/internal/provider/k8s_pod_security_policy_resource.go
@@ -749,25 +749,24 @@ func (r *K8SPodSecurityPolicyResource) Create(ctx context.Context, req resource.
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1040,6 +1039,15 @@ func (r *K8SPodSecurityPolicyResource) Create(ctx context.Context, req resource.
 	apiResource, err := r.client.CreateK8SPodSecurityPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create K8SPodSecurityPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2299,27 +2307,24 @@ func (r *K8SPodSecurityPolicyResource) Update(ctx context.Context, req resource.
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2592,6 +2597,17 @@ func (r *K8SPodSecurityPolicyResource) Update(ctx context.Context, req resource.
 	_, err := r.client.UpdateK8SPodSecurityPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update K8SPodSecurityPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/k8s_pod_security_policy_resource.go
+++ b/internal/provider/k8s_pod_security_policy_resource.go
@@ -2606,6 +2606,13 @@ func (r *K8SPodSecurityPolicyResource) Update(ctx context.Context, req resource.
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/log_receiver_resource.go
+++ b/internal/provider/log_receiver_resource.go
@@ -483,25 +483,24 @@ func (r *LogReceiverResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -607,6 +606,15 @@ func (r *LogReceiverResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateLogReceiver(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create LogReceiver: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1204,27 +1212,24 @@ func (r *LogReceiverResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1330,6 +1335,17 @@ func (r *LogReceiverResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateLogReceiver(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update LogReceiver: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/log_receiver_resource.go
+++ b/internal/provider/log_receiver_resource.go
@@ -1344,6 +1344,13 @@ func (r *LogReceiverResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/log_receiver_resource.go
+++ b/internal/provider/log_receiver_resource.go
@@ -483,6 +483,27 @@ func (r *LogReceiverResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -877,9 +898,18 @@ func (r *LogReceiverResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1172,6 +1202,29 @@ func (r *LogReceiverResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/malicious_user_mitigation_resource.go
+++ b/internal/provider/malicious_user_mitigation_resource.go
@@ -848,6 +848,13 @@ func (r *MaliciousUserMitigationResource) Update(ctx context.Context, req resour
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/malicious_user_mitigation_resource.go
+++ b/internal/provider/malicious_user_mitigation_resource.go
@@ -309,6 +309,27 @@ func (r *MaliciousUserMitigationResource) Create(ctx context.Context, req resour
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -542,9 +563,18 @@ func (r *MaliciousUserMitigationResource) Read(ctx context.Context, req resource
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -722,6 +752,29 @@ func (r *MaliciousUserMitigationResource) Update(ctx context.Context, req resour
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/malicious_user_mitigation_resource.go
+++ b/internal/provider/malicious_user_mitigation_resource.go
@@ -309,25 +309,24 @@ func (r *MaliciousUserMitigationResource) Create(ctx context.Context, req resour
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -387,6 +386,15 @@ func (r *MaliciousUserMitigationResource) Create(ctx context.Context, req resour
 	apiResource, err := r.client.CreateMaliciousUserMitigation(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create MaliciousUserMitigation: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -754,27 +762,24 @@ func (r *MaliciousUserMitigationResource) Update(ctx context.Context, req resour
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -834,6 +839,17 @@ func (r *MaliciousUserMitigationResource) Update(ctx context.Context, req resour
 	_, err := r.client.UpdateMaliciousUserMitigation(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update MaliciousUserMitigation: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/mitigated_domain_resource.go
+++ b/internal/provider/mitigated_domain_resource.go
@@ -235,6 +235,27 @@ func (r *MitigatedDomainResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -339,9 +360,18 @@ func (r *MitigatedDomainResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -430,6 +460,29 @@ func (r *MitigatedDomainResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/mitigated_domain_resource.go
+++ b/internal/provider/mitigated_domain_resource.go
@@ -235,25 +235,24 @@ func (r *MitigatedDomainResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -273,6 +272,15 @@ func (r *MitigatedDomainResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateMitigatedDomain(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create MitigatedDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -462,27 +470,24 @@ func (r *MitigatedDomainResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -502,6 +507,17 @@ func (r *MitigatedDomainResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateMitigatedDomain(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update MitigatedDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/mitigated_domain_resource.go
+++ b/internal/provider/mitigated_domain_resource.go
@@ -516,6 +516,13 @@ func (r *MitigatedDomainResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -210,25 +210,24 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -245,6 +244,15 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateNamespace(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Namespace: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -426,27 +434,24 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -463,6 +468,17 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateNamespace(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Namespace: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -477,6 +477,13 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -210,6 +210,27 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -308,9 +329,18 @@ func (r *NamespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -394,6 +424,29 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/nat_policy_resource.go
+++ b/internal/provider/nat_policy_resource.go
@@ -1018,25 +1018,24 @@ func (r *NATPolicyResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1395,6 +1394,15 @@ func (r *NATPolicyResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateNATPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NATPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2962,27 +2970,24 @@ func (r *NATPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3341,6 +3346,17 @@ func (r *NATPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateNATPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NATPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/nat_policy_resource.go
+++ b/internal/provider/nat_policy_resource.go
@@ -1018,6 +1018,27 @@ func (r *NATPolicyResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2150,9 +2171,18 @@ func (r *NATPolicyResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2930,6 +2960,29 @@ func (r *NATPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/nat_policy_resource.go
+++ b/internal/provider/nat_policy_resource.go
@@ -3355,6 +3355,13 @@ func (r *NATPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/network_connector_resource.go
+++ b/internal/provider/network_connector_resource.go
@@ -2090,6 +2090,13 @@ func (r *NetworkConnectorResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/network_connector_resource.go
+++ b/internal/provider/network_connector_resource.go
@@ -703,25 +703,24 @@ func (r *NetworkConnectorResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -918,6 +917,15 @@ func (r *NetworkConnectorResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateNetworkConnector(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NetworkConnector: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1859,27 +1867,24 @@ func (r *NetworkConnectorResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2076,6 +2081,17 @@ func (r *NetworkConnectorResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateNetworkConnector(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NetworkConnector: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/network_connector_resource.go
+++ b/internal/provider/network_connector_resource.go
@@ -703,6 +703,27 @@ func (r *NetworkConnectorResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1360,9 +1381,18 @@ func (r *NetworkConnectorResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1827,6 +1857,29 @@ func (r *NetworkConnectorResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/network_firewall_resource.go
+++ b/internal/provider/network_firewall_resource.go
@@ -1344,6 +1344,13 @@ func (r *NetworkFirewallResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/network_firewall_resource.go
+++ b/internal/provider/network_firewall_resource.go
@@ -483,6 +483,27 @@ func (r *NetworkFirewallResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -877,9 +898,18 @@ func (r *NetworkFirewallResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1148,6 +1178,29 @@ func (r *NetworkFirewallResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/network_firewall_resource.go
+++ b/internal/provider/network_firewall_resource.go
@@ -483,25 +483,24 @@ func (r *NetworkFirewallResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -631,6 +630,15 @@ func (r *NetworkFirewallResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateNetworkFirewall(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NetworkFirewall: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1180,27 +1188,24 @@ func (r *NetworkFirewallResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1330,6 +1335,17 @@ func (r *NetworkFirewallResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateNetworkFirewall(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NetworkFirewall: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/network_interface_resource.go
+++ b/internal/provider/network_interface_resource.go
@@ -1291,25 +1291,24 @@ func (r *NetworkInterfaceResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1727,6 +1726,15 @@ func (r *NetworkInterfaceResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateNetworkInterface(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NetworkInterface: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3806,27 +3814,24 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4244,6 +4249,17 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateNetworkInterface(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NetworkInterface: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/network_interface_resource.go
+++ b/internal/provider/network_interface_resource.go
@@ -4258,6 +4258,13 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/network_interface_resource.go
+++ b/internal/provider/network_interface_resource.go
@@ -1291,6 +1291,27 @@ func (r *NetworkInterfaceResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2738,9 +2759,18 @@ func (r *NetworkInterfaceResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3774,6 +3804,29 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/network_policy_resource.go
+++ b/internal/provider/network_policy_resource.go
@@ -947,6 +947,27 @@ func (r *NetworkPolicyResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2003,9 +2024,18 @@ func (r *NetworkPolicyResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2728,6 +2758,29 @@ func (r *NetworkPolicyResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/network_policy_resource.go
+++ b/internal/provider/network_policy_resource.go
@@ -947,25 +947,24 @@ func (r *NetworkPolicyResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1303,6 +1302,15 @@ func (r *NetworkPolicyResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateNetworkPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NetworkPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2760,27 +2768,24 @@ func (r *NetworkPolicyResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3118,6 +3123,17 @@ func (r *NetworkPolicyResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateNetworkPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NetworkPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/network_policy_resource.go
+++ b/internal/provider/network_policy_resource.go
@@ -3132,6 +3132,13 @@ func (r *NetworkPolicyResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/network_policy_rule_resource.go
+++ b/internal/provider/network_policy_rule_resource.go
@@ -416,6 +416,27 @@ func (r *NetworkPolicyRuleResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -739,9 +760,18 @@ func (r *NetworkPolicyRuleResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -967,6 +997,29 @@ func (r *NetworkPolicyRuleResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/network_policy_rule_resource.go
+++ b/internal/provider/network_policy_rule_resource.go
@@ -1135,6 +1135,13 @@ func (r *NetworkPolicyRuleResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/network_policy_rule_resource.go
+++ b/internal/provider/network_policy_rule_resource.go
@@ -416,25 +416,24 @@ func (r *NetworkPolicyRuleResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -536,6 +535,15 @@ func (r *NetworkPolicyRuleResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateNetworkPolicyRule(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NetworkPolicyRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -999,27 +1007,24 @@ func (r *NetworkPolicyRuleResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1121,6 +1126,17 @@ func (r *NetworkPolicyRuleResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateNetworkPolicyRule(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NetworkPolicyRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/network_policy_view_resource.go
+++ b/internal/provider/network_policy_view_resource.go
@@ -930,6 +930,27 @@ func (r *NetworkPolicyViewResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1980,9 +2001,18 @@ func (r *NetworkPolicyViewResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2703,6 +2733,29 @@ func (r *NetworkPolicyViewResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/network_policy_view_resource.go
+++ b/internal/provider/network_policy_view_resource.go
@@ -930,25 +930,24 @@ func (r *NetworkPolicyViewResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1282,6 +1281,15 @@ func (r *NetworkPolicyViewResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateNetworkPolicyView(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NetworkPolicyView: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2735,27 +2743,24 @@ func (r *NetworkPolicyViewResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3089,6 +3094,17 @@ func (r *NetworkPolicyViewResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateNetworkPolicyView(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NetworkPolicyView: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/network_policy_view_resource.go
+++ b/internal/provider/network_policy_view_resource.go
@@ -3103,6 +3103,13 @@ func (r *NetworkPolicyViewResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/nfv_service_resource.go
+++ b/internal/provider/nfv_service_resource.go
@@ -2990,6 +2990,27 @@ func (r *NfvServiceResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6369,9 +6390,18 @@ func (r *NfvServiceResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -8701,6 +8731,29 @@ func (r *NfvServiceResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/nfv_service_resource.go
+++ b/internal/provider/nfv_service_resource.go
@@ -9821,6 +9821,13 @@ func (r *NfvServiceResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/nfv_service_resource.go
+++ b/internal/provider/nfv_service_resource.go
@@ -2990,25 +2990,24 @@ func (r *NfvServiceResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4062,6 +4061,15 @@ func (r *NfvServiceResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateNfvService(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NfvService: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -8733,27 +8741,24 @@ func (r *NfvServiceResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -9807,6 +9812,17 @@ func (r *NfvServiceResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateNfvService(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NfvService: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/nginx_service_discovery_resource.go
+++ b/internal/provider/nginx_service_discovery_resource.go
@@ -408,25 +408,24 @@ func (r *NginxServiceDiscoveryResource) Create(ctx context.Context, req resource
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -530,6 +529,15 @@ func (r *NginxServiceDiscoveryResource) Create(ctx context.Context, req resource
 	apiResource, err := r.client.CreateNginxServiceDiscovery(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create NginxServiceDiscovery: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1023,27 +1031,24 @@ func (r *NginxServiceDiscoveryResource) Update(ctx context.Context, req resource
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1147,6 +1152,17 @@ func (r *NginxServiceDiscoveryResource) Update(ctx context.Context, req resource
 	_, err := r.client.UpdateNginxServiceDiscovery(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update NginxServiceDiscovery: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/nginx_service_discovery_resource.go
+++ b/internal/provider/nginx_service_discovery_resource.go
@@ -408,6 +408,27 @@ func (r *NginxServiceDiscoveryResource) Create(ctx context.Context, req resource
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -748,9 +769,18 @@ func (r *NginxServiceDiscoveryResource) Read(ctx context.Context, req resource.R
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -991,6 +1021,29 @@ func (r *NginxServiceDiscoveryResource) Update(ctx context.Context, req resource
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/nginx_service_discovery_resource.go
+++ b/internal/provider/nginx_service_discovery_resource.go
@@ -1161,6 +1161,13 @@ func (r *NginxServiceDiscoveryResource) Update(ctx context.Context, req resource
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/origin_pool_resource.go
+++ b/internal/provider/origin_pool_resource.go
@@ -2348,25 +2348,24 @@ func (r *OriginPoolResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3130,6 +3129,15 @@ func (r *OriginPoolResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateOriginPool(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create OriginPool: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -6627,27 +6635,24 @@ func (r *OriginPoolResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -7411,6 +7416,17 @@ func (r *OriginPoolResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateOriginPool(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update OriginPool: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/origin_pool_resource.go
+++ b/internal/provider/origin_pool_resource.go
@@ -2348,6 +2348,27 @@ func (r *OriginPoolResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -4850,9 +4871,18 @@ func (r *OriginPoolResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -6595,6 +6625,29 @@ func (r *OriginPoolResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/origin_pool_resource.go
+++ b/internal/provider/origin_pool_resource.go
@@ -7425,6 +7425,13 @@ func (r *OriginPoolResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/owned_labels.go
+++ b/internal/provider/owned_labels.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package provider
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// ownedLabelKeysPrivateKey is the private-state key holding the label keys the
+// configuration declared at the last Create or Update.
+//
+// Private state is the only place this can live. Read receives prior state and the API
+// response and nothing else, so it cannot tell a label the configuration asked for from
+// one the platform added — and prior state is not a substitute: every provider release up
+// to 3.81.1 wrote the platform's own labels into state, which is exactly why the #1391
+// attempt at inferring ownership from prior state had to be reverted.
+const ownedLabelKeysPrivateKey = "ownedLabelKeys"
+
+// ownedLabelKeysPayload is the private-state document. A named field rather than a bare
+// array so a future addition does not have to change the encoding.
+type ownedLabelKeysPayload struct {
+	Keys []string `json:"ownedLabelKeys"`
+}
+
+// encodeOwnedLabelKeys serialises the configuration's label keys for private state.
+//
+// Keys are sorted so the encoding depends only on the set, not on map iteration order.
+// Without that, every apply would rewrite private state and Terraform would report a
+// change on a configuration nobody touched.
+//
+// nolint:unused // Used by generated resource Create and Update methods
+func encodeOwnedLabelKeys(keys []string) ([]byte, error) {
+	sorted := make([]string, len(keys))
+	copy(sorted, keys)
+	sort.Strings(sorted)
+	return json.Marshal(ownedLabelKeysPayload{Keys: sorted})
+}
+
+// decodeOwnedLabelKeys reads the private-state entry written by encodeOwnedLabelKeys.
+//
+// Anything unreadable — absent, empty, not JSON, or the wrong shape — means "owns
+// nothing". That is deliberate and it is the upgrade path: every resource created before
+// this change has no entry, and treating it as owning nothing reproduces the #1391
+// behaviour, where the platform's labels are filtered and the plan is clean. Failing
+// loudly here would break every existing resource on the first refresh after upgrade.
+//
+// nolint:unused // Used by generated resource Read methods
+func decodeOwnedLabelKeys(raw []byte) map[string]struct{} {
+	owned := make(map[string]struct{})
+	if len(raw) == 0 {
+		return owned
+	}
+	var payload ownedLabelKeysPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return owned
+	}
+	for _, k := range payload.Keys {
+		owned[k] = struct{}{}
+	}
+	return owned
+}
+
+// filterSystemLabelsOwning is filterSystemLabels with an exemption list: a platform-
+// namespaced or discovery key the configuration declared is kept, so Terraform can see
+// what it wrote and the plan converges.
+//
+// Passing a nil or empty owned set is identical to filterSystemLabels, which is what
+// makes this safe for resources whose state predates the private-state entry.
+//
+// nolint:unused // Used by generated resource Read methods
+func filterSystemLabelsOwning(labels map[string]string, siteDiscovery bool, owned map[string]struct{}) map[string]string {
+	filtered := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if _, isOwned := owned[k]; isOwned {
+			// The configuration declared this key, so it is the configuration's to
+			// manage even though it sits in a namespace the platform also uses.
+			filtered[k] = v
+			continue
+		}
+		if !isPlatformLabel(k, siteDiscovery) {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
+// configLabelKeys returns the keys of the labels a configuration declares, for recording
+// as the owned set. A nil map yields an empty slice rather than nil so the encoded
+// payload is the same shape whether or not any labels were declared.
+//
+// nolint:unused // Used by generated resource Create and Update methods
+func configLabelKeys(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/provider/owned_labels_test.go
+++ b/internal/provider/owned_labels_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+// F5 XC uses the ves.io/ and internal.ves.io/ namespaces for labels it sets itself, and
+// filterSystemLabels strips every key in them from the read-back. Users set labels there
+// too — real sites in this tenant carry `ves.io/app`, `ves.io/app_type`,
+// `ves.io/mcn-demo` — and when they do the label becomes unmanageable: the configuration
+// writes it, the read-back removes it from state, the next plan proposes adding it again,
+// forever. Measured on cem1-l1 with released provider 3.81.1: two consecutive plans each
+// reported `1 to change` for `ves.io/app = demo`, while the server held the label.
+//
+// #1391 tried to fix this by treating any platform-prefixed key already in prior state as
+// owned. That failed: every provider up to 3.81.1 wrote the platform's OWN labels into
+// state, so the guard kept those too and went on proposing their deletion. Prior state is
+// not evidence of ownership.
+//
+// Ownership therefore has to be recorded where the configuration is actually visible —
+// Create and Update — and read back in Read, which only ever sees prior state. These
+// tests cover the encoding and the filter; #1398 tracks the live verification.
+
+func TestOwnedLabelKeysRoundTrip(t *testing.T) {
+	keys := []string{"ves.io/app", "env", "internal.ves.io/thing"}
+	encoded, err := encodeOwnedLabelKeys(keys)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got := decodeOwnedLabelKeys(encoded)
+	// Order must not matter to callers, but the encoding must be stable so an
+	// unchanged configuration does not rewrite private state on every apply.
+	want := map[string]struct{}{"ves.io/app": {}, "env": {}, "internal.ves.io/thing": {}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round trip lost keys\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestEncodeOwnedLabelKeysIsStable(t *testing.T) {
+	a, err := encodeOwnedLabelKeys([]string{"b", "a", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := encodeOwnedLabelKeys([]string{"c", "a", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Errorf("encoding depends on input order: %q vs %q", a, b)
+	}
+}
+
+// The upgrade path. Every resource created before this change has no private entry, so
+// there is nothing to decode. That must mean "owns no platform-namespaced label", which
+// reproduces the #1391 behaviour exactly — the platform's labels stay filtered and the
+// plan stays clean.
+func TestDecodeOwnedLabelKeysTreatsAbsentAndMalformedAsOwningNothing(t *testing.T) {
+	for name, raw := range map[string][]byte{
+		"nil":       nil,
+		"empty":     {},
+		"not json":  []byte("ves.io/app"),
+		"wrong sha": []byte(`{"unexpected":true}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := decodeOwnedLabelKeys(raw); len(got) != 0 {
+				t.Errorf("expected to own nothing, got %v", got)
+			}
+		})
+	}
+}
+
+func TestFilterSystemLabelsKeepsOwnedPlatformKeys(t *testing.T) {
+	server := map[string]string{
+		"env":              "demo",         // ordinary, always kept
+		"ves.io/app":       "demo",         // declared by the configuration
+		"ves.io/provider":  "ves-io-AZURE", // the platform's own, never declared
+		"hw-serial-number": "ABC123",       // discovery label
+	}
+	owned := map[string]struct{}{"ves.io/app": {}}
+
+	got := filterSystemLabelsOwning(server, true, owned)
+
+	want := map[string]string{"env": "demo", "ves.io/app": "demo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("owned platform key not preserved\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+// The criterion that #1391 exists to protect: the platform's own label must never be
+// proposed for deletion, whether or not an ownership entry exists.
+func TestFilterSystemLabelsNeverKeepsUnownedPlatformKeys(t *testing.T) {
+	server := map[string]string{"ves.io/provider": "ves-io-AZURE", "env": "demo"}
+
+	for name, owned := range map[string]map[string]struct{}{
+		"no entry at all":      nil,
+		"entry owning nothing": {},
+		"entry owning another": {"ves.io/app": {}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := filterSystemLabelsOwning(server, true, owned)
+			if _, present := got["ves.io/provider"]; present {
+				t.Error("ves.io/provider leaked into state and would be proposed for deletion")
+			}
+			if got["env"] != "demo" {
+				t.Errorf("ordinary label lost: %v", got)
+			}
+		})
+	}
+}
+
+// A configuration can deliberately take over a discovery label; #1391 already allows that
+// on the write path via mergePreservedLabels, so the read path must agree.
+func TestFilterSystemLabelsKeepsOwnedDiscoveryLabel(t *testing.T) {
+	server := map[string]string{"hw-vendor": "mine", "hw-model": "theirs"}
+	got := filterSystemLabelsOwning(server, true, map[string]struct{}{"hw-vendor": {}})
+	if got["hw-vendor"] != "mine" {
+		t.Errorf("owned discovery label not preserved: %v", got)
+	}
+	if _, present := got["hw-model"]; present {
+		t.Errorf("unowned discovery label leaked: %v", got)
+	}
+}
+
+// filterSystemLabels must keep behaving exactly as before, so the existing generated
+// callers and the #1391 regression tests are unaffected.
+func TestFilterSystemLabelsUnchangedWithoutOwnership(t *testing.T) {
+	server := map[string]string{"env": "demo", "ves.io/app": "demo", "hw-model": "x"}
+	if !reflect.DeepEqual(filterSystemLabels(server, true), filterSystemLabelsOwning(server, true, nil)) {
+		t.Error("filterSystemLabels and filterSystemLabelsOwning(nil) disagree")
+	}
+}

--- a/internal/provider/policer_resource.go
+++ b/internal/provider/policer_resource.go
@@ -251,6 +251,27 @@ func (r *PolicerResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -379,9 +400,18 @@ func (r *PolicerResource) Read(ctx context.Context, req resource.ReadRequest, re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -485,6 +515,29 @@ func (r *PolicerResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/policer_resource.go
+++ b/internal/provider/policer_resource.go
@@ -580,6 +580,13 @@ func (r *PolicerResource) Update(ctx context.Context, req resource.UpdateRequest
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/policer_resource.go
+++ b/internal/provider/policer_resource.go
@@ -251,25 +251,24 @@ func (r *PolicerResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -298,6 +297,15 @@ func (r *PolicerResource) Create(ctx context.Context, req resource.CreateRequest
 	apiResource, err := r.client.CreatePolicer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Policer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -517,27 +525,24 @@ func (r *PolicerResource) Update(ctx context.Context, req resource.UpdateRequest
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -566,6 +571,17 @@ func (r *PolicerResource) Update(ctx context.Context, req resource.UpdateRequest
 	_, err := r.client.UpdatePolicer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Policer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/policy_based_routing_resource.go
+++ b/internal/provider/policy_based_routing_resource.go
@@ -990,6 +990,27 @@ func (r *PolicyBasedRoutingResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2056,9 +2077,18 @@ func (r *PolicyBasedRoutingResource) Read(ctx context.Context, req resource.Read
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2779,6 +2809,29 @@ func (r *PolicyBasedRoutingResource) Update(ctx context.Context, req resource.Up
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/policy_based_routing_resource.go
+++ b/internal/provider/policy_based_routing_resource.go
@@ -3195,6 +3195,13 @@ func (r *PolicyBasedRoutingResource) Update(ctx context.Context, req resource.Up
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/policy_based_routing_resource.go
+++ b/internal/provider/policy_based_routing_resource.go
@@ -990,25 +990,24 @@ func (r *PolicyBasedRoutingResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1358,6 +1357,15 @@ func (r *PolicyBasedRoutingResource) Create(ctx context.Context, req resource.Cr
 	apiResource, err := r.client.CreatePolicyBasedRouting(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create PolicyBasedRouting: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2811,27 +2819,24 @@ func (r *PolicyBasedRoutingResource) Update(ctx context.Context, req resource.Up
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3181,6 +3186,17 @@ func (r *PolicyBasedRoutingResource) Update(ctx context.Context, req resource.Up
 	_, err := r.client.UpdatePolicyBasedRouting(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update PolicyBasedRouting: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/protected_application_resource.go
+++ b/internal/provider/protected_application_resource.go
@@ -2910,25 +2910,24 @@ func (r *ProtectedApplicationResource) Create(ctx context.Context, req resource.
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3970,6 +3969,15 @@ func (r *ProtectedApplicationResource) Create(ctx context.Context, req resource.
 	apiResource, err := r.client.CreateProtectedApplication(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ProtectedApplication: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -8555,27 +8563,24 @@ func (r *ProtectedApplicationResource) Update(ctx context.Context, req resource.
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -9617,6 +9622,17 @@ func (r *ProtectedApplicationResource) Update(ctx context.Context, req resource.
 	_, err := r.client.UpdateProtectedApplication(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ProtectedApplication: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/protected_application_resource.go
+++ b/internal/provider/protected_application_resource.go
@@ -9631,6 +9631,13 @@ func (r *ProtectedApplicationResource) Update(ctx context.Context, req resource.
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/protected_application_resource.go
+++ b/internal/provider/protected_application_resource.go
@@ -2910,6 +2910,27 @@ func (r *ProtectedApplicationResource) Create(ctx context.Context, req resource.
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6234,9 +6255,18 @@ func (r *ProtectedApplicationResource) Read(ctx context.Context, req resource.Re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -8523,6 +8553,29 @@ func (r *ProtectedApplicationResource) Update(ctx context.Context, req resource.
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/protected_domain_resource.go
+++ b/internal/provider/protected_domain_resource.go
@@ -517,6 +517,13 @@ func (r *ProtectedDomainResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/protected_domain_resource.go
+++ b/internal/provider/protected_domain_resource.go
@@ -236,6 +236,27 @@ func (r *ProtectedDomainResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -340,9 +361,18 @@ func (r *ProtectedDomainResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -431,6 +461,29 @@ func (r *ProtectedDomainResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/protected_domain_resource.go
+++ b/internal/provider/protected_domain_resource.go
@@ -236,25 +236,24 @@ func (r *ProtectedDomainResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -274,6 +273,15 @@ func (r *ProtectedDomainResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateProtectedDomain(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ProtectedDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -463,27 +471,24 @@ func (r *ProtectedDomainResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -503,6 +508,17 @@ func (r *ProtectedDomainResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateProtectedDomain(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ProtectedDomain: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/protocol_inspection_resource.go
+++ b/internal/provider/protocol_inspection_resource.go
@@ -318,25 +318,24 @@ func (r *ProtocolInspectionResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -386,6 +385,15 @@ func (r *ProtocolInspectionResource) Create(ctx context.Context, req resource.Cr
 	apiResource, err := r.client.CreateProtocolInspection(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ProtocolInspection: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -695,27 +703,24 @@ func (r *ProtocolInspectionResource) Update(ctx context.Context, req resource.Up
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -765,6 +770,17 @@ func (r *ProtocolInspectionResource) Update(ctx context.Context, req resource.Up
 	_, err := r.client.UpdateProtocolInspection(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ProtocolInspection: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/protocol_inspection_resource.go
+++ b/internal/provider/protocol_inspection_resource.go
@@ -318,6 +318,27 @@ func (r *ProtocolInspectionResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -512,9 +533,18 @@ func (r *ProtocolInspectionResource) Read(ctx context.Context, req resource.Read
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -663,6 +693,29 @@ func (r *ProtocolInspectionResource) Update(ctx context.Context, req resource.Up
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/protocol_inspection_resource.go
+++ b/internal/provider/protocol_inspection_resource.go
@@ -779,6 +779,13 @@ func (r *ProtocolInspectionResource) Update(ctx context.Context, req resource.Up
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/protocol_policer_resource.go
+++ b/internal/provider/protocol_policer_resource.go
@@ -1066,6 +1066,13 @@ func (r *ProtocolPolicerResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/protocol_policer_resource.go
+++ b/internal/provider/protocol_policer_resource.go
@@ -363,6 +363,27 @@ func (r *ProtocolPolicerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -678,9 +699,18 @@ func (r *ProtocolPolicerResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -910,6 +940,29 @@ func (r *ProtocolPolicerResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/protocol_policer_resource.go
+++ b/internal/provider/protocol_policer_resource.go
@@ -363,25 +363,24 @@ func (r *ProtocolPolicerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -471,6 +470,15 @@ func (r *ProtocolPolicerResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateProtocolPolicer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ProtocolPolicer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -942,27 +950,24 @@ func (r *ProtocolPolicerResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1052,6 +1057,17 @@ func (r *ProtocolPolicerResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateProtocolPolicer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ProtocolPolicer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/proxy_resource.go
+++ b/internal/provider/proxy_resource.go
@@ -13028,6 +13028,13 @@ func (r *ProxyResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/proxy_resource.go
+++ b/internal/provider/proxy_resource.go
@@ -3687,25 +3687,24 @@ func (r *ProxyResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -5147,6 +5146,15 @@ func (r *ProxyResource) Create(ctx context.Context, req resource.CreateRequest, 
 	apiResource, err := r.client.CreateProxy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Proxy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -11552,27 +11560,24 @@ func (r *ProxyResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -13014,6 +13019,17 @@ func (r *ProxyResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	_, err := r.client.UpdateProxy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Proxy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/proxy_resource.go
+++ b/internal/provider/proxy_resource.go
@@ -3687,6 +3687,27 @@ func (r *ProxyResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -8321,9 +8342,18 @@ func (r *ProxyResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -11520,6 +11550,29 @@ func (r *ProxyResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/rate_limiter_policy_resource.go
+++ b/internal/provider/rate_limiter_policy_resource.go
@@ -3659,6 +3659,13 @@ func (r *RateLimiterPolicyResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/rate_limiter_policy_resource.go
+++ b/internal/provider/rate_limiter_policy_resource.go
@@ -1056,25 +1056,24 @@ func (r *RateLimiterPolicyResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1479,6 +1478,15 @@ func (r *RateLimiterPolicyResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateRateLimiterPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create RateLimiterPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3220,27 +3228,24 @@ func (r *RateLimiterPolicyResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3645,6 +3650,17 @@ func (r *RateLimiterPolicyResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateRateLimiterPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update RateLimiterPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/rate_limiter_policy_resource.go
+++ b/internal/provider/rate_limiter_policy_resource.go
@@ -1056,6 +1056,27 @@ func (r *RateLimiterPolicyResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2321,9 +2342,18 @@ func (r *RateLimiterPolicyResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3188,6 +3218,29 @@ func (r *RateLimiterPolicyResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/rate_limiter_resource.go
+++ b/internal/provider/rate_limiter_resource.go
@@ -429,6 +429,27 @@ func (r *RateLimiterResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -803,9 +824,18 @@ func (r *RateLimiterResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1080,6 +1110,29 @@ func (r *RateLimiterResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/rate_limiter_resource.go
+++ b/internal/provider/rate_limiter_resource.go
@@ -1250,6 +1250,13 @@ func (r *RateLimiterResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/rate_limiter_resource.go
+++ b/internal/provider/rate_limiter_resource.go
@@ -429,25 +429,24 @@ func (r *RateLimiterResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -551,6 +550,15 @@ func (r *RateLimiterResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateRateLimiter(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create RateLimiter: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1112,27 +1120,24 @@ func (r *RateLimiterResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1236,6 +1241,17 @@ func (r *RateLimiterResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateRateLimiter(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update RateLimiter: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/registration_resource.go
+++ b/internal/provider/registration_resource.go
@@ -1213,25 +1213,24 @@ func (r *RegistrationResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1680,6 +1679,15 @@ func (r *RegistrationResource) Create(ctx context.Context, req resource.CreateRe
 	apiResource, err := r.client.CreateRegistration(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Registration: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -3681,27 +3689,24 @@ func (r *RegistrationResource) Update(ctx context.Context, req resource.UpdateRe
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4150,6 +4155,17 @@ func (r *RegistrationResource) Update(ctx context.Context, req resource.UpdateRe
 	_, err := r.client.UpdateRegistration(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Registration: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/registration_resource.go
+++ b/internal/provider/registration_resource.go
@@ -1213,6 +1213,27 @@ func (r *RegistrationResource) Create(ctx context.Context, req resource.CreateRe
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2652,9 +2673,18 @@ func (r *RegistrationResource) Read(ctx context.Context, req resource.ReadReques
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -3649,6 +3679,29 @@ func (r *RegistrationResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/registration_resource.go
+++ b/internal/provider/registration_resource.go
@@ -4164,6 +4164,13 @@ func (r *RegistrationResource) Update(ctx context.Context, req resource.UpdateRe
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -2213,25 +2213,24 @@ func (r *RouteResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3102,6 +3101,15 @@ func (r *RouteResource) Create(ctx context.Context, req resource.CreateRequest, 
 	apiResource, err := r.client.CreateRoute(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Route: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -6947,27 +6955,24 @@ func (r *RouteResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -7838,6 +7843,17 @@ func (r *RouteResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	_, err := r.client.UpdateRoute(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Route: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -2213,6 +2213,27 @@ func (r *RouteResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -4996,9 +5017,18 @@ func (r *RouteResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -6915,6 +6945,29 @@ func (r *RouteResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -7852,6 +7852,13 @@ func (r *RouteResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/secret_management_access_resource.go
+++ b/internal/provider/secret_management_access_resource.go
@@ -4733,6 +4733,13 @@ func (r *SecretManagementAccessResource) Update(ctx context.Context, req resourc
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/secret_management_access_resource.go
+++ b/internal/provider/secret_management_access_resource.go
@@ -1460,25 +1460,24 @@ func (r *SecretManagementAccessResource) Create(ctx context.Context, req resourc
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1988,6 +1987,15 @@ func (r *SecretManagementAccessResource) Create(ctx context.Context, req resourc
 	apiResource, err := r.client.CreateSecretManagementAccess(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create SecretManagementAccess: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -4189,27 +4197,24 @@ func (r *SecretManagementAccessResource) Update(ctx context.Context, req resourc
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4719,6 +4724,17 @@ func (r *SecretManagementAccessResource) Update(ctx context.Context, req resourc
 	_, err := r.client.UpdateSecretManagementAccess(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update SecretManagementAccess: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/secret_management_access_resource.go
+++ b/internal/provider/secret_management_access_resource.go
@@ -1460,6 +1460,27 @@ func (r *SecretManagementAccessResource) Create(ctx context.Context, req resourc
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -3060,9 +3081,18 @@ func (r *SecretManagementAccessResource) Read(ctx context.Context, req resource.
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -4157,6 +4187,29 @@ func (r *SecretManagementAccessResource) Update(ctx context.Context, req resourc
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/securemesh_site_resource.go
+++ b/internal/provider/securemesh_site_resource.go
@@ -2915,6 +2915,27 @@ func (r *SecuremeshSiteResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -6540,9 +6561,18 @@ func (r *SecuremeshSiteResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -9004,6 +9034,29 @@ func (r *SecuremeshSiteResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/securemesh_site_resource.go
+++ b/internal/provider/securemesh_site_resource.go
@@ -2915,25 +2915,24 @@ func (r *SecuremeshSiteResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -4101,6 +4100,15 @@ func (r *SecuremeshSiteResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateSecuremeshSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create SecuremeshSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -9036,27 +9044,24 @@ func (r *SecuremeshSiteResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -10245,6 +10250,17 @@ func (r *SecuremeshSiteResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateSecuremeshSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update SecuremeshSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/securemesh_site_resource.go
+++ b/internal/provider/securemesh_site_resource.go
@@ -10259,6 +10259,13 @@ func (r *SecuremeshSiteResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/securemesh_site_v2_resource.go
+++ b/internal/provider/securemesh_site_v2_resource.go
@@ -35942,6 +35942,13 @@ func (r *SecuremeshSiteV2Resource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/securemesh_site_v2_resource.go
+++ b/internal/provider/securemesh_site_v2_resource.go
@@ -10362,6 +10362,27 @@ func (r *SecuremeshSiteV2Resource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -23105,9 +23126,18 @@ func (r *SecuremeshSiteV2Resource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -31811,6 +31841,29 @@ func (r *SecuremeshSiteV2Resource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/securemesh_site_v2_resource.go
+++ b/internal/provider/securemesh_site_v2_resource.go
@@ -10362,25 +10362,24 @@ func (r *SecuremeshSiteV2Resource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -14424,6 +14423,15 @@ func (r *SecuremeshSiteV2Resource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateSecuremeshSiteV2(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create SecuremeshSiteV2: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -31843,27 +31851,24 @@ func (r *SecuremeshSiteV2Resource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -35928,6 +35933,17 @@ func (r *SecuremeshSiteV2Resource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateSecuremeshSiteV2(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update SecuremeshSiteV2: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -505,6 +505,13 @@ func (r *SegmentResource) Update(ctx context.Context, req resource.UpdateRequest
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -216,25 +216,24 @@ func (r *SegmentResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -257,6 +256,15 @@ func (r *SegmentResource) Create(ctx context.Context, req resource.CreateRequest
 	apiResource, err := r.client.CreateSegment(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Segment: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -448,27 +456,24 @@ func (r *SegmentResource) Update(ctx context.Context, req resource.UpdateRequest
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -491,6 +496,17 @@ func (r *SegmentResource) Update(ctx context.Context, req resource.UpdateRequest
 	_, err := r.client.UpdateSegment(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Segment: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/segment_resource.go
+++ b/internal/provider/segment_resource.go
@@ -216,6 +216,27 @@ func (r *SegmentResource) Create(ctx context.Context, req resource.CreateRequest
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -324,9 +345,18 @@ func (r *SegmentResource) Read(ctx context.Context, req resource.ReadRequest, re
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -416,6 +446,29 @@ func (r *SegmentResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/sensitive_data_policy_resource.go
+++ b/internal/provider/sensitive_data_policy_resource.go
@@ -306,25 +306,24 @@ func (r *SensitiveDataPolicyResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -381,6 +380,15 @@ func (r *SensitiveDataPolicyResource) Create(ctx context.Context, req resource.C
 	apiResource, err := r.client.CreateSensitiveDataPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create SensitiveDataPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -716,27 +724,24 @@ func (r *SensitiveDataPolicyResource) Update(ctx context.Context, req resource.U
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -793,6 +798,17 @@ func (r *SensitiveDataPolicyResource) Update(ctx context.Context, req resource.U
 	_, err := r.client.UpdateSensitiveDataPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update SensitiveDataPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/sensitive_data_policy_resource.go
+++ b/internal/provider/sensitive_data_policy_resource.go
@@ -306,6 +306,27 @@ func (r *SensitiveDataPolicyResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -520,9 +541,18 @@ func (r *SensitiveDataPolicyResource) Read(ctx context.Context, req resource.Rea
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -684,6 +714,29 @@ func (r *SensitiveDataPolicyResource) Update(ctx context.Context, req resource.U
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/sensitive_data_policy_resource.go
+++ b/internal/provider/sensitive_data_policy_resource.go
@@ -807,6 +807,13 @@ func (r *SensitiveDataPolicyResource) Update(ctx context.Context, req resource.U
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/service_policy_resource.go
+++ b/internal/provider/service_policy_resource.go
@@ -2585,25 +2585,24 @@ func (r *ServicePolicyResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3767,6 +3766,15 @@ func (r *ServicePolicyResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateServicePolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ServicePolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -8668,27 +8676,24 @@ func (r *ServicePolicyResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -9852,6 +9857,17 @@ func (r *ServicePolicyResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateServicePolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ServicePolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/service_policy_resource.go
+++ b/internal/provider/service_policy_resource.go
@@ -2585,6 +2585,27 @@ func (r *ServicePolicyResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6189,9 +6210,18 @@ func (r *ServicePolicyResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -8636,6 +8666,29 @@ func (r *ServicePolicyResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/service_policy_resource.go
+++ b/internal/provider/service_policy_resource.go
@@ -9866,6 +9866,13 @@ func (r *ServicePolicyResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/service_policy_rule_resource.go
+++ b/internal/provider/service_policy_rule_resource.go
@@ -1935,6 +1935,27 @@ func (r *ServicePolicyRuleResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -4524,9 +4545,18 @@ func (r *ServicePolicyRuleResource) Read(ctx context.Context, req resource.ReadR
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -6260,6 +6290,29 @@ func (r *ServicePolicyRuleResource) Update(ctx context.Context, req resource.Upd
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/service_policy_rule_resource.go
+++ b/internal/provider/service_policy_rule_resource.go
@@ -1935,25 +1935,24 @@ func (r *ServicePolicyRuleResource) Create(ctx context.Context, req resource.Cre
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2813,6 +2812,15 @@ func (r *ServicePolicyRuleResource) Create(ctx context.Context, req resource.Cre
 	apiResource, err := r.client.CreateServicePolicyRule(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ServicePolicyRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -6292,27 +6300,24 @@ func (r *ServicePolicyRuleResource) Update(ctx context.Context, req resource.Upd
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -7172,6 +7177,17 @@ func (r *ServicePolicyRuleResource) Update(ctx context.Context, req resource.Upd
 	_, err := r.client.UpdateServicePolicyRule(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update ServicePolicyRule: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/service_policy_rule_resource.go
+++ b/internal/provider/service_policy_rule_resource.go
@@ -7186,6 +7186,13 @@ func (r *ServicePolicyRuleResource) Update(ctx context.Context, req resource.Upd
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/site_mesh_group_resource.go
+++ b/internal/provider/site_mesh_group_resource.go
@@ -1265,6 +1265,13 @@ func (r *SiteMeshGroupResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/site_mesh_group_resource.go
+++ b/internal/provider/site_mesh_group_resource.go
@@ -446,6 +446,27 @@ func (r *SiteMeshGroupResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -819,9 +840,18 @@ func (r *SiteMeshGroupResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1089,6 +1119,29 @@ func (r *SiteMeshGroupResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/site_mesh_group_resource.go
+++ b/internal/provider/site_mesh_group_resource.go
@@ -446,25 +446,24 @@ func (r *SiteMeshGroupResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -574,6 +573,15 @@ func (r *SiteMeshGroupResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateSiteMeshGroup(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create SiteMeshGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1121,27 +1129,24 @@ func (r *SiteMeshGroupResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1251,6 +1256,17 @@ func (r *SiteMeshGroupResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateSiteMeshGroup(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update SiteMeshGroup: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -269,25 +269,24 @@ func (r *SiteResource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -334,6 +333,15 @@ func (r *SiteResource) Create(ctx context.Context, req resource.CreateRequest, r
 	apiResource, err := r.client.CreateSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Site: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -557,27 +565,24 @@ func (r *SiteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -645,6 +650,17 @@ func (r *SiteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	_, err := r.client.UpdateSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Site: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -659,6 +659,13 @@ func (r *SiteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/site_resource.go
+++ b/internal/provider/site_resource.go
@@ -269,6 +269,27 @@ func (r *SiteResource) Create(ctx context.Context, req resource.CreateRequest, r
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -417,9 +438,18 @@ func (r *SiteResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -525,6 +555,29 @@ func (r *SiteResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/srv6_network_slice_resource.go
+++ b/internal/provider/srv6_network_slice_resource.go
@@ -234,6 +234,27 @@ func (r *Srv6NetworkSliceResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -376,9 +397,18 @@ func (r *Srv6NetworkSliceResource) Read(ctx context.Context, req resource.ReadRe
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -492,6 +522,29 @@ func (r *Srv6NetworkSliceResource) Update(ctx context.Context, req resource.Upda
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/srv6_network_slice_resource.go
+++ b/internal/provider/srv6_network_slice_resource.go
@@ -591,6 +591,13 @@ func (r *Srv6NetworkSliceResource) Update(ctx context.Context, req resource.Upda
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/srv6_network_slice_resource.go
+++ b/internal/provider/srv6_network_slice_resource.go
@@ -234,25 +234,24 @@ func (r *Srv6NetworkSliceResource) Create(ctx context.Context, req resource.Crea
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -285,6 +284,15 @@ func (r *Srv6NetworkSliceResource) Create(ctx context.Context, req resource.Crea
 	apiResource, err := r.client.CreateSrv6NetworkSlice(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Srv6NetworkSlice: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -524,27 +532,24 @@ func (r *Srv6NetworkSliceResource) Update(ctx context.Context, req resource.Upda
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -577,6 +582,17 @@ func (r *Srv6NetworkSliceResource) Update(ctx context.Context, req resource.Upda
 	_, err := r.client.UpdateSrv6NetworkSlice(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Srv6NetworkSlice: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -396,25 +396,24 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -506,6 +505,15 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResource, err := r.client.CreateSubnet(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Subnet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -957,27 +965,24 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1069,6 +1074,17 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 	_, err := r.client.UpdateSubnet(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Subnet: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -1083,6 +1083,13 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/subnet_resource.go
+++ b/internal/provider/subnet_resource.go
@@ -396,6 +396,27 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -703,9 +724,18 @@ func (r *SubnetResource) Read(ctx context.Context, req resource.ReadRequest, res
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -925,6 +955,29 @@ func (r *SubnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/tcp_loadbalancer_resource.go
+++ b/internal/provider/tcp_loadbalancer_resource.go
@@ -2104,25 +2104,24 @@ func (r *TCPLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -2818,6 +2817,15 @@ func (r *TCPLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateTCPLoadBalancer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create TCPLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -5671,27 +5679,24 @@ func (r *TCPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -6387,6 +6392,17 @@ func (r *TCPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateTCPLoadBalancer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update TCPLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/tcp_loadbalancer_resource.go
+++ b/internal/provider/tcp_loadbalancer_resource.go
@@ -2104,6 +2104,27 @@ func (r *TCPLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -4216,9 +4237,18 @@ func (r *TCPLoadBalancerResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -5639,6 +5669,29 @@ func (r *TCPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/tcp_loadbalancer_resource.go
+++ b/internal/provider/tcp_loadbalancer_resource.go
@@ -6401,6 +6401,13 @@ func (r *TCPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/tenant_configuration_resource.go
+++ b/internal/provider/tenant_configuration_resource.go
@@ -1312,6 +1312,13 @@ func (r *TenantConfigurationResource) Update(ctx context.Context, req resource.U
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/tenant_configuration_resource.go
+++ b/internal/provider/tenant_configuration_resource.go
@@ -485,25 +485,24 @@ func (r *TenantConfigurationResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -602,6 +601,15 @@ func (r *TenantConfigurationResource) Create(ctx context.Context, req resource.C
 	apiResource, err := r.client.CreateTenantConfiguration(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create TenantConfiguration: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1179,27 +1187,24 @@ func (r *TenantConfigurationResource) Update(ctx context.Context, req resource.U
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1298,6 +1303,17 @@ func (r *TenantConfigurationResource) Update(ctx context.Context, req resource.U
 	_, err := r.client.UpdateTenantConfiguration(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update TenantConfiguration: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/tenant_configuration_resource.go
+++ b/internal/provider/tenant_configuration_resource.go
@@ -485,6 +485,27 @@ func (r *TenantConfigurationResource) Create(ctx context.Context, req resource.C
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -862,9 +883,18 @@ func (r *TenantConfigurationResource) Read(ctx context.Context, req resource.Rea
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1147,6 +1177,29 @@ func (r *TenantConfigurationResource) Update(ctx context.Context, req resource.U
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -222,25 +222,24 @@ func (r *TokenResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -257,6 +256,15 @@ func (r *TokenResource) Create(ctx context.Context, req resource.CreateRequest, 
 	apiResource, err := r.client.CreateToken(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Token: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -448,27 +456,24 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -485,6 +490,17 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	_, err := r.client.UpdateToken(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Token: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -499,6 +499,13 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -222,6 +222,27 @@ func (r *TokenResource) Create(ctx context.Context, req resource.CreateRequest, 
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -330,9 +351,18 @@ func (r *TokenResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -416,6 +446,29 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/trusted_ca_list_resource.go
+++ b/internal/provider/trusted_ca_list_resource.go
@@ -499,6 +499,13 @@ func (r *TrustedCAListResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/trusted_ca_list_resource.go
+++ b/internal/provider/trusted_ca_list_resource.go
@@ -218,6 +218,27 @@ func (r *TrustedCAListResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -322,9 +343,18 @@ func (r *TrustedCAListResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -413,6 +443,29 @@ func (r *TrustedCAListResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/trusted_ca_list_resource.go
+++ b/internal/provider/trusted_ca_list_resource.go
@@ -218,25 +218,24 @@ func (r *TrustedCAListResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -256,6 +255,15 @@ func (r *TrustedCAListResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateTrustedCAList(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create TrustedCAList: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -445,27 +453,24 @@ func (r *TrustedCAListResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -485,6 +490,17 @@ func (r *TrustedCAListResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateTrustedCAList(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update TrustedCAList: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/tunnel_resource.go
+++ b/internal/provider/tunnel_resource.go
@@ -644,25 +644,24 @@ func (r *TunnelResource) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -820,6 +819,15 @@ func (r *TunnelResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResource, err := r.client.CreateTunnel(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Tunnel: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1609,27 +1617,24 @@ func (r *TunnelResource) Update(ctx context.Context, req resource.UpdateRequest,
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1787,6 +1792,17 @@ func (r *TunnelResource) Update(ctx context.Context, req resource.UpdateRequest,
 	_, err := r.client.UpdateTunnel(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Tunnel: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/tunnel_resource.go
+++ b/internal/provider/tunnel_resource.go
@@ -644,6 +644,27 @@ func (r *TunnelResource) Create(ctx context.Context, req resource.CreateRequest,
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1186,9 +1207,18 @@ func (r *TunnelResource) Read(ctx context.Context, req resource.ReadRequest, res
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1577,6 +1607,29 @@ func (r *TunnelResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/tunnel_resource.go
+++ b/internal/provider/tunnel_resource.go
@@ -1801,6 +1801,13 @@ func (r *TunnelResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/udp_loadbalancer_resource.go
+++ b/internal/provider/udp_loadbalancer_resource.go
@@ -1114,25 +1114,24 @@ func (r *UDPLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1451,6 +1450,15 @@ func (r *UDPLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 	apiResource, err := r.client.CreateUDPLoadBalancer(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create UDPLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -2730,27 +2738,24 @@ func (r *UDPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -3069,6 +3074,17 @@ func (r *UDPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	_, err := r.client.UpdateUDPLoadBalancer(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update UDPLoadBalancer: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/udp_loadbalancer_resource.go
+++ b/internal/provider/udp_loadbalancer_resource.go
@@ -1114,6 +1114,27 @@ func (r *UDPLoadBalancerResource) Create(ctx context.Context, req resource.Creat
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -2062,9 +2083,18 @@ func (r *UDPLoadBalancerResource) Read(ctx context.Context, req resource.ReadReq
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -2698,6 +2728,29 @@ func (r *UDPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/udp_loadbalancer_resource.go
+++ b/internal/provider/udp_loadbalancer_resource.go
@@ -3083,6 +3083,13 @@ func (r *UDPLoadBalancerResource) Update(ctx context.Context, req resource.Updat
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/usb_policy_resource.go
+++ b/internal/provider/usb_policy_resource.go
@@ -711,6 +711,13 @@ func (r *UsbPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/usb_policy_resource.go
+++ b/internal/provider/usb_policy_resource.go
@@ -266,25 +266,24 @@ func (r *UsbPolicyResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -332,6 +331,15 @@ func (r *UsbPolicyResource) Create(ctx context.Context, req resource.CreateReque
 	apiResource, err := r.client.CreateUsbPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create UsbPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -629,27 +637,24 @@ func (r *UsbPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -697,6 +702,17 @@ func (r *UsbPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateUsbPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update UsbPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/usb_policy_resource.go
+++ b/internal/provider/usb_policy_resource.go
@@ -266,6 +266,27 @@ func (r *UsbPolicyResource) Create(ctx context.Context, req resource.CreateReque
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -452,9 +473,18 @@ func (r *UsbPolicyResource) Read(ctx context.Context, req resource.ReadRequest, 
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -597,6 +627,29 @@ func (r *UsbPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/user_identification_resource.go
+++ b/internal/provider/user_identification_resource.go
@@ -328,6 +328,27 @@ func (r *UserIdentificationResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -625,9 +646,18 @@ func (r *UserIdentificationResource) Read(ctx context.Context, req resource.Read
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -854,6 +884,29 @@ func (r *UserIdentificationResource) Update(ctx context.Context, req resource.Up
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/user_identification_resource.go
+++ b/internal/provider/user_identification_resource.go
@@ -995,6 +995,13 @@ func (r *UserIdentificationResource) Update(ctx context.Context, req resource.Up
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/user_identification_resource.go
+++ b/internal/provider/user_identification_resource.go
@@ -328,25 +328,24 @@ func (r *UserIdentificationResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -421,6 +420,15 @@ func (r *UserIdentificationResource) Create(ctx context.Context, req resource.Cr
 	apiResource, err := r.client.CreateUserIdentification(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create UserIdentification: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -886,27 +894,24 @@ func (r *UserIdentificationResource) Update(ctx context.Context, req resource.Up
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -981,6 +986,17 @@ func (r *UserIdentificationResource) Update(ctx context.Context, req resource.Up
 	_, err := r.client.UpdateUserIdentification(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update UserIdentification: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/virtual_host_resource.go
+++ b/internal/provider/virtual_host_resource.go
@@ -2854,25 +2854,24 @@ func (r *VirtualHostResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -4037,6 +4036,15 @@ func (r *VirtualHostResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateVirtualHost(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create VirtualHost: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -8924,27 +8932,24 @@ func (r *VirtualHostResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -10109,6 +10114,17 @@ func (r *VirtualHostResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateVirtualHost(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update VirtualHost: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/virtual_host_resource.go
+++ b/internal/provider/virtual_host_resource.go
@@ -2854,6 +2854,27 @@ func (r *VirtualHostResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -6452,9 +6473,18 @@ func (r *VirtualHostResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -8892,6 +8922,29 @@ func (r *VirtualHostResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/virtual_host_resource.go
+++ b/internal/provider/virtual_host_resource.go
@@ -10123,6 +10123,13 @@ func (r *VirtualHostResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/virtual_k8s_resource.go
+++ b/internal/provider/virtual_k8s_resource.go
@@ -845,6 +845,13 @@ func (r *VirtualK8SResource) Update(ctx context.Context, req resource.UpdateRequ
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/virtual_k8s_resource.go
+++ b/internal/provider/virtual_k8s_resource.go
@@ -324,6 +324,27 @@ func (r *VirtualK8SResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -548,9 +569,18 @@ func (r *VirtualK8SResource) Read(ctx context.Context, req resource.ReadRequest,
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -715,6 +745,29 @@ func (r *VirtualK8SResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/virtual_k8s_resource.go
+++ b/internal/provider/virtual_k8s_resource.go
@@ -324,25 +324,24 @@ func (r *VirtualK8SResource) Create(ctx context.Context, req resource.CreateRequ
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -406,6 +405,15 @@ func (r *VirtualK8SResource) Create(ctx context.Context, req resource.CreateRequ
 	apiResource, err := r.client.CreateVirtualK8S(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create VirtualK8S: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -747,27 +755,24 @@ func (r *VirtualK8SResource) Update(ctx context.Context, req resource.UpdateRequ
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -831,6 +836,17 @@ func (r *VirtualK8SResource) Update(ctx context.Context, req resource.UpdateRequ
 	_, err := r.client.UpdateVirtualK8S(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update VirtualK8S: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/virtual_network_resource.go
+++ b/internal/provider/virtual_network_resource.go
@@ -1172,6 +1172,13 @@ func (r *VirtualNetworkResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/virtual_network_resource.go
+++ b/internal/provider/virtual_network_resource.go
@@ -391,6 +391,27 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -745,9 +766,18 @@ func (r *VirtualNetworkResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -996,6 +1026,29 @@ func (r *VirtualNetworkResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/virtual_network_resource.go
+++ b/internal/provider/virtual_network_resource.go
@@ -391,25 +391,24 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -519,6 +518,15 @@ func (r *VirtualNetworkResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateVirtualNetwork(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create VirtualNetwork: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1028,27 +1036,24 @@ func (r *VirtualNetworkResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1158,6 +1163,17 @@ func (r *VirtualNetworkResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateVirtualNetwork(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update VirtualNetwork: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/virtual_site_resource.go
+++ b/internal/provider/virtual_site_resource.go
@@ -248,25 +248,24 @@ func (r *VirtualSiteResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -297,6 +296,15 @@ func (r *VirtualSiteResource) Create(ctx context.Context, req resource.CreateReq
 	apiResource, err := r.client.CreateVirtualSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create VirtualSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -520,27 +528,24 @@ func (r *VirtualSiteResource) Update(ctx context.Context, req resource.UpdateReq
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -571,6 +576,17 @@ func (r *VirtualSiteResource) Update(ctx context.Context, req resource.UpdateReq
 	_, err := r.client.UpdateVirtualSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update VirtualSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/virtual_site_resource.go
+++ b/internal/provider/virtual_site_resource.go
@@ -585,6 +585,13 @@ func (r *VirtualSiteResource) Update(ctx context.Context, req resource.UpdateReq
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/virtual_site_resource.go
+++ b/internal/provider/virtual_site_resource.go
@@ -248,6 +248,27 @@ func (r *VirtualSiteResource) Create(ctx context.Context, req resource.CreateReq
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -380,9 +401,18 @@ func (r *VirtualSiteResource) Read(ctx context.Context, req resource.ReadRequest
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -488,6 +518,29 @@ func (r *VirtualSiteResource) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/voltstack_site_resource.go
+++ b/internal/provider/voltstack_site_resource.go
@@ -7137,6 +7137,27 @@ func (r *VoltstackSiteResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
 	// unknown at validate time (labels = var.x, or a value derived from another
 	// resource). Runs against the resolved map, and before the platform's own labels are
@@ -16018,9 +16039,18 @@ func (r *VoltstackSiteResource) Read(ctx context.Context, req resource.ReadReque
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, true)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, true, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -22079,6 +22109,29 @@ func (r *VoltstackSiteResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is

--- a/internal/provider/voltstack_site_resource.go
+++ b/internal/provider/voltstack_site_resource.go
@@ -7137,25 +7137,24 @@ func (r *VoltstackSiteResource) Create(ctx context.Context, req resource.CreateR
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -9982,6 +9981,15 @@ func (r *VoltstackSiteResource) Create(ctx context.Context, req resource.CreateR
 	apiResource, err := r.client.CreateVoltstackSite(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create VoltstackSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -22111,27 +22119,24 @@ func (r *VoltstackSiteResource) Update(ctx context.Context, req resource.UpdateR
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -24979,6 +24984,17 @@ func (r *VoltstackSiteResource) Update(ctx context.Context, req resource.UpdateR
 	_, err := r.client.UpdateVoltstackSite(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update VoltstackSite: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/voltstack_site_resource.go
+++ b/internal/provider/voltstack_site_resource.go
@@ -24993,6 +24993,13 @@ func (r *VoltstackSiteResource) Update(ctx context.Context, req resource.UpdateR
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/waf_exclusion_policy_resource.go
+++ b/internal/provider/waf_exclusion_policy_resource.go
@@ -506,6 +506,27 @@ func (r *WAFExclusionPolicyResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -1009,9 +1030,18 @@ func (r *WAFExclusionPolicyResource) Read(ctx context.Context, req resource.Read
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -1362,6 +1392,29 @@ func (r *WAFExclusionPolicyResource) Update(ctx context.Context, req resource.Up
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/waf_exclusion_policy_resource.go
+++ b/internal/provider/waf_exclusion_policy_resource.go
@@ -506,25 +506,24 @@ func (r *WAFExclusionPolicyResource) Create(ctx context.Context, req resource.Cr
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -681,6 +680,15 @@ func (r *WAFExclusionPolicyResource) Create(ctx context.Context, req resource.Cr
 	apiResource, err := r.client.CreateWAFExclusionPolicy(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create WAFExclusionPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -1394,27 +1402,24 @@ func (r *WAFExclusionPolicyResource) Update(ctx context.Context, req resource.Up
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -1571,6 +1576,17 @@ func (r *WAFExclusionPolicyResource) Update(ctx context.Context, req resource.Up
 	_, err := r.client.UpdateWAFExclusionPolicy(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update WAFExclusionPolicy: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/waf_exclusion_policy_resource.go
+++ b/internal/provider/waf_exclusion_policy_resource.go
@@ -1585,6 +1585,13 @@ func (r *WAFExclusionPolicyResource) Update(ctx context.Context, req resource.Up
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/workload_flavor_resource.go
+++ b/internal/provider/workload_flavor_resource.go
@@ -224,6 +224,27 @@ func (r *WorkloadFlavorResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -344,9 +365,18 @@ func (r *WorkloadFlavorResource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -445,6 +475,29 @@ func (r *WorkloadFlavorResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/internal/provider/workload_flavor_resource.go
+++ b/internal/provider/workload_flavor_resource.go
@@ -537,6 +537,13 @@ func (r *WorkloadFlavorResource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/workload_flavor_resource.go
+++ b/internal/provider/workload_flavor_resource.go
@@ -224,25 +224,24 @@ func (r *WorkloadFlavorResource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -268,6 +267,15 @@ func (r *WorkloadFlavorResource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.CreateWorkloadFlavor(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create WorkloadFlavor: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -477,27 +485,24 @@ func (r *WorkloadFlavorResource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -523,6 +528,17 @@ func (r *WorkloadFlavorResource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.UpdateWorkloadFlavor(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update WorkloadFlavor: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/workload_resource.go
+++ b/internal/provider/workload_resource.go
@@ -65648,6 +65648,13 @@ func (r *WorkloadResource) Update(ctx context.Context, req resource.UpdateReques
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/workload_resource.go
+++ b/internal/provider/workload_resource.go
@@ -19501,25 +19501,24 @@ func (r *WorkloadResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -26610,6 +26609,15 @@ func (r *WorkloadResource) Create(ctx context.Context, req resource.CreateReques
 	apiResource, err := r.client.CreateWorkload(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create Workload: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -58523,27 +58531,24 @@ func (r *WorkloadResource) Update(ctx context.Context, req resource.UpdateReques
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
 	if !data.Annotations.IsNull() {
@@ -65634,6 +65639,17 @@ func (r *WorkloadResource) Update(ctx context.Context, req resource.UpdateReques
 	_, err := r.client.UpdateWorkload(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update Workload: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/workload_resource.go
+++ b/internal/provider/workload_resource.go
@@ -19501,6 +19501,27 @@ func (r *WorkloadResource) Create(ctx context.Context, req resource.CreateReques
 		createReq.Metadata.Labels = labels
 	}
 
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if !data.Annotations.IsNull() {
 		annotations := make(map[string]string)
 		resp.Diagnostics.Append(data.Annotations.ElementsAs(ctx, &annotations, false)...)
@@ -42538,9 +42559,18 @@ func (r *WorkloadResource) Read(ctx context.Context, req resource.ReadRequest, r
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, false)
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, false, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -58491,6 +58521,29 @@ func (r *WorkloadResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	if !data.Annotations.IsNull() {

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -1741,7 +1741,10 @@ func TestRenderNestedAttributes_Int64MinZero(t *testing.T) {
 // no convergence and only hides hw-model and friends from a caller that asked for the
 // object. A local review caught exactly that regression before this test existed.
 func TestTemplates_DiscoveryLabelFilterIsResourceOnly_Issue1391(t *testing.T) {
-	resourceCall := "filterSystemLabels(apiResource.Metadata.Labels, {{.FiltersDiscoveredSiteLabels}})"
+	// #1398 changed the call to filterSystemLabelsOwning, which takes the same
+	// per-resource flag plus the set of keys the configuration declared. The invariant
+	// this test protects is unchanged and still asserted: the flag drives the filter.
+	resourceCall := "filterSystemLabelsOwning(apiResource.Metadata.Labels, {{.FiltersDiscoveredSiteLabels}}, ownedLabels)"
 	if !strings.Contains(ResourceTemplate, resourceCall) {
 		t.Errorf("the resource template must drive the discovery filter from the per-resource flag; expected %q", resourceCall)
 	}
@@ -1839,6 +1842,51 @@ func TestResourceTemplate_PreservesPlatformLabelsAcrossAWrite_Issue1396(t *testi
 	for _, unwanted := range []string{"preservedPlatformLabels", "mergePreservedLabels", "isDiscoveredSiteLabel", "discoveredSiteLabelKeys"} {
 		if strings.Contains(undecorated, unwanted) {
 			t.Errorf("a resource F5 XC does not decorate must get none of the preservation mechanism; found %q", unwanted)
+		}
+	}
+}
+
+// #1398: a configuration must be able to own a label in the ves.io/ namespace. That
+// works only if the set of configuration-declared keys is recorded in private state at
+// Create and Update — the only points where the configuration is visible — and consulted
+// in Read, which sees prior state and cannot otherwise tell an owned label from one the
+// platform added.
+func TestTemplates_RecordOwnedLabelKeys_Issue1398(t *testing.T) {
+	record := "encodeOwnedLabelKeys(configLabelKeys("
+	if got := strings.Count(ResourceTemplate, record); got != 2 {
+		t.Errorf("expected ownership to be recorded in exactly Create and Update, found %d call(s) to %q", got, record)
+	}
+	if !strings.Contains(ResourceTemplate, "req.Private.GetKey(ctx, ownedLabelKeysPrivateKey)") {
+		t.Error("Read must consult the recorded ownership; without it a ves.io/ label never converges")
+	}
+
+	// The ordering that matters. Update merges the platform's own discovery labels into
+	// the outgoing map (#1391); recording ownership AFTER that merge would file those
+	// platform labels as configuration-owned, so Read would stop filtering them and the
+	// plan would propose deleting them again — the exact bug #1391 fixed.
+	updateIdx := strings.Index(ResourceTemplate, "func (r *{{.TitleCase}}Resource) Update(")
+	if updateIdx < 0 {
+		t.Fatal("Update method not found in the resource template")
+	}
+	update := ResourceTemplate[updateIdx:]
+	recordIdx := strings.Index(update, record)
+	mergeIdx := strings.Index(update, "mergePreservedLabels(")
+	if recordIdx < 0 {
+		t.Fatal("Update does not record owned label keys")
+	}
+	if mergeIdx >= 0 && recordIdx > mergeIdx {
+		t.Error("Update records ownership after mergePreservedLabels; the platform's own " +
+			"discovery labels would be recorded as configuration-owned, reintroducing #1391")
+	}
+
+	// Data sources have no plan to converge and no private state to read, so they must
+	// keep using the plain filter.
+	for name, tmpl := range map[string]string{
+		"DataSourceTemplate":         DataSourceTemplate,
+		"ReadOnlyDataSourceTemplate": ReadOnlyDataSourceTemplate,
+	} {
+		if strings.Contains(tmpl, "ownedLabelKeys") {
+			t.Errorf("%s must not consult label ownership: it has no plan to converge", name)
 		}
 	}
 }

--- a/tools/pkg/codegen/codegen_test.go
+++ b/tools/pkg/codegen/codegen_test.go
@@ -1890,3 +1890,44 @@ func TestTemplates_RecordOwnedLabelKeys_Issue1398(t *testing.T) {
 		}
 	}
 }
+
+// #1398, second round: private state is persisted even when Create or Update returns an
+// error. terraform-plugin-framework v1.17.0 copies createResp.Private / updateResp.Private
+// into the response (server_createresource.go:150, server_updateresource.go:165) BEFORE
+// its `if resp.Diagnostics.HasError() { return }`.
+//
+// So recording ownership before the API call is unsafe. Remove an owned ves.io/ label,
+// have the update fail, and private state records "owns nothing" while the server still
+// holds the label: the next Read filters it out, the plan shows nothing, and the label is
+// stranded on the server where Terraform can never see or remove it.
+//
+// The keys must still be CAPTURED before mergePreservedLabels — that ordering is asserted
+// separately — but they may only be WRITTEN once the API call has succeeded.
+func TestTemplates_OwnershipIsPersistedOnlyAfterTheAPICall_Issue1398(t *testing.T) {
+	for _, tc := range []struct{ method, apiCall string }{
+		{"Create", "r.client.Create{{.TitleCase}}(ctx, createReq)"},
+		{"Update", "r.client.Update{{.TitleCase}}(ctx, apiResource)"},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			start := strings.Index(ResourceTemplate, "func (r *{{.TitleCase}}Resource) "+tc.method+"(")
+			if start < 0 {
+				t.Fatalf("%s method not found", tc.method)
+			}
+			body := ResourceTemplate[start:]
+
+			apiIdx := strings.Index(body, tc.apiCall)
+			setIdx := strings.Index(body, "Private.SetKey(ctx, ownedLabelKeysPrivateKey")
+			if apiIdx < 0 {
+				t.Fatalf("%s: API call anchor %q not found — this guard would silently pass", tc.method, tc.apiCall)
+			}
+			if setIdx < 0 {
+				t.Fatalf("%s: ownership is never written to private state", tc.method)
+			}
+			if setIdx < apiIdx {
+				t.Errorf("%s writes ownership to private state before the API call. Private state "+
+					"survives an error, so a failed write would strand the label on the server, "+
+					"invisible to Terraform.", tc.method)
+			}
+		})
+	}
+}

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -335,25 +335,24 @@ func (r *{{.TitleCase}}Resource) Create(ctx context.Context, req resource.Create
 		createReq.Metadata.Labels = labels
 	}
 
-	// Record which label keys the configuration declared, so Read can tell a label this
+	// Capture which label keys the configuration declared, so Read can tell a label this
 	// configuration owns from one the platform added (#1398). Create and Update are the
 	// only places the configuration is visible; Read sees prior state, and prior state is
 	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
 	// labels into it.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+	//
+	// Captured here, written to private state only after the API call succeeds — see the
+	// note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 {{- if .FiltersDiscoveredSiteLabels}}
 
@@ -389,6 +388,15 @@ func (r *{{.TitleCase}}Resource) Create(ctx context.Context, req resource.Create
 	apiResource, err := r.client.Create{{.TitleCase}}(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create {{.TitleCase}}: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies createResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would claim
+	// keys the server never received.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -590,27 +598,24 @@ func (r *{{.TitleCase}}Resource) Update(ctx context.Context, req resource.Update
 		apiResource.Metadata.Labels = labels
 	}
 
-	// Re-record ownership on every update, because the configuration's label set can
+	// Re-capture ownership on every update, because the configuration's label set can
 	// change: a key added here becomes owned, and a key removed stops being owned so the
 	// next Read filters it again if it lives in a platform namespace (#1398).
 	//
-	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// Captured HERE, before the platform's own discovery labels are merged in below —
 	// merging first would record those as configuration-owned and reintroduce exactly the
-	// #1391 bug this pairs with.
-	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+	// #1391 bug this pairs with. Written to private state only after the API call
+	// succeeds; see the note at the write site.
+	ownedLabelKeys, ownedLabelErr := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels))
+	if ownedLabelErr != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Record Owned Label Keys",
-			"Could not encode the configuration's label keys for private state: "+err.Error()+
+			"Could not encode the configuration's label keys for private state: "+ownedLabelErr.Error()+
 				"\n\nWithout this record the read-back cannot distinguish a label this "+
 				"configuration owns from one the platform authored, and a label in the "+
 				"ves.io/ namespace would never converge.",
 		)
 		return
-	} else {
-		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 {{- if .FiltersDiscoveredSiteLabels}}
 
@@ -669,6 +674,17 @@ func (r *{{.TitleCase}}Resource) Update(ctx context.Context, req resource.Update
 	_, err := r.client.Update{{.TitleCase}}(ctx, apiResource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update {{.TitleCase}}: %s", err))
+		return
+	}
+
+	// Only now that the write has landed. terraform-plugin-framework persists private
+	// state even when the method returns an error (it copies updateResp.Private into the
+	// response before checking diagnostics), so recording ownership earlier would be
+	// worse than not recording it: dropping a ves.io/ label from the configuration and
+	// then failing the update would leave private state claiming the key is unowned while
+	// the server still holds it, and Read would filter it out of sight for good.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -334,6 +334,27 @@ func (r *{{.TitleCase}}Resource) Create(ctx context.Context, req resource.Create
 		}
 		createReq.Metadata.Labels = labels
 	}
+
+	// Record which label keys the configuration declared, so Read can tell a label this
+	// configuration owns from one the platform added (#1398). Create and Update are the
+	// only places the configuration is visible; Read sees prior state, and prior state is
+	// not evidence of ownership because providers up to 3.81.1 wrote the platform's own
+	// labels into it.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(createReq.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
 {{- if .FiltersDiscoveredSiteLabels}}
 
 	// Backstop for the ValidateConfig check, which cannot inspect a labels map that is
@@ -471,9 +492,18 @@ func (r *{{.TitleCase}}Resource) Read(ctx context.Context, req resource.ReadRequ
 	priorAnnotationsEmpty := !data.Annotations.IsNull() && !data.Annotations.IsUnknown() && len(data.Annotations.Elements()) == 0
 
 	// Filter out the labels the platform authors itself, which Terraform must not
-	// propose deleting just because the configuration does not mention them (#1391).
+	// propose deleting just because the configuration does not mention them (#1391) —
+	// except any key the configuration declared at the last Create or Update, recorded
+	// in private state. Without that exemption a configuration cannot own a label in the
+	// ves.io/ namespace at all: the write succeeds, the read-back strips it, and the next
+	// plan proposes adding it again, forever (#1398). Prior state cannot serve as the
+	// record, because providers up to 3.81.1 wrote the platform's own labels into it.
+	ownedLabels := map[string]struct{}{}
+	if rawOwned, ownedDiags := req.Private.GetKey(ctx, ownedLabelKeysPrivateKey); !ownedDiags.HasError() {
+		ownedLabels = decodeOwnedLabelKeys(rawOwned)
+	}
 	if len(apiResource.Metadata.Labels) > 0 {
-		filteredLabels := filterSystemLabels(apiResource.Metadata.Labels, {{.FiltersDiscoveredSiteLabels}})
+		filteredLabels := filterSystemLabelsOwning(apiResource.Metadata.Labels, {{.FiltersDiscoveredSiteLabels}}, ownedLabels)
 		if len(filteredLabels) > 0 {
 			labels, diags := types.MapValueFrom(ctx, types.StringType, filteredLabels)
 			resp.Diagnostics.Append(diags...)
@@ -558,6 +588,29 @@ func (r *{{.TitleCase}}Resource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		apiResource.Metadata.Labels = labels
+	}
+
+	// Re-record ownership on every update, because the configuration's label set can
+	// change: a key added here becomes owned, and a key removed stops being owned so the
+	// next Read filters it again if it lives in a platform namespace (#1398).
+	//
+	// Captured here, BEFORE the platform's own discovery labels are merged in below —
+	// merging first would record those as configuration-owned and reintroduce exactly the
+	// #1391 bug this pairs with.
+	if ownedEncoded, err := encodeOwnedLabelKeys(configLabelKeys(apiResource.Metadata.Labels)); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Record Owned Label Keys",
+			"Could not encode the configuration's label keys for private state: "+err.Error()+
+				"\n\nWithout this record the read-back cannot distinguish a label this "+
+				"configuration owns from one the platform authored, and a label in the "+
+				"ves.io/ namespace would never converge.",
+		)
+		return
+	} else {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedEncoded)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 {{- if .FiltersDiscoveredSiteLabels}}
 

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -683,6 +683,13 @@ func (r *{{.TitleCase}}Resource) Update(ctx context.Context, req resource.Update
 	// worse than not recording it: dropping a ves.io/ label from the configuration and
 	// then failing the update would leave private state claiming the key is unowned while
 	// the server still holds it, and Read would filter it out of sight for good.
+	//
+	// This is not airtight, and cannot be: Client.Put returns json.Unmarshal's error
+	// after a 2xx, so an error does not strictly prove the write was rejected. What it
+	// does guarantee is the direction of the residual. If the write landed and we return
+	// early, ownership stays as it was — an added label keeps being planned, which is
+	// visible and self-corrects on the next successful apply. The opposite ordering loses
+	// a label silently and permanently. Fail loud rather than fail quiet.
 	resp.Diagnostics.Append(resp.Private.SetKey(ctx, ownedLabelKeysPrivateKey, ownedLabelKeys)...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
`filterSystemLabels` strips every key in the `ves.io/` and `internal.ves.io/` namespaces from the read-back, because F5 XC authors labels there and Terraform must not propose deleting them (#1391). **Users set labels in those namespaces too** — real sites in this tenant carry `ves.io/app`, `ves.io/app_type`, `ves.io/mcn-demo` — and when they do the label is unmanageable: the configuration writes it, the read-back removes it from state, the next plan proposes adding it again, forever.

Measured on `cem1-l1` with released provider 3.81.1 and `labels = { "ves.io/app" = "demo" }`: two consecutive plans each reported `1 to change` while the server held the label. Not drift — Terraform cannot see what it wrote.

## Why prior state cannot be the record

#1391 briefly fixed this by treating any platform-prefixed key already in prior state as owned. That had to be reverted: **every provider up to 3.81.1 wrote the platform's own labels into state**, so the guard kept those too and went on proposing their deletion.

Ownership is therefore recorded where the configuration is actually visible — Create and Update — in private state, which legacy state cannot forge. `Read` decodes it and exempts exactly those keys. **130 of the 130 label-carrying resources** carry the plumbing (131 total; one has no labels).

## Two orderings that both matter

| ordering | why |
| --- | --- |
| capture **before** `mergePreservedLabels` | capturing after would file the platform's discovery labels as configuration-owned and reintroduce #1391 |
| persist **after** the API call | private state survives an error, so persisting first could strand a label on the server |

Both are asserted by template tests that **fatal if their anchors stop matching**, rather than skipping silently. That mattered enough to check explicitly: a guard that quietly binds to nothing is the defect class behind most of this week's work.

## Second opinion

Two rounds of `codex:verified-code-review`, **both findings confirmed, neither refuted**:

1. **high** — I was persisting ownership *before* the API call. Confirmed by reading terraform-plugin-framework v1.17.0: `server_createresource.go:150` and `server_updateresource.go:165` copy `Private` into the response **before** their `if resp.Diagnostics.HasError() { return }`. Dropping a `ves.io/` label and then failing the update would have left private state claiming the key unowned while the server still held it — filtered out of state, absent from the plan, stranded permanently. Fixed; the guard above was red before and green after.
2. **medium** — `Client.Put` returns `json.Unmarshal`'s error after a 2xx, so an error does not prove the write was rejected. Not closable: a transport error carries no evidence either way. What the current ordering guarantees is the *direction* of the residual — write-landed-plus-error leaves ownership unchanged, so an added label keeps being planned, which is visible and self-corrects on the next successful apply. The pre-fix ordering lost a label silently and permanently. Documented at the write site.

Gate: `done: true`, `findingsClear: true`, suite pass.

## Verification

- 8 new unit tests on the helpers, 2 new template guards — each red before its fix
- `go build`, `go vet`, full suite, `golangci-lint` — all clean, **0 issues**
- docs and examples regenerate with **0 drift**
- the #1391 template guard is updated for the new call and still asserts its invariant

## Live verification — done

Run against the live tenant on a disposable `ip_prefix_set`, created and destroyed for the purpose.

| provider | plan | result |
| --- | --- | --- |
| this build | plan 1 | `exit=0` — No changes |
| this build | plan 2 | `exit=0` — No changes |
| released 3.81.1, same object and state | plan | `exit=2` — `1 to change`, proposing `+ "ves.io/app" = "demo"` |

Changing the label and removing it both reconcile, with the removal taking effect server-side. A platform-style `ves.io/` label the configuration never declares stays filtered and is never proposed for deletion — both with the private entry present and with it stripped, which is the pre-#1398 upgrade path.

Full detail and the counterfactual output are on #1398. Resource destroyed afterwards; follow-up `GET` returns 404.

Closes #1398