### PR TITLE
fix(release): accept exact recovery receipt rebinds

### DIFF
--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -224,6 +225,41 @@ func TestPrepareSpecDeliveryReceiptRetryRecognizesDurableMain(t *testing.T) {
 	}
 	if strings.TrimSpace(string(outputs)) != "changed=false" {
 		t.Fatalf("durable retry did not produce an exact no-op: %s", outputs)
+	}
+}
+
+func TestPrepareSpecDeliveryReceiptAcceptsExactRecoveryRebind(t *testing.T) {
+	fixture := newReceiptFixture(t, false, false)
+	rebindReceiptFixture(t, fixture, "", "")
+	runReleaseTestCommand(t, fixture.repo, fixture.env, fixture.script)
+}
+
+func TestPrepareSpecDeliveryReceiptRejectsInvalidRecoveryRebind(t *testing.T) {
+	for _, tc := range []struct {
+		name, previousVersion, sourceCommit, want string
+	}{
+		{
+			name:            "identity changed",
+			previousVersion: "2.1.207",
+			want:            "may change only its source commit",
+		},
+		{
+			name:         "source is not exact parent",
+			sourceCommit: strings.Repeat("a", 40),
+			want:         "source is not the exact release parent",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newReceiptFixture(t, false, false)
+			rebindReceiptFixture(t, fixture, tc.previousVersion, tc.sourceCommit)
+			cmd := exec.Command(fixture.script)
+			cmd.Dir = fixture.repo
+			cmd.Env = append(os.Environ(), fixture.env...)
+			output, runErr := cmd.CombinedOutput()
+			if runErr == nil || !strings.Contains(string(output), tc.want) {
+				t.Fatalf("invalid recovery rebind was accepted or failed for the wrong reason: err=%v\n%s", runErr, output)
+			}
+		})
 	}
 }
 
@@ -1642,6 +1678,46 @@ func TestReleaseReadyStateRejectsDescendantOfRegeneration(t *testing.T) {
 	}
 }
 
+func TestReleaseReadyStateAcceptsExactRecoveryRebind(t *testing.T) {
+	root := testRepositoryRoot(t)
+	fixture := newReceiptFixture(t, false, false)
+	rebindReceiptFixture(t, fixture, "", "")
+
+	validator := filepath.Join(root, "scripts", "validate-provider-delivery-state.sh")
+	runReleaseTestCommand(t, fixture.repo, []string{"TARGET_REPOSITORY=" + dispatchTarget}, validator, "--release-ready")
+}
+
+func TestReleaseReadyStateRejectsInvalidRecoveryRebind(t *testing.T) {
+	root := testRepositoryRoot(t)
+	validator := filepath.Join(root, "scripts", "validate-provider-delivery-state.sh")
+	for _, tc := range []struct {
+		name, previousVersion, sourceCommit, want string
+	}{
+		{
+			name:            "identity changed",
+			previousVersion: "2.1.207",
+			want:            "may change only its source commit",
+		},
+		{
+			name:         "source is not exact parent",
+			sourceCommit: strings.Repeat("a", 40),
+			want:         "source is not the exact release parent",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newReceiptFixture(t, false, false)
+			rebindReceiptFixture(t, fixture, tc.previousVersion, tc.sourceCommit)
+			cmd := exec.Command(validator, "--release-ready")
+			cmd.Dir = fixture.repo
+			cmd.Env = append(os.Environ(), "TARGET_REPOSITORY="+dispatchTarget)
+			output, runErr := cmd.CombinedOutput()
+			if runErr == nil || !strings.Contains(string(output), tc.want) {
+				t.Fatalf("invalid recovery rebind was accepted or failed for the wrong reason: err=%v\n%s", runErr, output)
+			}
+		})
+	}
+}
+
 func TestDraftCleanupDeletesEveryMeasuredAsset(t *testing.T) {
 	script := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Clear repairable draft artifacts")
 	tmp := t.TempDir()
@@ -1896,6 +1972,88 @@ func rewriteRegenerationPRIdentity(t *testing.T, fixture *receiptFixture, mergeC
 	pulls[0]["merge_commit_sha"] = mergeCommit
 	pulls[0]["head"].(map[string]any)["ref"] = "auto-regenerate/" + sourceCommit
 	writeReleaseTestJSON(t, fixture.regenPR, pulls)
+}
+
+func rebindReceiptFixture(t *testing.T, fixture *receiptFixture, previousVersion, sourceCommit string) {
+	t.Helper()
+	receiptPath := filepath.Join(fixture.repo, "tools/spec-regeneration-receipt.json")
+	data, err := os.ReadFile(receiptPath) //nolint:gosec // isolated test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	var canonical map[string]any
+	if err := json.Unmarshal(data, &canonical); err != nil {
+		t.Fatal(err)
+	}
+	if previousVersion != "" {
+		previous := maps.Clone(canonical)
+		previous["version"] = previousVersion
+		writeReleaseTestJSON(t, receiptPath, previous)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "--amend", "--no-edit", "-q")
+	}
+	parent := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+	if sourceCommit == "" {
+		sourceCommit = parent
+	}
+	canonical["source_commit"] = sourceCommit
+	writeReleaseTestJSON(t, receiptPath, canonical)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "chore: auto-regenerate provider and documentation")
+	releasedCommit := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "tag", "-f", "v9.8.7")
+
+	releasePath := envValue(t, fixture.env, "RELEASE_JSON")
+	releaseData, err := os.ReadFile(releasePath) //nolint:gosec // isolated test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	var release map[string]any
+	if err := json.Unmarshal(releaseData, &release); err != nil {
+		t.Fatal(err)
+	}
+	body := release["body"].(string)
+	const markerPrefix = "<!-- provider-publication-receipt:"
+	markerStart := strings.Index(body, markerPrefix)
+	if markerStart < 0 {
+		t.Fatalf("release fixture is missing its publication receipt marker")
+	}
+	markerEnd := strings.Index(body[markerStart:], " -->")
+	if markerEnd < 0 {
+		t.Fatalf("release fixture has an unterminated publication receipt marker")
+	}
+	markerEnd += markerStart
+	var publication map[string]any
+	if err := json.Unmarshal([]byte(body[markerStart+len(markerPrefix):markerEnd]), &publication); err != nil {
+		t.Fatal(err)
+	}
+	publication["commit"] = releasedCommit
+	publicationJSON, err := json.Marshal(publication)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release["body"] = body[:markerStart+len(markerPrefix)] + string(publicationJSON) + body[markerEnd:]
+	writeReleaseTestJSON(t, releasePath, release)
+
+	rewriteRegenerationPRIdentity(t, fixture, releasedCommit, parent)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "push", "-q", "--force", "origin", "HEAD:main", "v9.8.7")
+	for i, assignment := range fixture.env {
+		if strings.HasPrefix(assignment, "RELEASED_COMMIT=") {
+			fixture.env[i] = "RELEASED_COMMIT=" + releasedCommit
+		}
+	}
+}
+
+func envValue(t *testing.T, env []string, name string) string {
+	t.Helper()
+	prefix := name + "="
+	for _, assignment := range env {
+		if strings.HasPrefix(assignment, prefix) {
+			return strings.TrimPrefix(assignment, prefix)
+		}
+	}
+	t.Fatalf("environment fixture is missing %s", name)
+	return ""
 }
 
 func newReceiptFixture(t *testing.T, forgedLedger, falseDigest bool) *receiptFixture {

--- a/scripts/is-release-recovery-only.sh
+++ b/scripts/is-release-recovery-only.sh
@@ -13,6 +13,8 @@ while IFS= read -r path; do
     scripts/generate-provider-docs.sh | \
     scripts/check-spec-version-freshness.sh | \
     scripts/test-check-spec-version-freshness.sh | \
+    scripts/prepare-spec-delivery-receipt.sh | \
+    scripts/validate-provider-delivery-state.sh | \
     scripts/is-release-recovery-only.sh) ;;
   *) exit 1 ;;
   esac

--- a/scripts/prepare-spec-delivery-receipt.sh
+++ b/scripts/prepare-spec-delivery-receipt.sh
@@ -129,9 +129,30 @@ expected_id=$(canonical_id \
   "$(jq -r '.target_commit' "$pending")")
 [ "$delivery_id" = "$expected_id" ] || fail "Pending delivery ID is not canonical"
 
-git diff --diff-filter=A --name-only "${RELEASED_COMMIT}^" "$RELEASED_COMMIT" |
-  grep -qx "$regeneration_receipt" ||
-  fail "Released commit did not introduce the regeneration receipt"
+receipt_status=$(git diff --name-status "${RELEASED_COMMIT}^" "$RELEASED_COMMIT" -- "$regeneration_receipt" |
+  awk 'NR == 1 { print $1 }')
+case "$receipt_status" in
+A)
+  ;;
+M)
+  previous_receipt=$(git show "${RELEASED_COMMIT}^:$regeneration_receipt") ||
+    fail "Pre-release regeneration receipt could not be read"
+  jq -e --slurpfile current "$regeneration_receipt" '
+    type == "object" and
+    (keys | sort) == [
+      "delivery_id", "release_tag", "source_commit", "spec_release_sha256",
+      "target_commit", "version"
+    ] and
+    (.source_commit | test("^[0-9a-f]{40}$")) and
+    .source_commit != $current[0].source_commit and
+    del(.source_commit) == ($current[0] | del(.source_commit))
+  ' <<<"$previous_receipt" >/dev/null ||
+    fail "Regeneration receipt may change only its source commit during recovery"
+  ;;
+*)
+  fail "Released commit did not introduce or exactly rebind the regeneration receipt"
+  ;;
+esac
 [ "$(tr -d '[:space:]' <tools/spec-version.txt)" = "$(jq -r '.release_tag' "$pending")" ] ||
   fail "Published spec marker does not match pending delivery"
 jq -e --slurpfile pending "$pending" '
@@ -166,8 +187,8 @@ jq -e --arg pin_sha "$pin_sha" --slurpfile pending "$pending" '
 ' "$regeneration_receipt" >/dev/null ||
   fail "Regeneration receipt does not bind the pending delivery"
 source_commit=$(jq -r '.source_commit' "$regeneration_receipt")
-git merge-base --is-ancestor "$source_commit" "${RELEASED_COMMIT}^" ||
-  fail "Regeneration source is not an ancestor of the released commit"
+[ "$source_commit" = "$(git rev-parse "${RELEASED_COMMIT}^")" ] ||
+  fail "Regeneration receipt source is not the exact release parent"
 
 release_json=$(mktemp)
 provider_receipts=$(mktemp)

--- a/scripts/validate-provider-delivery-state.sh
+++ b/scripts/validate-provider-delivery-state.sh
@@ -180,14 +180,36 @@ if [ -e "$pending" ]; then
       (.source_commit | test("^[0-9a-f]{40}$"))
     ' "$regeneration" >/dev/null || fail "regeneration receipt is malformed or cross-bound"
     source_commit=$(jq -r '.source_commit' "$regeneration")
-    git merge-base --is-ancestor "$source_commit" HEAD ||
-      fail "regeneration source is not an ancestor of HEAD"
     if [ "$release_ready" = true ]; then
-      git diff --diff-filter=A --name-only HEAD^ HEAD |
-        grep -qx "$regeneration" ||
-        fail "release commit did not introduce the regeneration receipt"
-      git merge-base --is-ancestor "$source_commit" HEAD^ ||
-        fail "regeneration source is not an ancestor of the pre-release commit"
+      receipt_status=$(git diff --name-status HEAD^ HEAD -- "$regeneration" |
+        awk 'NR == 1 { print $1 }')
+      case "$receipt_status" in
+      A)
+        ;;
+      M)
+        previous_receipt=$(git show "HEAD^:$regeneration") ||
+          fail "pre-release regeneration receipt could not be read"
+        jq -e --slurpfile current "$regeneration" '
+          type == "object" and
+          (keys | sort) == [
+            "delivery_id", "release_tag", "source_commit", "spec_release_sha256",
+            "target_commit", "version"
+          ] and
+          (.source_commit | test("^[0-9a-f]{40}$")) and
+          .source_commit != $current[0].source_commit and
+          del(.source_commit) == ($current[0] | del(.source_commit))
+        ' <<<"$previous_receipt" >/dev/null ||
+          fail "regeneration receipt may change only its source commit during recovery"
+        ;;
+      *)
+        fail "release commit did not introduce or exactly rebind the regeneration receipt"
+        ;;
+      esac
+      [ "$source_commit" = "$(git rev-parse HEAD^)" ] ||
+        fail "regeneration receipt source is not the exact release parent"
+    else
+      git merge-base --is-ancestor "$source_commit" HEAD ||
+        fail "regeneration source is not an ancestor of HEAD"
     fi
   elif [ "$release_ready" = true ]; then
     fail "pending delivery has no regeneration receipt"

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -99,6 +99,8 @@ func TestReleaseRecoveryPathClassifier(t *testing.T) {
 				"scripts/generate-provider-docs.sh",
 				"scripts/check-spec-version-freshness.sh",
 				"scripts/test-check-spec-version-freshness.sh",
+				"scripts/prepare-spec-delivery-receipt.sh",
+				"scripts/validate-provider-delivery-state.sh",
 				"scripts/is-release-recovery-only.sh",
 			}, "\n"),
 			allowed: true,


### PR DESCRIPTION
## Summary

- accept an exact pending-delivery receipt rebind in release preflight
- enforce the same add-or-rebind contract during durable receipt preparation
- require the rebound `source_commit` to equal the exact release parent
- cover valid recovery and identity/source forgery cases in both paths

## Verification

- `go test ./internal/acctest -count=1`
- `go test ./tools -run TestProviderWorkflowContracts -count=1`
- `pre-commit run --all-files`
- `go test ./...`
- actual v2.1.219 state: `TARGET_REPOSITORY=f5-sales-demo/terraform-provider-xcsh scripts/validate-provider-delivery-state.sh --release-ready`

Closes #1712
