### PR TITLE
fix(ci): verify ShellCheck without sudo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,11 +292,19 @@ jobs:
             echo "No shell script changes - skipping validation"
           fi
 
-      - name: Install shellcheck
+      - name: Install verified ShellCheck
         if: steps.check.outputs.needs_validation == 'true'
+        env:
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+          SHELLCHECK_VERSION: v0.11.0
         run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+          archive="${RUNNER_TEMP}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          curl --fail --location --retry 3 \
+            --output "${archive}" \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          printf '%s  %s\n' "${SHELLCHECK_SHA256}" "${archive}" | sha256sum --check -
+          tar -xJf "${archive}" -C "${RUNNER_TEMP}"
+          echo "${RUNNER_TEMP}/shellcheck-${SHELLCHECK_VERSION}" >> "${GITHUB_PATH}"
 
       - name: Run shellcheck
         if: steps.check.outputs.needs_validation == 'true'


### PR DESCRIPTION
## Summary

- replace the runtime `sudo apt-get` ShellCheck installation with the official v0.11.0 Linux/amd64 release
- verify the release asset against its published SHA-256 digest before execution
- install only into `RUNNER_TEMP`, preserving the immutable socketless runner contract

## Verification

- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml`
- `zizmor --pedantic .github/workflows/ci.yml`
- downloaded the pinned asset, verified its digest, and ran it across every repository shell script with `--severity=warning`
- `go test ./tools`
- `git diff --check`
- exact-HEAD `bash scripts/agy-pre-push-review.sh` (no high or critical findings)

Closes #1659