### PR TITLE
fix(release): suppress recovery-only releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,7 @@ jobs:
           set -euo pipefail
           CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           ALLOW_PENDING_DELIVERY=false
-          if [ -n "$CHANGED_FILES" ] &&
-            ! printf '%s\n' "$CHANGED_FILES" | grep -qvE \
-              '^(\.github/workflows/|tools/validate_workflows_test\.go$|scripts/(generate-provider-docs|(check|test-check)-spec-version-freshness)\.sh$)'; then
+          if printf '%s\n' "$CHANGED_FILES" | scripts/is-release-recovery-only.sh; then
             ALLOW_PENDING_DELIVERY=true
           fi
           ALLOW_PENDING_DELIVERY="$ALLOW_PENDING_DELIVERY" \

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -84,6 +84,7 @@ jobs:
       has-any-changes: ${{ steps.changes.outputs.has_any_changes }}
       is-regeneration-commit: ${{ steps.check-author.outputs.is_regeneration }}
       pending-delivery: ${{ steps.changes.outputs.pending_delivery }}
+      recovery-infrastructure-only: ${{ steps.changes.outputs.recovery_infrastructure_only }}
       should-process: ${{ steps.should-process.outputs.result }}
       needs-regeneration: ${{ steps.should-process.outputs.needs_regeneration }}
       provider-regeneration-required: ${{ steps.should-process.outputs.provider_required }}
@@ -247,6 +248,12 @@ jobs:
             PENDING_DELIVERY=true
           fi
           echo "pending_delivery=$PENDING_DELIVERY" >> "$GITHUB_OUTPUT"
+
+          RECOVERY_INFRASTRUCTURE_ONLY=false
+          if printf '%s\n' "$CHANGED" | scripts/is-release-recovery-only.sh; then
+            RECOVERY_INFRASTRUCTURE_ONLY=true
+          fi
+          echo "recovery_infrastructure_only=$RECOVERY_INFRASTRUCTURE_ONLY" >> "$GITHUB_OUTPUT"
 
           # Check for OpenAPI spec changes
           if echo "$CHANGED" | grep -qE '^docs/specifications/api/'; then
@@ -444,6 +451,7 @@ jobs:
           SHOULD_PROCESS: ${{ needs.detect-changes.outputs.should-process }}
           IS_REGENERATION: ${{ needs.detect-changes.outputs.is-regeneration-commit }}
           PENDING_DELIVERY: ${{ needs.detect-changes.outputs.pending-delivery }}
+          RECOVERY_INFRASTRUCTURE_ONLY: ${{ needs.detect-changes.outputs.recovery-infrastructure-only }}
           BUILD_RESULT: ${{ needs.build-test.result }}
           PROVIDER_REQUIRED: ${{ needs.detect-changes.outputs.provider-regeneration-required }}
           PROVIDER_RESULT: ${{ needs.regenerate-provider.result }}
@@ -511,7 +519,7 @@ jobs:
           if [ "$PENDING_DELIVERY" = "true" ] ||
              [ "$PROVIDER_CHANGED" = "true" ] || [ "$DOCS_CHANGED" = "true" ]; then
             CREATE_PR=true
-          else
+          elif [ "$RECOVERY_INFRASTRUCTURE_ONLY" != "true" ]; then
             RELEASE=true
           fi
           {

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -342,18 +342,19 @@ func TestOnMergeGeneratorStateTruthTable(t *testing.T) {
 		tmp := t.TempDir()
 		output := filepath.Join(tmp, "github-output")
 		values := map[string]string{
-			"DETECT_RESULT":     "success",
-			"SHOULD_PROCESS":    "true",
-			"IS_REGENERATION":   "false",
-			"PENDING_DELIVERY":  "false",
-			"BUILD_RESULT":      "success",
-			"PROVIDER_REQUIRED": "true",
-			"PROVIDER_RESULT":   "success",
-			"PROVIDER_CHANGED":  "false",
-			"DOCS_REQUIRED":     "true",
-			"DOCS_RESULT":       "success",
-			"DOCS_CHANGED":      "false",
-			"GITHUB_OUTPUT":     output,
+			"DETECT_RESULT":                "success",
+			"SHOULD_PROCESS":               "true",
+			"IS_REGENERATION":              "false",
+			"PENDING_DELIVERY":             "false",
+			"RECOVERY_INFRASTRUCTURE_ONLY": "false",
+			"BUILD_RESULT":                 "success",
+			"PROVIDER_REQUIRED":            "true",
+			"PROVIDER_RESULT":              "success",
+			"PROVIDER_CHANGED":             "false",
+			"DOCS_REQUIRED":                "true",
+			"DOCS_RESULT":                  "success",
+			"DOCS_CHANGED":                 "false",
+			"GITHUB_OUTPUT":                output,
 		}
 		for _, assignment := range extraEnv {
 			key, value, ok := strings.Cut(assignment, "=")
@@ -425,6 +426,27 @@ func TestOnMergeGeneratorStateTruthTable(t *testing.T) {
 		}
 		if !strings.Contains(outputs, "create_pr=true") || strings.Contains(outputs, "release=true") {
 			t.Fatalf("pending delivery bypassed regeneration PR:\n%s", outputs)
+		}
+	})
+
+	t.Run("recovery infrastructure cannot release directly", func(t *testing.T) {
+		outputs, result, err := run(t, "RECOVERY_INFRASTRUCTURE_ONLY=true")
+		if err != nil {
+			t.Fatalf("recovery-only state failed classification: %v\n%s", err, result)
+		}
+		if strings.Contains(outputs, "create_pr=true") || strings.Contains(outputs, "release=true") {
+			t.Fatalf("recovery-only state authorized publication:\n%s", outputs)
+		}
+
+		outputs, result, err = run(t,
+			"RECOVERY_INFRASTRUCTURE_ONLY=true",
+			"PROVIDER_CHANGED=true",
+		)
+		if err != nil {
+			t.Fatalf("recovery generated-change state failed: %v\n%s", err, result)
+		}
+		if !strings.Contains(outputs, "create_pr=true") || strings.Contains(outputs, "release=true") {
+			t.Fatalf("recovery generated change bypassed regeneration PR:\n%s", outputs)
 		}
 	})
 

--- a/scripts/is-release-recovery-only.sh
+++ b/scripts/is-release-recovery-only.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+saw_path=false
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  saw_path=true
+  case "$path" in
+  .github/workflows/* | \
+    tools/validate_workflows_test.go | \
+    internal/acctest/release_integrity_test.go | \
+    scripts/generate-provider-docs.sh | \
+    scripts/check-spec-version-freshness.sh | \
+    scripts/test-check-spec-version-freshness.sh | \
+    scripts/is-release-recovery-only.sh) ;;
+  *) exit 1 ;;
+  esac
+done
+
+[ "$saw_path" = true ]

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -71,13 +72,71 @@ func TestConstitutionAllowsOnlyExactPendingWorkflowRecovery(t *testing.T) {
 	required := []string{
 		`ALLOW_PENDING_DELIVERY=false`,
 		`ALLOW_PENDING_DELIVERY=true`,
-		`grep -qvE`,
-		`generate-provider-docs`,
+		`scripts/is-release-recovery-only.sh`,
 		`tools/spec-pending-delivery.json`,
 	}
 	for _, fragment := range required {
 		if !strings.Contains(workflow, fragment) {
 			t.Errorf("constitution pending-recovery contract is missing %q", fragment)
+		}
+	}
+}
+
+func TestReleaseRecoveryPathClassifier(t *testing.T) {
+	script := filepath.Join("..", "scripts", "is-release-recovery-only.sh")
+	cases := []struct {
+		name    string
+		paths   string
+		allowed bool
+	}{
+		{
+			name: "exact recovery infrastructure",
+			paths: strings.Join([]string{
+				".github/workflows/on-merge.yml",
+				".github/workflows/ci.yml",
+				"tools/validate_workflows_test.go",
+				"internal/acctest/release_integrity_test.go",
+				"scripts/generate-provider-docs.sh",
+				"scripts/check-spec-version-freshness.sh",
+				"scripts/test-check-spec-version-freshness.sh",
+				"scripts/is-release-recovery-only.sh",
+			}, "\n"),
+			allowed: true,
+		},
+		{name: "empty", paths: "", allowed: false},
+		{name: "substantive", paths: "internal/provider/provider.go\n", allowed: false},
+		{
+			name:    "mixed substantive",
+			paths:   ".github/workflows/on-merge.yml\ninternal/provider/provider.go\n",
+			allowed: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(script)
+			cmd.Stdin = strings.NewReader(tc.paths)
+			err := cmd.Run()
+			if (err == nil) != tc.allowed {
+				t.Fatalf("allowed=%v, error=%v", tc.allowed, err)
+			}
+		})
+	}
+}
+
+func TestOnMergeGeneratorStateClassifier(t *testing.T) {
+	workflowBytes, err := os.ReadFile(filepath.Join("..", ".github", "workflows", "on-merge.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(workflowBytes)
+	for _, fragment := range []string{
+		`recovery-infrastructure-only: ${{ steps.changes.outputs.recovery_infrastructure_only }}`,
+		`scripts/is-release-recovery-only.sh`,
+		`RECOVERY_INFRASTRUCTURE_ONLY: ${{ needs.detect-changes.outputs.recovery-infrastructure-only }}`,
+		`elif [ "$RECOVERY_INFRASTRUCTURE_ONLY" != "true" ]; then`,
+	} {
+		if !strings.Contains(workflow, fragment) {
+			t.Errorf("on-merge recovery release classifier is missing %q", fragment)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- centralize the exact recovery-infrastructure path set in one executable classifier shared by CI and On Merge
- expose recovery-only change state to the generator-state gate
- suppress direct tagging when recovery validation produces no generated output
- preserve regeneration PRs for generated changes and pending deliveries
- extend the authoritative release truth table and workflow contract tests

## Verification

- `go test ./tools`
- `go test ./internal/acctest -run "TestOnMergeGeneratorStateTruthTable|TestOnMergePublicationJobsConsumeOnlyClassifierAuthorization"`
- `go test ./...`
- `actionlint .github/workflows/ci.yml .github/workflows/on-merge.yml`
- changed-file pre-commit suite (all hooks passed)

Closes #1685