### PR TITLE
fix(ci): route reusable jobs to governed runner

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -29,7 +29,7 @@ permissions: {}
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # checkout plus the repository-local download action
     outputs:
@@ -131,7 +131,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     if: inputs.run-lint
     permissions:
       contents: read # checkout the source being linted

--- a/.github/workflows/_generate-docs.yml
+++ b/.github/workflows/_generate-docs.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   generate:
     name: Generate Documentation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # checkout and download the public API-spec release
     outputs:

--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   generate:
     name: Generate Provider Code
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # checkout and download the public API-spec release
     outputs:

--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   preflight:
     name: Verify Release Source Is Reproducible
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # checkout and exact public spec release download
     steps:
@@ -95,7 +95,7 @@ jobs:
   tag:
     name: Resolve Immutable Version Tag
     needs: preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     # Creates the annotated version tag after proving it targets github.sha.
     permissions:
       contents: write # push the verified annotated tag
@@ -202,7 +202,7 @@ jobs:
   publish:
     name: Verify and Publish Release
     needs: tag
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     # GoReleaser creates/repairs the draft and this job seals it after byte verification.
     permissions:
       contents: write # create/repair, verify, and publish release assets

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -445,6 +445,13 @@ func TestProviderWorkflowContracts(t *testing.T) {
 		}
 	}
 	expected := map[string]bool{
+		"_build-test.yml/build":                    true,
+		"_build-test.yml/lint":                     true,
+		"_generate-docs.yml/generate":              true,
+		"_generate-provider.yml/generate":          true,
+		"_tag-release.yml/preflight":               true,
+		"_tag-release.yml/publish":                 true,
+		"_tag-release.yml/tag":                     true,
 		"acc-tests.yml/cleanup":                    true,
 		"acc-tests.yml/compare-results":            true,
 		"acc-tests.yml/mock-tests":                 true,


### PR DESCRIPTION
## Summary

- route all seven concrete jobs in the reusable build, generation, and release workflows through the exact repository-scoped socketless `ubuntu-24.04` profile
- extend the workflow contract inventory so hosted-route regressions fail locally
- preserve permissions, steps, secrets, triggers, and release behavior without granting Docker socket access

## Validation

- `go test ./tools`
- `go test -race ./tools`
- `go vet ./tools`
- `actionlint`
- exact PR #1666 combined-state workflow-security validator and runner auditor: 32 governed self-hosted findings approved, zero routing errors
- `git diff --check`
- exact-HEAD `bash scripts/agy-pre-push-review.sh`: passed

Closes #1667