### PR TITLE
fix(release): bypass stale attestation during pending recovery

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -101,9 +101,19 @@ jobs:
         id: check-author
         env:
           GH_TOKEN: ${{ github.token }}
+          PENDING_RESUME: ${{ inputs.resume-pending || false }}
           TARGET_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "${PENDING_RESUME:-false}" = "true" ]; then
+            # A recovery dispatch regenerates from the current main tree. HEAD may
+            # be the previously rejected stale regeneration merge, so it is not a
+            # candidate release commit in this path. The build, generators, and
+            # pending-delivery validators below remain mandatory.
+            echo "Manual pending recovery bypasses historical merge attestation"
+            echo "is_regeneration=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           MESSAGE=$(git log -1 --format='%s')
           echo "Message: $MESSAGE"
           REGENERATION_TITLE="chore: auto-regenerate provider and documentation"

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -301,6 +301,31 @@ func TestRegenerationCommitRequiresExactPendingAttestation(t *testing.T) {
 		}
 	})
 
+	t.Run("manual pending recovery bypasses historical merge attestation", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		regenerationCommit := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+		sourceCommit := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD^"))
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "checkout", "-q", "--detach", sourceCommit)
+		writeReleaseTestFile(t, fixture.repo, "intervening.txt", "main advanced\n", 0o600)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", "intervening.txt")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "intervening main change")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "cherry-pick", regenerationCommit)
+		rewriteRegenerationPRMergeCommit(t, fixture, strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD")))
+		output := filepath.Join(fixture.repo, "attestation-output")
+		env := append(append([]string{}, fixture.env...), "PENDING_RESUME=true", "TARGET_REPOSITORY="+dispatchTarget, "GITHUB_OUTPUT="+output)
+		result, runErr := runWorkflowScript(fixture.repo, script, env)
+		if runErr != nil {
+			t.Fatalf("manual recovery inspected the historical regeneration merge: %v\n%s", runErr, result)
+		}
+		outputs, readErr := os.ReadFile(output) //nolint:gosec // isolated fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.TrimSpace(string(outputs)) != "is_regeneration=false" {
+			t.Fatalf("manual recovery did not enter the human regeneration path: %s", outputs)
+		}
+	})
+
 	t.Run("exact subject without PR attestation is a human change", func(t *testing.T) {
 		fixture := newReceiptFixture(t, false, false)
 		parent := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD^"))


### PR DESCRIPTION
## Summary

- bypass push-only HEAD regeneration attestation for an explicit `resume-pending=true` dispatch
- classify that recovery as a human regeneration path so build, generators, and receipt rebinding remain mandatory
- cover a stale-but-ancestral historical merge on both the normal fail-closed path and the manual recovery path

## Verification

- `go test ./internal/acctest -run TestRegenerationCommitRequiresExactPendingAttestation -count=1`
- `go test ./tools -run Test\(OnMergeRegenerationSubjectBindsSquashPRNumber\|ReleaseRecoveryPathClassifier\|OnMergeGeneratorStateClassifier\) -count=1`
- `go test ./...`
- `git diff --check`
- `pre-commit run --files .github/workflows/on-merge.yml internal/acctest/release_integrity_test.go`

Closes #1693