### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -80,7 +80,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   mock-tests:
     name: Mock Tests (Parallel)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     # Always run mock tests except for real-only mode
     if: |
       github.event_name != 'workflow_dispatch' ||
@@ -420,7 +420,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   compare-results:
     name: Compare Mock vs Real
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     needs: [mock-tests, real-api-tests]
     # Only run when both mock and real tests have completed
     if: |
@@ -540,7 +540,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   summary:
     name: Test Summary
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     needs: [mock-tests, real-api-tests, compare-results, cleanup]
     if: always()
 

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -80,7 +80,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   mock-tests:
     name: Mock Tests (Parallel)
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     # Always run mock tests except for real-only mode
     if: |
       github.event_name != 'workflow_dispatch' ||
@@ -200,7 +200,7 @@ jobs:
     name: Real API Tests (Sequential)
     environment: acceptance-tests
     # Runner selection: exact repository-specific self-hosted runner tuple
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     needs: [mock-tests]
     # Run only when the selected mode's prerequisite state is exact. The
     # explicit always() is required for real-only: its mock prerequisite is
@@ -348,7 +348,7 @@ jobs:
   cleanup:
     name: Cleanup Test Resources
     environment: acceptance-tests
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     needs: [real-api-tests]
     # ALWAYS run after real API tests, even if they failed
     if: |
@@ -420,7 +420,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   compare-results:
     name: Compare Mock vs Real
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     needs: [mock-tests, real-api-tests]
     # Only run when both mock and real tests have completed
     if: |
@@ -540,7 +540,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   summary:
     name: Test Summary
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     needs: [mock-tests, real-api-tests, compare-results, cleanup]
     if: always()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   check-constitution:
     name: Constitution Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     # Skip for automated branches - they're expected to contain generated files
     if: |
       github.event_name == 'pull_request' &&
@@ -88,7 +88,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-docs-generation:
     name: Validate Docs Generation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -186,7 +186,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-mock-fixtures:
     name: Validate Mock Fixtures
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -266,7 +266,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-shell-scripts:
     name: Validate Shell Scripts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -310,7 +310,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-terraform-examples:
     name: Validate Terraform Examples
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   check-constitution:
     name: Constitution Check
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     # Skip for automated branches - they're expected to contain generated files
     if: |
       github.event_name == 'pull_request' &&
@@ -88,7 +88,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-docs-generation:
     name: Validate Docs Generation
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -186,7 +186,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-mock-fixtures:
     name: Validate Mock Fixtures
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -266,7 +266,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-shell-scripts:
     name: Validate Shell Scripts
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -310,7 +310,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   validate-terraform-examples:
     name: Validate Terraform Examples
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -62,7 +62,7 @@ jobs:
     environment: default-discovery
     # IMPORTANT: This MUST run on a self-hosted runner with VPN access
     # The staging environment is not accessible from public GitHub runners
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     # Checkout, push, and PR creation all use REPO_SYNC_TOKEN explicitly. Keep
     # the automatic GITHUB_TOKEN disabled rather than granting duplicate writes.
     permissions: {}
@@ -301,7 +301,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   summary:
     name: Discovery Summary
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     needs: discover
     if: always()
     steps:

--- a/.github/workflows/discover-defaults.yml
+++ b/.github/workflows/discover-defaults.yml
@@ -301,7 +301,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   summary:
     name: Discovery Summary
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     needs: discover
     if: always()
     steps:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -71,7 +71,7 @@ jobs:
   # ===========================================================================
   detect-changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     permissions:
       contents: read # actions/checkout only
       pull-requests: read # attest an automated regeneration merge from its exact PR
@@ -427,7 +427,7 @@ jobs:
     name: Classify Generator State
     needs: [detect-changes, build-test, regenerate-provider, regenerate-docs]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     permissions: {}
     outputs:
       create-pr: ${{ steps.classify.outputs.create_pr }}
@@ -530,7 +530,7 @@ jobs:
       always() &&
       needs.generation-state.result == 'success' &&
       needs.generation-state.outputs.create-pr == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     # Branch push, issue creation, PR creation and auto-merge all authenticate
     # with secrets.REPO_SYNC_TOKEN (checkout too, with persist-credentials:
     # false), so GITHUB_TOKEN needs no write scope here.
@@ -916,7 +916,7 @@ jobs:
       needs.detect-changes.outputs.is-regeneration-commit == 'true' &&
       needs.tag-release.result == 'success' &&
       needs.tag-release.outputs.new-tag != ''
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     permissions:
       contents: read
     steps:
@@ -931,7 +931,7 @@ jobs:
           fi
 
       - name: Checkout immutable released commit
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -1041,7 +1041,7 @@ jobs:
     name: Workflow Summary
     needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, generation-state, create-regeneration-pr, tag-release, receipt-spec-delivery]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     permissions: {} # writes only to GITHUB_STEP_SUMMARY
     steps:
       - name: Print summary

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -71,7 +71,7 @@ jobs:
   # ===========================================================================
   detect-changes:
     name: Detect Changes
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     permissions:
       contents: read # actions/checkout only
       pull-requests: read # attest an automated regeneration merge from its exact PR
@@ -427,7 +427,7 @@ jobs:
     name: Classify Generator State
     needs: [detect-changes, build-test, regenerate-provider, regenerate-docs]
     if: always()
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     permissions: {}
     outputs:
       create-pr: ${{ steps.classify.outputs.create_pr }}
@@ -530,7 +530,7 @@ jobs:
       always() &&
       needs.generation-state.result == 'success' &&
       needs.generation-state.outputs.create-pr == 'true'
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     # Branch push, issue creation, PR creation and auto-merge all authenticate
     # with secrets.REPO_SYNC_TOKEN (checkout too, with persist-credentials:
     # false), so GITHUB_TOKEN needs no write scope here.
@@ -916,7 +916,7 @@ jobs:
       needs.detect-changes.outputs.is-regeneration-commit == 'true' &&
       needs.tag-release.result == 'success' &&
       needs.tag-release.outputs.new-tag != ''
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     permissions:
       contents: read
     steps:
@@ -1041,7 +1041,7 @@ jobs:
     name: Workflow Summary
     needs: [detect-changes, build-test, regenerate-provider, regenerate-docs, generation-state, create-regeneration-pr, tag-release, receipt-spec-delivery]
     if: always()
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     permissions: {} # writes only to GITHUB_STEP_SUMMARY
     steps:
       - name: Print summary

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   govulncheck:
     name: Go Vulnerability Check
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     permissions:
       contents: read # checkout and resolve the repository's Go dependency graph
       issues: write # create one deduplicated vulnerability issue when needed

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   govulncheck:
     name: Go Vulnerability Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     permissions:
       contents: read # checkout and resolve the repository's Go dependency graph
       issues: write # create one deduplicated vulnerability issue when needed

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -34,7 +34,7 @@ jobs:
   sync:
     name: Sync OpenAPI Specs
     environment: provider-delivery
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
     # Every mutation uses REPO_SYNC_TOKEN explicitly. Keeping GITHUB_TOKEN
     # disabled also prevents an accidental token push that suppresses PR checks.
     permissions: {}

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -34,7 +34,7 @@ jobs:
   sync:
     name: Sync OpenAPI Specs
     environment: provider-delivery
-    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh]
+    runs-on: [self-hosted, Linux, X64, terraform-provider-xcsh, ubuntu-24.04]
     # Every mutation uses REPO_SYNC_TOKEN explicitly. Keeping GITHUB_TOKEN
     # disabled also prevents an accidental token push that suppresses PR checks.
     permissions: {}

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -20,6 +20,10 @@ import (
 
 const repositoryRunnerLabel = "terraform-provider-xcsh"
 
+var canonicalSelfHostedRunsOn = []string{
+	"self-hosted", "Linux", "X64", repositoryRunnerLabel, "ubuntu-24.04",
+}
+
 type jobContract struct {
 	workflow    string
 	job         string
@@ -34,13 +38,13 @@ type jobContract struct {
 func strptr(value string) *string { return &value }
 
 var protectedJobs = []jobContract{
-	{"acc-tests.yml", "mock-tests", []string{"ubuntu-latest"}, "", map[string]string{"checks": "write", "contents": "read"}, []string{"pull_request", "schedule", "workflow_dispatch"}, nil, nil},
-	{"acc-tests.yml", "real-api-tests", []string{"self-hosted", "Linux", "X64", repositoryRunnerLabel}, "acceptance-tests", map[string]string{"checks": "write", "contents": "read"}, []string{"pull_request", "schedule", "workflow_dispatch"}, strptr("always() &&\ngithub.event_name != 'pull_request' &&\n((github.event_name == 'schedule' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'full' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'real-only' &&\n  needs.mock-tests.result == 'skipped'))\n"), []string{"XCSH_API_TOKEN", "XCSH_API_URL"}},
-	{"acc-tests.yml", "cleanup", []string{"self-hosted", "Linux", "X64", repositoryRunnerLabel}, "acceptance-tests", map[string]string{"contents": "read"}, []string{"pull_request", "schedule", "workflow_dispatch"}, strptr("always() &&\ngithub.event_name != 'pull_request' &&\nneeds.real-api-tests.result != 'skipped'\n"), []string{"XCSH_API_TOKEN", "XCSH_API_URL"}},
-	{"discover-defaults.yml", "discover", []string{"self-hosted", "Linux", "X64", repositoryRunnerLabel}, "default-discovery", map[string]string{}, []string{"schedule", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN", "XCSH_API_TOKEN", "XCSH_API_URL"}},
-	{"sync-openapi.yml", "sync", []string{"ubuntu-latest"}, "provider-delivery", map[string]string{}, []string{"repository_dispatch", "workflow_dispatch"}, nil, []string{"GITHUB_TOKEN", "REPO_SYNC_TOKEN"}},
-	{"on-merge.yml", "create-regeneration-pr", []string{"ubuntu-latest"}, "provider-delivery", map[string]string{"contents": "read"}, []string{"push", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN"}},
-	{"on-merge.yml", "receipt-spec-delivery", []string{"ubuntu-latest"}, "provider-delivery", map[string]string{"contents": "read"}, []string{"push", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN"}},
+	{"acc-tests.yml", "mock-tests", canonicalSelfHostedRunsOn, "", map[string]string{"checks": "write", "contents": "read"}, []string{"pull_request", "schedule", "workflow_dispatch"}, nil, nil},
+	{"acc-tests.yml", "real-api-tests", canonicalSelfHostedRunsOn, "acceptance-tests", map[string]string{"checks": "write", "contents": "read"}, []string{"pull_request", "schedule", "workflow_dispatch"}, strptr("always() &&\ngithub.event_name != 'pull_request' &&\n((github.event_name == 'schedule' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'full' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'real-only' &&\n  needs.mock-tests.result == 'skipped'))\n"), []string{"XCSH_API_TOKEN", "XCSH_API_URL"}},
+	{"acc-tests.yml", "cleanup", canonicalSelfHostedRunsOn, "acceptance-tests", map[string]string{"contents": "read"}, []string{"pull_request", "schedule", "workflow_dispatch"}, strptr("always() &&\ngithub.event_name != 'pull_request' &&\nneeds.real-api-tests.result != 'skipped'\n"), []string{"XCSH_API_TOKEN", "XCSH_API_URL"}},
+	{"discover-defaults.yml", "discover", canonicalSelfHostedRunsOn, "default-discovery", map[string]string{}, []string{"schedule", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN", "XCSH_API_TOKEN", "XCSH_API_URL"}},
+	{"sync-openapi.yml", "sync", canonicalSelfHostedRunsOn, "provider-delivery", map[string]string{}, []string{"repository_dispatch", "workflow_dispatch"}, nil, []string{"GITHUB_TOKEN", "REPO_SYNC_TOKEN"}},
+	{"on-merge.yml", "create-regeneration-pr", canonicalSelfHostedRunsOn, "provider-delivery", map[string]string{"contents": "read"}, []string{"push", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN"}},
+	{"on-merge.yml", "receipt-spec-delivery", canonicalSelfHostedRunsOn, "provider-delivery", map[string]string{"contents": "read"}, []string{"push", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN"}},
 	{"auto-merge.yml", "require-token", []string{"ubuntu-latest"}, "repository-settings", map[string]string{}, []string{"pull_request"}, nil, []string{"REPO_SYNC_TOKEN"}},
 }
 
@@ -280,10 +284,10 @@ func validateWorkflowBytes(filename string, content []byte) []string {
 				}
 			}
 		}
-		contract, listed := contracts[jobID]
-		if isSelfHosted && !listed {
-			errors = append(errors, "unlisted self-hosted job "+jobID)
+		if isSelfHosted && !reflect.DeepEqual(runsOn, canonicalSelfHostedRunsOn) {
+			errors = append(errors, jobID+": invalid self-hosted tuple")
 		}
+		contract, listed := contracts[jobID]
 		if !listed {
 			continue
 		}
@@ -293,9 +297,6 @@ func validateWorkflowBytes(filename string, content []byte) []string {
 		}
 		if !reflect.DeepEqual(runsOn, contract.runsOn) {
 			errors = append(errors, fmt.Sprintf("%s: runs-on %v", jobID, runsOn))
-		}
-		if isSelfHosted && !reflect.DeepEqual(runsOn, []string{"self-hosted", "Linux", "X64", repositoryRunnerLabel}) {
-			errors = append(errors, jobID+": invalid self-hosted tuple")
 		}
 		if scalarString(job["environment"]) != contract.environment {
 			errors = append(errors, jobID+": environment mismatch")
@@ -416,7 +417,27 @@ func TestProviderWorkflowContracts(t *testing.T) {
 			}
 		}
 	}
-	expected := map[string]bool{"acc-tests.yml/real-api-tests": true, "acc-tests.yml/cleanup": true, "discover-defaults.yml/discover": true}
+	expected := map[string]bool{
+		"acc-tests.yml/cleanup":               true,
+		"acc-tests.yml/compare-results":       true,
+		"acc-tests.yml/mock-tests":            true,
+		"acc-tests.yml/real-api-tests":        true,
+		"acc-tests.yml/summary":               true,
+		"ci.yml/check-constitution":           true,
+		"ci.yml/validate-docs-generation":     true,
+		"ci.yml/validate-mock-fixtures":       true,
+		"ci.yml/validate-shell-scripts":       true,
+		"ci.yml/validate-terraform-examples":  true,
+		"discover-defaults.yml/discover":      true,
+		"discover-defaults.yml/summary":       true,
+		"on-merge.yml/create-regeneration-pr": true,
+		"on-merge.yml/detect-changes":         true,
+		"on-merge.yml/generation-state":       true,
+		"on-merge.yml/receipt-spec-delivery":  true,
+		"on-merge.yml/summary":                true,
+		"security-audit.yml/govulncheck":      true,
+		"sync-openapi.yml/sync":               true,
+	}
 	if !reflect.DeepEqual(selfHosted, expected) {
 		t.Fatalf("self-hosted inventory mismatch: %v", selfHosted)
 	}


### PR DESCRIPTION
Closes #1642

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.