### PR TITLE
fix(release): resolve mutable drafts from collection

### DIFF
--- a/.github/workflows/_tag-release.yml
+++ b/.github/workflows/_tag-release.yml
@@ -260,7 +260,35 @@ jobs:
               echo "state=published" >> "$GITHUB_OUTPUT"
             fi
           elif grep -q '(HTTP 404)$' "$RUNNER_TEMP/release-probe.err"; then
-            echo "state=absent" >> "$GITHUB_OUTPUT"
+            if ! gh api --paginate \
+              "repos/${REPOSITORY}/releases?per_page=100" \
+              > "$RUNNER_TEMP/release-pages.json" \
+              2> "$RUNNER_TEMP/release-list.err"; then
+              cat "$RUNNER_TEMP/release-list.err" >&2
+              echo "::error::Failed to resolve draft release state"
+              exit 1
+            fi
+            jq -se --arg tag "$RELEASE_TAG" \
+              '[.[][] | select(.tag_name == $tag)]' \
+              "$RUNNER_TEMP/release-pages.json" \
+              > "$RUNNER_TEMP/release-matches.json"
+            MATCH_COUNT=$(jq 'length' "$RUNNER_TEMP/release-matches.json")
+            if [ "$MATCH_COUNT" -eq 0 ]; then
+              echo "state=absent" >> "$GITHUB_OUTPUT"
+            elif [ "$MATCH_COUNT" -eq 1 ]; then
+              jq -e '.[0].draft == true and .[0].prerelease == false' \
+                "$RUNNER_TEMP/release-matches.json" \
+                >/dev/null || {
+                echo "::error::Release collection returned an invalid draft state"
+                exit 1
+              }
+              jq '.[0]' "$RUNNER_TEMP/release-matches.json" \
+                > "$RUNNER_TEMP/release-initial.json"
+              echo "state=draft" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Release tag resolves to multiple releases"
+              exit 1
+            fi
           else
             cat "$RUNNER_TEMP/release-probe.err" >&2
             echo "::error::Failed to resolve existing release state"
@@ -341,13 +369,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.tag.outputs.new_tag }}
+          RELEASE_STATE: ${{ steps.release_state.outputs.state }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           rm -rf "$RUNNER_TEMP/provider-assets"
           mkdir -p "$RUNNER_TEMP/provider-assets"
-          gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}" \
-            > "$RUNNER_TEMP/release-measured.json"
+          if [ "$RELEASE_STATE" = "published" ]; then
+            gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+              > "$RUNNER_TEMP/release-measured.json"
+          else
+            gh api --paginate "repos/${REPOSITORY}/releases?per_page=100" \
+              | jq -se --arg tag "$RELEASE_TAG" '
+                  [.[][] | select(.tag_name == $tag)] |
+                  if length == 1 and .[0].draft == true and .[0].prerelease == false
+                  then .[0]
+                  elif length == 0 then error("draft release not found")
+                  elif length > 1 then error("release tag is ambiguous")
+                  else error("release is not a stable draft")
+                  end
+                ' > "$RUNNER_TEMP/release-measured.json"
+          fi
           gh release download "$RELEASE_TAG" --dir "$RUNNER_TEMP/provider-assets"
 
       - name: Verify already-published release without mutation
@@ -430,8 +472,16 @@ jobs:
           # body edit: another writer could have replaced an asset or receipt.
           rm -rf "$RUNNER_TEMP/provider-assets"
           mkdir -p "$RUNNER_TEMP/provider-assets"
-          gh api "repos/${REPOSITORY}/releases/tags/${RELEASE_TAG}" \
-            > "$RUNNER_TEMP/release-prepublish.json"
+          gh api --paginate "repos/${REPOSITORY}/releases?per_page=100" \
+            | jq -se --arg tag "$RELEASE_TAG" '
+                [.[][] | select(.tag_name == $tag)] |
+                if length == 1 and .[0].draft == true and .[0].prerelease == false
+                then .[0]
+                elif length == 0 then error("draft release not found")
+                elif length > 1 then error("release tag is ambiguous")
+                else error("release is not a stable draft")
+                end
+              ' > "$RUNNER_TEMP/release-prepublish.json"
           jq -e '.draft == true and .prerelease == false' \
             "$RUNNER_TEMP/release-prepublish.json" >/dev/null || {
             echo "::error::Verified draft changed state before publication"

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -980,6 +980,7 @@ func TestReleaseWorkflowSerializesAndClassifiesReleaseState(t *testing.T) {
 		"absent":    {mode: "absent", wantState: "absent"},
 		"draft":     {mode: "draft", wantState: "draft"},
 		"published": {mode: "published", wantState: "published"},
+		"duplicate": {mode: "duplicate", wantError: "Release tag resolves to multiple releases"},
 		"forbidden": {mode: "forbidden", wantError: "Failed to resolve existing release state"},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -991,12 +992,24 @@ if [[ "$*" == *immutable-releases* ]]; then
   printf '%s\n' '{"enabled":true}'
   exit 0
 fi
-case "$RELEASE_MODE" in
-  absent) printf '%s\n' 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
-  draft) printf '%s\n' '{"draft":true,"prerelease":false}' ;;
-  published) printf '%s\n' '{"draft":false,"prerelease":false}' ;;
-  forbidden) printf '%s\n' 'gh: Forbidden (HTTP 403)' >&2; exit 1 ;;
-esac
+if [[ "$*" == *"releases/tags"* ]]; then
+  case "$RELEASE_MODE" in
+    absent|draft|duplicate) printf '%s\n' 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
+    published) printf '%s\n' '{"tag_name":"v1.2.3","draft":false,"prerelease":false}' ;;
+    forbidden) printf '%s\n' 'gh: Forbidden (HTTP 403)' >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+if [[ "$*" == *"releases?per_page=100"* ]]; then
+  case "$RELEASE_MODE" in
+    absent) printf '%s\n' '[]' ;;
+    draft) printf '%s\n' '[{"tag_name":"v1.2.3","draft":true,"prerelease":false}]' ;;
+    duplicate) printf '%s\n' '[{"tag_name":"v1.2.3","draft":true,"prerelease":false},{"tag_name":"v1.2.3","draft":true,"prerelease":false}]' ;;
+    *) exit 88 ;;
+  esac
+  exit 0
+fi
+exit 88
 `
 			writeReleaseTestFile(t, bin, "gh", stub, 0o700)
 			output := filepath.Join(tmp, "github-output")
@@ -1027,6 +1040,39 @@ esac
 				t.Fatalf("release state was not classified as %s: %s", fixture.wantState, outputs)
 			}
 		})
+	}
+}
+
+func TestMutableDraftLookupUsesReleaseCollection(t *testing.T) {
+	measure := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Download and measure all release assets")
+	prepublish := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Publish verified draft")
+	published := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Verify sealed publication")
+
+	for name, script := range map[string]string{
+		"measure":    measure,
+		"prepublish": prepublish,
+	} {
+		for _, fragment := range []string{
+			`releases?per_page=100`,
+			`--paginate`,
+			`.tag_name == $tag`,
+			`length == 1`,
+			`.draft == true`,
+		} {
+			if !strings.Contains(script, fragment) {
+				t.Errorf("%s does not resolve exactly one stable draft from the release collection; missing %q", name, fragment)
+			}
+		}
+	}
+	if strings.Contains(prepublish, `releases/tags/${RELEASE_TAG}`) {
+		t.Fatal("prepublication draft re-measurement still uses the published-release tag endpoint")
+	}
+	if !strings.Contains(measure, `if [ "$RELEASE_STATE" = "published" ]; then`) ||
+		!strings.Contains(measure, `releases/tags/${RELEASE_TAG}`) {
+		t.Fatal("asset measurement does not reserve the exact tag endpoint for an already-published release")
+	}
+	if !strings.Contains(published, `releases/tags/${RELEASE_TAG}`) {
+		t.Fatal("sealed publication verification no longer uses the exact published-release tag endpoint")
 	}
 }
 
@@ -1308,7 +1354,7 @@ exit 0
 	writeReleaseTestFile(t, tampered, "release-notes.md", "notes\n", 0o600)
 	writeReleaseTestFile(t, tampered, "provider-receipt.json", "{}\n", 0o600)
 	writeReleaseTestJSON(t, filepath.Join(tampered, "release.json"), map[string]any{
-		"body": "notes\n", "draft": true, "prerelease": false,
+		"body": "notes\n", "tag_name": "v1.2.3", "draft": true, "prerelease": false,
 	})
 	writeReleaseTestFile(t, tamperedBin, "gh", `#!/usr/bin/env bash
 set -euo pipefail
@@ -1316,7 +1362,7 @@ printf '%s\n' "$*" >> "$GH_LOG"
 if [[ "$*" == *"/commits/"* ]]; then
   printf '%s\n' "$EXPECTED_COMMIT"
 elif [ "$1" = api ]; then
-  cat "$RELEASE_JSON"
+  jq -c -s '.' "$RELEASE_JSON"
 elif [ "$1 $2" = "release download" ]; then
   while [ "$#" -gt 0 ]; do
     if [ "$1" = --dir ]; then


### PR DESCRIPTION
## Summary

- resolve authenticated draft releases by exact tag from the paginated releases collection after the published-release tag endpoint returns 404
- require exactly one stable draft during transaction classification, initial asset measurement, and final prepublication re-measurement
- retain the tag-specific endpoint for already-published immutable release verification
- emulate GitHub draft endpoint behavior and reject ambiguous matches in workflow regression tests

## Verification

- `go test ./internal/acctest -run "TestReleaseWorkflowSerializesAndClassifiesReleaseState|TestMutableDraftLookupUsesReleaseCollection|TestReleasePublicationRechecksRemoteTagIdentity" -count=1`
- `go test ./internal/acctest -count=1`
- `go test ./tools -run TestProviderWorkflowContracts -count=1`
- `go test ./...`
- `pre-commit run --all-files`
- `git diff --check`

Closes #1724