### PR TITLE
fix(release): attest recovered receipt rebinds

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -175,10 +175,36 @@ jobs:
                 echo "::error::A pending delivery can be released only by a receipted regeneration commit"
                 exit 1
               }
-              git diff --diff-filter=A --name-only HEAD^ HEAD | grep -qx "$RECEIPT" || {
-                echo "::error::Regeneration receipt was not introduced by this commit"
-                exit 1
-              }
+              RECEIPT_STATUS=$(git diff --name-status HEAD^ HEAD -- "$RECEIPT" | awk 'NR == 1 { print $1 }')
+              case "$RECEIPT_STATUS" in
+                A)
+                  echo "Regeneration receipt was introduced by this commit"
+                  ;;
+                M)
+                  PREVIOUS_RECEIPT=$(git show "HEAD^:$RECEIPT") || {
+                    echo "::error::Existing regeneration receipt could not be read from the pre-merge commit"
+                    exit 1
+                  }
+                  jq -e --slurpfile current "$RECEIPT" '
+                    type == "object" and
+                    (keys | sort) == [
+                      "delivery_id", "release_tag", "source_commit", "spec_release_sha256",
+                      "target_commit", "version"
+                    ] and
+                    (.source_commit | test("^[0-9a-f]{40}$")) and
+                    .source_commit != $current[0].source_commit and
+                    del(.source_commit) == ($current[0] | del(.source_commit))
+                  ' <<< "$PREVIOUS_RECEIPT" >/dev/null || {
+                    echo "::error::Existing regeneration receipt may change only its source commit during recovery"
+                    exit 1
+                  }
+                  echo "Existing regeneration receipt was rebound for pending recovery"
+                  ;;
+                *)
+                  echo "::error::Regeneration receipt must be added or rebound by this commit"
+                  exit 1
+                  ;;
+              esac
               jq -e '
                 type == "object" and
                 (keys | sort) == ["delivery_id", "release_tag", "target_commit", "version"] and
@@ -238,7 +264,7 @@ jobs:
               echo "Detected a regeneration merge without a spec delivery"
             fi
           elif [ "$RECEIPT_CHANGED" = true ]; then
-            echo "::error::Only the exact regeneration merge may introduce a receipt"
+            echo "::error::Only the exact regeneration merge may add or modify a receipt"
             exit 1
           fi
           echo "is_regeneration=$IS_REGENERATION" >> "$GITHUB_OUTPUT"

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -246,6 +246,95 @@ func TestRegenerationCommitRequiresExactPendingAttestation(t *testing.T) {
 		}
 	})
 
+	t.Run("pending recovery rebinds an existing receipt", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		receiptPath := filepath.Join(fixture.repo, "tools/spec-regeneration-receipt.json")
+		data, err := os.ReadFile(receiptPath) //nolint:gosec // isolated test fixture
+		if err != nil {
+			t.Fatal(err)
+		}
+		var receipt map[string]any
+		if err := json.Unmarshal(data, &receipt); err != nil {
+			t.Fatal(err)
+		}
+
+		base := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD^"))
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "checkout", "-q", "--detach", base)
+		receipt["source_commit"] = strings.Repeat("a", 40)
+		writeReleaseTestJSON(t, receiptPath, receipt)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "rejected regeneration receipt")
+		recoverySource := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+
+		receipt["source_commit"] = recoverySource
+		writeReleaseTestJSON(t, receiptPath, receipt)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "chore: auto-regenerate provider and documentation")
+		recoveryMerge := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+		rewriteRegenerationPRIdentity(t, fixture, recoveryMerge, recoverySource)
+
+		output := filepath.Join(fixture.repo, "attestation-output")
+		env := append(append([]string{}, fixture.env...), "TARGET_REPOSITORY="+dispatchTarget, "GITHUB_OUTPUT="+output)
+		result, runErr := runWorkflowScript(fixture.repo, script, env)
+		if runErr != nil {
+			t.Fatalf("valid recovery receipt rebind failed: %v\n%s", runErr, result)
+		}
+		outputs, readErr := os.ReadFile(output) //nolint:gosec // isolated fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !strings.Contains(string(outputs), "is_regeneration=true") {
+			t.Fatalf("recovery receipt rebind was not recognized:\n%s", outputs)
+		}
+	})
+
+	t.Run("recovery receipt may change only its source commit", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		receiptPath := filepath.Join(fixture.repo, "tools/spec-regeneration-receipt.json")
+		data, err := os.ReadFile(receiptPath) //nolint:gosec // isolated test fixture
+		if err != nil {
+			t.Fatal(err)
+		}
+		var receipt map[string]any
+		if err := json.Unmarshal(data, &receipt); err != nil {
+			t.Fatal(err)
+		}
+
+		base := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD^"))
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "checkout", "-q", "--detach", base)
+		receipt["source_commit"] = strings.Repeat("a", 40)
+		writeReleaseTestJSON(t, receiptPath, receipt)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "rejected regeneration receipt")
+		recoverySource := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+
+		receipt["source_commit"] = recoverySource
+		receipt["version"] = "2.1.209"
+		writeReleaseTestJSON(t, receiptPath, receipt)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "chore: auto-regenerate provider and documentation")
+		recoveryMerge := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+		rewriteRegenerationPRIdentity(t, fixture, recoveryMerge, recoverySource)
+
+		output := filepath.Join(fixture.repo, "attestation-output")
+		env := append(append([]string{}, fixture.env...), "TARGET_REPOSITORY="+dispatchTarget, "GITHUB_OUTPUT="+output)
+		result, runErr := runWorkflowScript(fixture.repo, script, env)
+		if runErr == nil || !strings.Contains(result, "may change only its source commit") {
+			t.Fatalf("non-source recovery receipt change was accepted: err=%v\n%s", runErr, result)
+		}
+	})
+
+	t.Run("unattested receipt change fails closed", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		writeReleaseTestJSON(t, fixture.regenPR, []map[string]any{})
+		output := filepath.Join(fixture.repo, "attestation-output")
+		env := append(append([]string{}, fixture.env...), "TARGET_REPOSITORY="+dispatchTarget, "GITHUB_OUTPUT="+output)
+		result, runErr := runWorkflowScript(fixture.repo, script, env)
+		if runErr == nil || !strings.Contains(result, "Only the exact regeneration merge may add or modify a receipt") {
+			t.Fatalf("unattested receipt change was accepted: err=%v\n%s", runErr, result)
+		}
+	})
+
 	t.Run("pending delivery without receipt fails closed", func(t *testing.T) {
 		fixture := newReceiptFixture(t, false, false)
 		runReleaseTestCommand(t, fixture.repo, nil, "git", "rm", "-q", "tools/spec-regeneration-receipt.json")
@@ -1711,6 +1800,24 @@ func rewriteRegenerationPRMergeCommit(t *testing.T, fixture *receiptFixture, com
 		t.Fatalf("expected one regeneration PR fixture, found %d", len(pulls))
 	}
 	pulls[0]["merge_commit_sha"] = commit
+	writeReleaseTestJSON(t, fixture.regenPR, pulls)
+}
+
+func rewriteRegenerationPRIdentity(t *testing.T, fixture *receiptFixture, mergeCommit, sourceCommit string) {
+	t.Helper()
+	data, err := os.ReadFile(fixture.regenPR) //nolint:gosec // isolated test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pulls []map[string]any
+	if err := json.Unmarshal(data, &pulls); err != nil {
+		t.Fatal(err)
+	}
+	if len(pulls) != 1 {
+		t.Fatalf("expected one regeneration PR fixture, found %d", len(pulls))
+	}
+	pulls[0]["merge_commit_sha"] = mergeCommit
+	pulls[0]["head"].(map[string]any)["ref"] = "auto-regenerate/" + sourceCommit
 	writeReleaseTestJSON(t, fixture.regenPR, pulls)
 }
 


### PR DESCRIPTION
## Summary

Allow the exact trusted regeneration merge to rebind a pre-existing pending-delivery receipt during recovery while preserving fail-closed release attestation.

## Related Issue

Closes #1697

## Changes

- distinguish newly added receipts from recovery modifications in post-merge attestation
- require a recovery modification to change only `source_commit`
- retain exact PR identity, pre-merge parent, pending pin, canonical delivery ID, and current receipt validation
- cover valid additions, valid recovery rebinds, non-source mutations, and unattested edits

## Verification evidence

- `go test ./internal/acctest -run '^TestRegenerationCommitRequiresExactPendingAttestation$' -count=1` — passed
- focused workflow-contract test set — passed
- `git diff --check` — passed
- `pre-commit run --files .github/workflows/on-merge.yml internal/acctest/release_integrity_test.go` — passed
- `go test ./...` — passed

## Delivery evidence

- Failed release run 31974716550 was contained before build/tag/release and supplied the reproduced error.
- CI, squash auto-merge, post-merge recovery, release, and receipt evidence will be monitored through completion.

## Checklist

- [x] Linked to a detailed issue with `Closes #1697`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written and passing; the issue acceptance criteria are met
- [x] Verified locally by running the workflow-contract and full Go test suites
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned
- [x] Follows project conventions and style guides