### PR TITLE
fix(release): authenticate immutable policy checks

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -10,6 +10,9 @@ on:
       gpg-passphrase:
         description: GPG key passphrase
         required: true
+      repository-administration-token:
+        description: Read repository release-immutability policy
+        required: true
     outputs:
       new-tag:
         description: The immutable version tag for this commit
@@ -40,7 +43,7 @@ jobs:
 
       - name: Require immutable release policy before tagging
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.repository-administration-token }}
           REPOSITORY: ${{ github.repository }}
         run: |
           gh api "repos/${REPOSITORY}/immutable-releases" \
@@ -233,11 +236,13 @@ jobs:
         id: release_state
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_ADMINISTRATION_TOKEN: ${{ secrets.repository-administration-token }}
           RELEASE_TAG: ${{ needs.tag.outputs.new_tag }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh api "repos/${REPOSITORY}/immutable-releases" \
+          GH_TOKEN="$REPOSITORY_ADMINISTRATION_TOKEN" \
+            gh api "repos/${REPOSITORY}/immutable-releases" \
             | jq -e '.enabled == true' >/dev/null || {
             echo "::error::Repository release immutability must be enabled before tagging"
             exit 1

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -951,6 +951,7 @@ jobs:
     secrets:
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
       gpg-passphrase: ${{ secrets.PASSPHRASE }}
+      repository-administration-token: ${{ secrets.REPO_SYNC_TOKEN }}
 
   # A dispatch is complete only after generated provider content is merged and
   # the corresponding provider release exists. The sync PR records pending

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -23,3 +23,4 @@ jobs:
     secrets:
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
       gpg-passphrase: ${{ secrets.PASSPHRASE }}
+      repository-administration-token: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -972,6 +972,7 @@ esac
 				"RUNNER_TEMP=" + tmp,
 				"GITHUB_OUTPUT=" + output,
 				"GH_TOKEN=fixture",
+				"REPOSITORY_ADMINISTRATION_TOKEN=administration-fixture",
 			})
 			if fixture.wantError != "" {
 				if runErr == nil || !strings.Contains(result, fixture.wantError) {
@@ -990,6 +991,36 @@ esac
 				t.Fatalf("release state was not classified as %s: %s", fixture.wantState, outputs)
 			}
 		})
+	}
+}
+
+func TestReleaseImmutabilityChecksUseAdministrationToken(t *testing.T) {
+	root := testRepositoryRoot(t)
+	releaseData, err := os.ReadFile(filepath.Join(root, ".github/workflows/_tag-release.yml")) //nolint:gosec // fixed repository path
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseWorkflow := string(releaseData)
+	if strings.Count(releaseWorkflow, "repos/${REPOSITORY}/immutable-releases") != 2 {
+		t.Fatal("release workflow must check immutable-release policy before tagging and publishing")
+	}
+	if !strings.Contains(releaseWorkflow, "GH_TOKEN: ${{ secrets.repository-administration-token }}") ||
+		!strings.Contains(releaseWorkflow, "REPOSITORY_ADMINISTRATION_TOKEN: ${{ secrets.repository-administration-token }}") ||
+		!strings.Contains(releaseWorkflow, "GH_TOKEN=\"$REPOSITORY_ADMINISTRATION_TOKEN\"") {
+		t.Fatal("immutable-release policy probes do not use the dedicated administration credential")
+	}
+	if !strings.Contains(releaseWorkflow, "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}") {
+		t.Fatal("ordinary release API reads no longer use the job-scoped token")
+	}
+
+	for _, caller := range []string{"on-merge.yml", "release-manual.yml"} {
+		data, readErr := os.ReadFile(filepath.Join(root, ".github/workflows", caller)) //nolint:gosec // fixed repository path
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.Count(string(data), "repository-administration-token: ${{ secrets.REPO_SYNC_TOKEN }}") != 1 {
+			t.Fatalf("%s does not pass the established administration credential exactly once", caller)
+		}
 	}
 }
 

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -165,6 +165,7 @@ var protectedJobs = []jobContract{
 	{"discover-defaults.yml", "discover", canonicalSelfHostedRunsOn, "default-discovery", map[string]string{}, []string{"schedule", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN", "XCSH_API_TOKEN", "XCSH_API_URL"}},
 	{"sync-openapi.yml", "sync", canonicalSelfHostedRunsOn, "provider-delivery", map[string]string{}, []string{"repository_dispatch", "workflow_dispatch"}, nil, []string{"GITHUB_TOKEN", "REPO_SYNC_TOKEN"}},
 	{"on-merge.yml", "create-regeneration-pr", canonicalSelfHostedRunsOn, "provider-delivery", map[string]string{"contents": "read"}, []string{"push", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN"}},
+	{"on-merge.yml", "tag-release", nil, "", map[string]string{"contents": "write"}, []string{"push", "workflow_dispatch"}, nil, []string{"GPG_PRIVATE_KEY", "PASSPHRASE", "REPO_SYNC_TOKEN"}},
 	{"on-merge.yml", "receipt-spec-delivery", canonicalSelfHostedRunsOn, "provider-delivery", map[string]string{"contents": "read"}, []string{"push", "workflow_dispatch"}, nil, []string{"REPO_SYNC_TOKEN"}},
 	{"auto-merge.yml", "require-token", []string{"ubuntu-latest"}, "repository-settings", map[string]string{}, []string{"pull_request"}, nil, []string{"REPO_SYNC_TOKEN"}},
 }
@@ -427,7 +428,7 @@ func validateWorkflowBytes(filename string, content []byte, policySchema int) []
 		if !listed {
 			continue
 		}
-		if runErr != nil {
+		if runErr != nil && !(contract.runsOn == nil && scalarString(job["uses"]) != "") {
 			errors = append(errors, jobID+": "+runErr.Error())
 			continue
 		}


### PR DESCRIPTION
## Summary

- authenticate repository release-immutability policy probes with the established administration token
- keep ordinary release API reads on the job-scoped GitHub token
- protect the reusable release caller's exact secret contract
- cover both release entrypoints and both immutable-policy probes with contract tests

## Verification

- `go test ./internal/acctest -run 'TestReleaseImmutabilityChecksUseAdministrationToken|TestReleaseWorkflowSerializesAndClassifiesReleaseState|TestEveryReleaseEntrypointPublishes' -count=1`
- `go test ./tools -run TestProviderWorkflowContracts -count=1`
- `pre-commit run --files .github/workflows/_tag-release.yml .github/workflows/on-merge.yml .github/workflows/release-manual.yml internal/acctest/release_integrity_test.go tools/validate_workflows_test.go`
- `go test ./...`

Closes #1708
