### PR TITLE
fix(release): process attested receipt-only merges

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -387,11 +387,11 @@ jobs:
           fi
           RESULT=false
 
-          if [[ "$DELIVERY_METADATA_ONLY" == "true" ]]; then
-            echo "Skipping: delivery receipt metadata cannot trigger regeneration or a release"
-          elif [[ "$IS_REGENERATION" == "true" ]]; then
+          if [[ "$IS_REGENERATION" == "true" ]]; then
             echo "Processing: exact regeneration completion - will proceed to tag/release"
             RESULT=true
+          elif [[ "$DELIVERY_METADATA_ONLY" == "true" ]]; then
+            echo "Skipping: delivery receipt metadata cannot trigger regeneration or a release"
           elif [[ "$NEEDS_REGEN" == "false" ]]; then
             # No regeneration needed - check if there are any substantive changes for tagging
             if [[ "$HAS_ANY_CHANGES" == "true" ]]; then

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -437,6 +437,52 @@ func TestRegenerationCommitRequiresExactPendingAttestation(t *testing.T) {
 	})
 }
 
+func TestOnMergeProcessingPrioritizesExactRegenerationIdentity(t *testing.T) {
+	script := extractWorkflowRunStep(t, "on-merge.yml", "detect-changes", "Determine if processing should proceed")
+	run := func(t *testing.T, isRegeneration string) (string, string, error) {
+		t.Helper()
+		tmp := t.TempDir()
+		output := filepath.Join(tmp, "github-output")
+		env := []string{
+			"IS_REGENERATION=" + isRegeneration,
+			"SPECS=false",
+			"CODE=false",
+			"TOOLS=false",
+			"FUNCTIONS=false",
+			"HAS_ANY_CHANGES=false",
+			"DELIVERY_METADATA_ONLY=true",
+			"PENDING_DELIVERY=false",
+			"GITHUB_OUTPUT=" + output,
+		}
+		result, err := runWorkflowScript(tmp, script, env)
+		outputs, readErr := os.ReadFile(output) //nolint:gosec // isolated fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		return string(outputs), result, err
+	}
+
+	t.Run("attested receipt-only regeneration proceeds", func(t *testing.T) {
+		outputs, result, err := run(t, "true")
+		if err != nil {
+			t.Fatalf("exact regeneration classification failed: %v\n%s", err, result)
+		}
+		if !strings.Contains(outputs, "result=true") || !strings.Contains(result, "exact regeneration completion") {
+			t.Fatalf("exact receipt-only regeneration did not proceed:\n%s\n%s", outputs, result)
+		}
+	})
+
+	t.Run("ordinary receipt-only commit remains skipped", func(t *testing.T) {
+		outputs, result, err := run(t, "false")
+		if err != nil {
+			t.Fatalf("ordinary metadata classification failed: %v\n%s", err, result)
+		}
+		if !strings.Contains(outputs, "result=false") || !strings.Contains(result, "metadata cannot trigger") {
+			t.Fatalf("ordinary receipt-only commit was not skipped:\n%s\n%s", outputs, result)
+		}
+	})
+}
+
 func TestOnMergeGeneratorStateTruthTable(t *testing.T) {
 	script := extractWorkflowRunStep(t, "on-merge.yml", "generation-state", "Classify generator state")
 	type generatorState struct {


### PR DESCRIPTION
## Summary

- prioritize an exact attested regeneration merge over the generic delivery-metadata-only guard
- preserve the non-releasing behavior for ordinary receipt-only commits
- add workflow contract coverage for both sides of that precedence

## Verification

- `go test ./internal/acctest -run 'TestOnMergeProcessingPrioritizesExactRegenerationIdentity|TestRegenerationCommitRequiresExactPendingAttestation|TestOnMergeGeneratorStateTruthTable' -count=1`
- `go test ./internal/acctest -count=1`
- `pre-commit run --files .github/workflows/on-merge.yml internal/acctest/release_integrity_test.go`
- `go test ./...`
- `git diff --check`

Closes #1701
