### PR TITLE
fix(security): resolve repository scan findings

### DIFF
--- a/.github-runner-docker/.env.example
+++ b/.github-runner-docker/.env.example
@@ -6,7 +6,7 @@ GITHUB_OWNER=f5-sales-demo
 GITHUB_REPOSITORY=robinmordasiewicz/terraform-provider-xcsh
 
 # Authentication (use fine-grained PAT with Administration: Read & Write)
-GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GITHUB_TOKEN=<GITHUB_TOKEN>
 
 # Runner Settings
 RUNNER_LABELS=self-hosted,Linux,X64,container

--- a/internal/provider/origin_pool_resource_test.go
+++ b/internal/provider/origin_pool_resource_test.go
@@ -788,7 +788,7 @@ func testAccOriginPoolConfig_nestedLabels(name, ip string, labels map[string]str
 	if len(labels) > 0 {
 		labelsStr.WriteString("    labels = {\n")
 		for k, v := range labels {
-			labelsStr.WriteString(fmt.Sprintf("      %q = %q\n", k, v))
+			fmt.Fprintf(&labelsStr, "      %q = %q\n", k, v)
 		}
 		labelsStr.WriteString("    }\n")
 	}
@@ -811,4 +811,3 @@ resource "xcsh_origin_pool" "test" {
 }
 `, name, ip, labelsStr.String())
 }
-

--- a/internal/provider/securemesh_site_v2_resource_test.go
+++ b/internal/provider/securemesh_site_v2_resource_test.go
@@ -95,7 +95,7 @@ func testAccSecuremeshSiteV2ResourceConfig_withLabels(name, description string, 
 	if len(topLabels) > 0 {
 		topLabelsStr.WriteString("  labels = {\n")
 		for k, v := range topLabels {
-			topLabelsStr.WriteString(fmt.Sprintf("    %q = %q\n", k, v))
+			fmt.Fprintf(&topLabelsStr, "    %q = %q\n", k, v)
 		}
 		topLabelsStr.WriteString("  }\n")
 	}


### PR DESCRIPTION
## Summary

- replace the token-shaped runner example with the governed placeholder format
- repair existing Go test-helper formatting and staticcheck findings discovered by the full lint gate
- retain the managed repository-hygiene findings for the final docs-control rollout

## Validation

- `make test`
- `make lint` (0 issues)
- `go run tools/generate-mock-fixtures.go && gofmt -w internal/mocks/generated_defaults.go && git diff --exit-code -- internal/mocks/generated_defaults.go`
- `bash scripts/check-pii.sh --scope staged --mode enforce`
- `gitleaks git --staged --redact --no-banner .`
- workflow-equivalent Semgrep scan (9 known/classified findings; no new finding introduced by this diff)

Closes #1640
