### PR TITLE
chore: auto-regenerate provider and documentation

### DIFF
--- a/docs/resources/dns_domain.md
+++ b/docs/resources/dns_domain.md
@@ -47,7 +47,7 @@ resource "xcsh_dns_domain" "example" {
 
 ### Metadata Argument Reference
 
-<a id="name"></a>&#x2022; [`name`](#name) - Required String<br>Domain name for the DNS Domain (e.g., example.com). Must be a valid DNS domain name
+<a id="name"></a>&#x2022; [`name`](#name) - Required String<br>Name of the DNS Domain. Must be unique within the namespace
 
 <a id="annotations"></a>&#x2022; [`annotations`](#annotations) - Optional Map<br>Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata
 

--- a/internal/provider/dns_domain_resource.go
+++ b/internal/provider/dns_domain_resource.go
@@ -69,13 +69,13 @@ func (r *DNSDomainResource) Schema(ctx context.Context, req resource.SchemaReque
 		MarkdownDescription: "Manages DNS Domain in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Domain name for the DNS Domain (e.g., example.com). Must be a valid DNS domain name.",
+				MarkdownDescription: "Name of the DNS Domain. Must be unique within the namespace.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					validators.DomainValidator(),
+					validators.NameValidator(),
 				},
 			},
 			"namespace": schema.StringAttribute{

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -114,7 +114,6 @@ func (r *TokenResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"uid": schema.StringAttribute{
 				MarkdownDescription: "Server-generated unique identifier (`system_metadata.uid`). Read-only; assigned by F5 Distributed Cloud on creation.",
 				Computed:            true,
-				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
## Summary
Automated regeneration of provider code and/or documentation.

## Triggered By
Commit: 646a5b6322f969fe2084bf3b8fcd65078b48ec12

## Changes
- Provider code regenerated: true
- Documentation regenerated: false

Closes #1587