### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -610,7 +610,9 @@
       "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
     },
     "f5-sales-demo/api-specs-enriched": {
-      "runner": { "profiles": ["ubuntu-24.04", "container-build"] }
+      "runner": {
+        "profiles": ["ubuntu-24.04", "ubuntu-24.04-secondary", "container-build"]
+      }
     },
     "f5-sales-demo/apt-repo": {
       "runner": { "profiles": ["ubuntu-24.04", "container-build"] }


### PR DESCRIPTION
Closes #1681

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/config/self-hosted-runner-policy.json