### PR TITLE
chore(governance): bootstrap exact managed callers

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   resolve-source:
     name: Resolve protected governance source
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     environment: repository-settings
     outputs:
       source_sha: ${{ steps.resolve.outputs.source_sha }}
@@ -255,7 +255,7 @@ jobs:
   enforce-settings:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@1c904e731ec7ef505850e9f6cfdba76a692f421b
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
     secrets:
@@ -264,7 +264,7 @@ jobs:
   sync-files:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@1c904e731ec7ef505850e9f6cfdba76a692f421b
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
       downstream_sha: ${{ github.sha }}

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   check:
     name: Check linked issues
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       issues: write # read linked issues and publish one deduplicated guidance comment
       pull-requests: read # enumerate open pull requests and linked-issue references

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@1c904e731ec7ef505850e9f6cfdba76a692f421b
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
     with:
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
     permissions:

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const repositoryRunnerLabel = "terraform-provider-xcsh"
+const repositoryRunnerExpression = "${{ github.event.repository.name }}"
 
 var canonicalSelfHostedRunsOn = []string{
 	"self-hosted", "Linux", "X64", repositoryRunnerLabel, "ubuntu-24.04",
@@ -106,6 +107,21 @@ func stringSlice(value any) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("runs-on must be a literal string or list, got %T", value)
 	}
+}
+
+func canonicalizeRunsOn(runsOn []string, errors *[]string, jobID string) []string {
+	canonical := append([]string(nil), runsOn...)
+	for index, label := range runsOn {
+		if !strings.Contains(label, "${{") {
+			continue
+		}
+		if label != repositoryRunnerExpression {
+			*errors = append(*errors, jobID+": dynamic runs-on is forbidden")
+			continue
+		}
+		canonical[index] = repositoryRunnerLabel
+	}
+	return canonical
 }
 
 func stringMap(value any) (map[string]string, error) {
@@ -277,14 +293,11 @@ func validateWorkflowBytes(filename string, content []byte) []string {
 	for jobID, job := range workflow.Jobs {
 		runsOn, runErr := stringSlice(job["runs-on"])
 		isSelfHosted := runErr == nil && slicesContain(runsOn, "self-hosted")
+		canonicalRunsOn := runsOn
 		if runErr == nil {
-			for _, label := range runsOn {
-				if strings.Contains(label, "${{") {
-					errors = append(errors, jobID+": dynamic runs-on is forbidden")
-				}
-			}
+			canonicalRunsOn = canonicalizeRunsOn(runsOn, &errors, jobID)
 		}
-		if isSelfHosted && !reflect.DeepEqual(runsOn, canonicalSelfHostedRunsOn) {
+		if isSelfHosted && !reflect.DeepEqual(canonicalRunsOn, canonicalSelfHostedRunsOn) {
 			errors = append(errors, jobID+": invalid self-hosted tuple")
 		}
 		contract, listed := contracts[jobID]
@@ -295,8 +308,8 @@ func validateWorkflowBytes(filename string, content []byte) []string {
 			errors = append(errors, jobID+": "+runErr.Error())
 			continue
 		}
-		if !reflect.DeepEqual(runsOn, contract.runsOn) {
-			errors = append(errors, fmt.Sprintf("%s: runs-on %v", jobID, runsOn))
+		if !reflect.DeepEqual(canonicalRunsOn, contract.runsOn) {
+			errors = append(errors, fmt.Sprintf("%s: runs-on %v", jobID, canonicalRunsOn))
 		}
 		if scalarString(job["environment"]) != contract.environment {
 			errors = append(errors, jobID+": environment mismatch")
@@ -418,25 +431,27 @@ func TestProviderWorkflowContracts(t *testing.T) {
 		}
 	}
 	expected := map[string]bool{
-		"acc-tests.yml/cleanup":               true,
-		"acc-tests.yml/compare-results":       true,
-		"acc-tests.yml/mock-tests":            true,
-		"acc-tests.yml/real-api-tests":        true,
-		"acc-tests.yml/summary":               true,
-		"ci.yml/check-constitution":           true,
-		"ci.yml/validate-docs-generation":     true,
-		"ci.yml/validate-mock-fixtures":       true,
-		"ci.yml/validate-shell-scripts":       true,
-		"ci.yml/validate-terraform-examples":  true,
-		"discover-defaults.yml/discover":      true,
-		"discover-defaults.yml/summary":       true,
-		"on-merge.yml/create-regeneration-pr": true,
-		"on-merge.yml/detect-changes":         true,
-		"on-merge.yml/generation-state":       true,
-		"on-merge.yml/receipt-spec-delivery":  true,
-		"on-merge.yml/summary":                true,
-		"security-audit.yml/govulncheck":      true,
-		"sync-openapi.yml/sync":               true,
+		"acc-tests.yml/cleanup":                    true,
+		"acc-tests.yml/compare-results":            true,
+		"acc-tests.yml/mock-tests":                 true,
+		"acc-tests.yml/real-api-tests":             true,
+		"acc-tests.yml/summary":                    true,
+		"ci.yml/check-constitution":                true,
+		"ci.yml/validate-docs-generation":          true,
+		"ci.yml/validate-mock-fixtures":            true,
+		"ci.yml/validate-shell-scripts":            true,
+		"ci.yml/validate-terraform-examples":       true,
+		"discover-defaults.yml/discover":           true,
+		"discover-defaults.yml/summary":            true,
+		"enforce-repo-settings.yml/resolve-source": true,
+		"on-merge.yml/create-regeneration-pr":      true,
+		"on-merge.yml/detect-changes":              true,
+		"on-merge.yml/generation-state":            true,
+		"on-merge.yml/receipt-spec-delivery":       true,
+		"on-merge.yml/summary":                     true,
+		"require-linked-issue.yml/check":           true,
+		"security-audit.yml/govulncheck":           true,
+		"sync-openapi.yml/sync":                    true,
 	}
 	if !reflect.DeepEqual(selfHosted, expected) {
 		t.Fatalf("self-hosted inventory mismatch: %v", selfHosted)
@@ -493,6 +508,24 @@ func TestProviderWorkflowMutationsFail(t *testing.T) {
 				t.Fatal("unsafe mutation passed validation")
 			}
 		})
+	}
+}
+
+func TestWorkflowContractsRejectNonCanonicalDynamicRunner(t *testing.T) {
+	valid := []byte(`
+name: runner contract fixture
+on: workflow_dispatch
+jobs:
+  check:
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+`)
+	if issues := validateWorkflowBytes("fixture.yml", valid); len(issues) != 0 {
+		t.Fatalf("canonical repository runner expression failed: %v", issues)
+	}
+
+	unsafe := []byte(strings.Replace(string(valid), "github.event.repository.name", "github.event.inputs.runner", 1))
+	if issues := validateWorkflowBytes("fixture.yml", unsafe); len(issues) == 0 {
+		t.Fatal("non-canonical dynamic runner passed validation")
 	}
 }
 


### PR DESCRIPTION
Installs the exact enforcement, Super-Linter, translation-audit, and linked-issue workflows before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.

The workflow-contract test canonicalizes only the fixed repository-name runner expression, adds the two generated caller jobs to the approved self-hosted inventory, and rejects every other dynamic runner selector.

Closes #1645