### PR TITLE
fix(release): keep MCP archive out of GoReleaser worktree

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -293,14 +293,12 @@ jobs:
           RELEASE_TAG: ${{ needs.tag.outputs.new_tag }}
         run: |
           set -euo pipefail
-          VERSION=${RELEASE_TAG#v}
           scripts/build-mcp-data.sh "$RELEASE_TAG" "$RUNNER_TEMP/mcp-a.tar.gz"
           scripts/build-mcp-data.sh "$RELEASE_TAG" "$RUNNER_TEMP/mcp-b.tar.gz"
           cmp "$RUNNER_TEMP/mcp-a.tar.gz" "$RUNNER_TEMP/mcp-b.tar.gz" || {
             echo "::error::MCP archive is not byte-reproducible"
             exit 1
           }
-          cp "$RUNNER_TEMP/mcp-a.tar.gz" "mcp-data-${VERSION}.tar.gz"
 
       - name: Clear repairable draft artifacts
         if: steps.release_state.outputs.state == 'draft'
@@ -336,6 +334,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=${RELEASE_TAG#v}
+          cp "$RUNNER_TEMP/mcp-a.tar.gz" "mcp-data-${VERSION}.tar.gz"
           gh release upload "$RELEASE_TAG" "mcp-data-${VERSION}.tar.gz" --clobber
 
       - name: Download and measure all release assets

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -1030,6 +1030,23 @@ esac
 	}
 }
 
+func TestMCPArchiveDoesNotDirtyGoReleaserCheckout(t *testing.T) {
+	buildScript := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Build MCP archive twice")
+	canonicalArchive := `mcp-data-${VERSION}.tar.gz`
+	if strings.Contains(buildScript, canonicalArchive) {
+		t.Fatalf("MCP reproducibility step writes the canonical archive into the GoReleaser checkout:\n%s", buildScript)
+	}
+
+	attachScript := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Attach deterministic MCP archive to draft")
+	copyCommand := `cp "$RUNNER_TEMP/mcp-a.tar.gz" "mcp-data-${VERSION}.tar.gz"`
+	uploadCommand := `gh release upload "$RELEASE_TAG" "mcp-data-${VERSION}.tar.gz" --clobber`
+	copyIndex := strings.Index(attachScript, copyCommand)
+	uploadIndex := strings.Index(attachScript, uploadCommand)
+	if copyIndex < 0 || uploadIndex < 0 || copyIndex >= uploadIndex {
+		t.Fatalf("MCP archive is not copied to its canonical name immediately before upload:\n%s", attachScript)
+	}
+}
+
 func TestReleaseImmutabilityChecksUseAdministrationToken(t *testing.T) {
 	root := testRepositoryRoot(t)
 	releaseData, err := os.ReadFile(filepath.Join(root, ".github/workflows/_tag-release.yml")) //nolint:gosec // fixed repository path


### PR DESCRIPTION
## Summary

- keep deterministic MCP reproducibility archives in runner temp while GoReleaser validates the checkout
- copy the verified archive to its canonical asset name only immediately before release upload
- add a workflow contract test preventing a pre-GoReleaser checkout artifact regression

## Verification

- `go test ./internal/acctest -count=1`
- `go test ./tools -count=1`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

Closes #1720