### PR TITLE
fix(release): tolerate delayed squash-merge PR association

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -102,6 +102,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PENDING_RESUME: ${{ inputs.resume-pending || false }}
+          PR_ASSOCIATION_ATTEMPTS: '6'
+          PR_ASSOCIATION_RETRY_DELAY_SECONDS: '10'
           TARGET_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -118,6 +120,8 @@ jobs:
           echo "Message: $MESSAGE"
           REGENERATION_TITLE="chore: auto-regenerate provider and documentation"
           IS_REGENERATION=false
+          PR_ASSOCIATION_ATTEMPTS=${PR_ASSOCIATION_ATTEMPTS:-6}
+          PR_ASSOCIATION_RETRY_DELAY_SECONDS=${PR_ASSOCIATION_RETRY_DELAY_SECONDS:-10}
           PENDING=tools/spec-pending-delivery.json
           RECEIPT=tools/spec-regeneration-receipt.json
           RECEIPT_CHANGED=false
@@ -127,28 +131,65 @@ jobs:
 
           if [[ "$MESSAGE" == "$REGENERATION_TITLE"* ]]; then
             HEAD_COMMIT=$(git rev-parse HEAD)
-            ASSOCIATED_PRS=$(gh api \
-              "repos/${TARGET_REPOSITORY}/commits/${HEAD_COMMIT}/pulls")
-            MATCHING_PRS=$(jq -c \
-              --arg commit "$HEAD_COMMIT" \
-              --arg message "$MESSAGE" \
-              --arg repository "$TARGET_REPOSITORY" \
-              --arg title "$REGENERATION_TITLE" '
-              [ .[] | select(
-                .state == "closed" and
-                .merged_at != null and
-                .merge_commit_sha == $commit and
-                .title == $title and
-                ($message == $title or
-                  $message == ($title + " (#" + (.number | tostring) + ")")) and
-                .base.ref == "main" and
-                .base.repo.full_name == $repository and
-                .head.repo.full_name == $repository and
-                (.head.ref | test("^auto-regenerate/[0-9a-f]{40}$")) and
-                (([.labels[].name] | index("automated")) != null) and
-                (([.labels[].name] | index("regeneration")) != null)
-              ) ]
-            ' <<< "$ASSOCIATED_PRS")
+            [[ "$PR_ASSOCIATION_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || {
+              echo "::error::PR association attempts must be a positive integer"
+              exit 1
+            }
+            [[ "$PR_ASSOCIATION_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]] || {
+              echo "::error::PR association retry delay must be a non-negative integer"
+              exit 1
+            }
+            matching_prs() {
+              jq -c \
+                --arg commit "$HEAD_COMMIT" \
+                --arg message "$MESSAGE" \
+                --arg repository "$TARGET_REPOSITORY" \
+                --arg title "$REGENERATION_TITLE" '
+                [ .[] | select(
+                  .state == "closed" and
+                  .merged_at != null and
+                  .merge_commit_sha == $commit and
+                  .title == $title and
+                  ($message == $title or
+                    $message == ($title + " (#" + (.number | tostring) + ")")) and
+                  .base.ref == "main" and
+                  .base.repo.full_name == $repository and
+                  .head.repo.full_name == $repository and
+                  (.head.ref | test("^auto-regenerate/[0-9a-f]{40}$")) and
+                  (([.labels[].name] | index("automated")) != null) and
+                  (([.labels[].name] | index("regeneration")) != null)
+                ) ]
+              '
+            }
+
+            MATCHING_PRS='[]'
+            ASSOCIATION_EXHAUSTED=false
+            if [[ "$MESSAGE" =~ ^chore:\ auto-regenerate\ provider\ and\ documentation\ \(#[0-9]+\)$ ]]; then
+              PR_NUMBER=${MESSAGE##*\(#}
+              PR_NUMBER=${PR_NUMBER%)}
+              EXACT_PR=$(gh api "repos/${TARGET_REPOSITORY}/pulls/${PR_NUMBER}")
+              MATCHING_PRS=$(jq -cn --argjson pr "$EXACT_PR" '[$pr]' | matching_prs)
+            else
+              for ((attempt = 1; attempt <= PR_ASSOCIATION_ATTEMPTS; attempt++)); do
+                ASSOCIATED_PRS=$(gh api \
+                  "repos/${TARGET_REPOSITORY}/commits/${HEAD_COMMIT}/pulls")
+                MATCHING_PRS=$(matching_prs <<< "$ASSOCIATED_PRS")
+                MATCHING_COUNT=$(jq 'length' <<< "$MATCHING_PRS")
+                [ "$MATCHING_COUNT" -le 1 ] || {
+                  echo "::error::Release commit is associated with multiple regeneration PR identities"
+                  exit 1
+                }
+                if [ "$MATCHING_COUNT" -eq 1 ]; then
+                  break
+                fi
+                if [ "$attempt" -lt "$PR_ASSOCIATION_ATTEMPTS" ]; then
+                  echo "PR association is not visible yet; retrying (${attempt}/${PR_ASSOCIATION_ATTEMPTS})"
+                  sleep "$PR_ASSOCIATION_RETRY_DELAY_SECONDS"
+                else
+                  ASSOCIATION_EXHAUSTED=true
+                fi
+              done
+            fi
             MATCHING_COUNT=$(jq 'length' <<< "$MATCHING_PRS")
             [ "$MATCHING_COUNT" -le 1 ] || {
               echo "::error::Release commit is associated with multiple regeneration PR identities"
@@ -165,6 +206,10 @@ jobs:
               IS_REGENERATION=true
               echo "Detected exact automated regeneration PR ${REGENERATION_BRANCH}"
             else
+              if [ "$ASSOCIATION_EXHAUSTED" = true ] && [ "$RECEIPT_CHANGED" = true ]; then
+                echo "::error::Merged regeneration PR association was not visible after ${PR_ASSOCIATION_ATTEMPTS} attempts"
+                exit 1
+              fi
               echo "Exact subject has no matching automated regeneration PR; processing as a human change"
             fi
           fi

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -265,6 +265,94 @@ func TestPrepareSpecDeliveryReceiptRejectsInvalidRecoveryRebind(t *testing.T) {
 
 func TestRegenerationCommitRequiresExactPendingAttestation(t *testing.T) {
 	script := extractWorkflowRunStep(t, "on-merge.yml", "detect-changes", "Identify an exact regeneration completion commit")
+	t.Run("delayed pull request association is retried", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		output := filepath.Join(fixture.repo, "attestation-output")
+		callCount := filepath.Join(fixture.repo, "association-call-count")
+		env := append(append([]string{}, fixture.env...),
+			"TARGET_REPOSITORY="+dispatchTarget,
+			"GITHUB_OUTPUT="+output,
+			"PR_ASSOCIATION_ATTEMPTS=3",
+			"REGENERATION_PR_EMPTY_RESPONSES=2",
+			"REGENERATION_PR_CALL_COUNT="+callCount,
+		)
+		result, err := runWorkflowScript(fixture.repo, script, env)
+		if err != nil {
+			t.Fatalf("delayed PR association was not retried successfully: %v\n%s", err, result)
+		}
+		outputs, readErr := os.ReadFile(output) //nolint:gosec // isolated test fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !strings.Contains(string(outputs), "is_regeneration=true") {
+			t.Fatalf("delayed exact association was not recognized:\n%s", outputs)
+		}
+		calls, readErr := os.ReadFile(callCount) //nolint:gosec // isolated test fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.TrimSpace(string(calls)) != "3" {
+			t.Fatalf("association lookup count = %q, want 3", strings.TrimSpace(string(calls)))
+		}
+	})
+
+	t.Run("exhausted pull request association fails receipt closed", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		output := filepath.Join(fixture.repo, "attestation-output")
+		callCount := filepath.Join(fixture.repo, "association-call-count")
+		env := append(append([]string{}, fixture.env...),
+			"TARGET_REPOSITORY="+dispatchTarget,
+			"GITHUB_OUTPUT="+output,
+			"PR_ASSOCIATION_ATTEMPTS=3",
+			"REGENERATION_PR_EMPTY_RESPONSES=3",
+			"REGENERATION_PR_CALL_COUNT="+callCount,
+		)
+		result, runErr := runWorkflowScript(fixture.repo, script, env)
+		if runErr == nil || !strings.Contains(result, "not visible after 3 attempts") {
+			t.Fatalf("exhausted association lookup did not fail closed: err=%v\n%s", runErr, result)
+		}
+		if strings.Contains(result, "processing as a human change") {
+			t.Fatalf("receipt-changing commit was downgraded after exhausted lookup:\n%s", result)
+		}
+		calls, readErr := os.ReadFile(callCount) //nolint:gosec // isolated test fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.TrimSpace(string(calls)) != "3" {
+			t.Fatalf("association lookup count = %q, want 3", strings.TrimSpace(string(calls)))
+		}
+	})
+
+	t.Run("squash subject resolves the exact pull request directly", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "--amend", "-qm", "chore: auto-regenerate provider and documentation (#42)")
+		mergeCommit := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+		rewriteRegenerationPRMergeCommit(t, fixture, mergeCommit)
+		output := filepath.Join(fixture.repo, "attestation-output")
+		callCount := filepath.Join(fixture.repo, "association-call-count")
+		env := append(append([]string{}, fixture.env...),
+			"TARGET_REPOSITORY="+dispatchTarget,
+			"GITHUB_OUTPUT="+output,
+			"PR_ASSOCIATION_ATTEMPTS=3",
+			"REGENERATION_PR_EMPTY_RESPONSES=3",
+			"REGENERATION_PR_CALL_COUNT="+callCount,
+		)
+		result, err := runWorkflowScript(fixture.repo, script, env)
+		if err != nil {
+			t.Fatalf("exact squash-subject PR lookup failed: %v\n%s", err, result)
+		}
+		outputs, readErr := os.ReadFile(output) //nolint:gosec // isolated test fixture
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !strings.Contains(string(outputs), "is_regeneration=true") {
+			t.Fatalf("exact squash-subject PR was not recognized:\n%s", outputs)
+		}
+		if _, statErr := os.Stat(callCount); !os.IsNotExist(statErr) {
+			t.Fatalf("commit association endpoint was called despite exact PR number: %v", statErr)
+		}
+	})
+
 	t.Run("zero generated diff still binds pending delivery", func(t *testing.T) {
 		fixture := newReceiptFixture(t, false, false)
 		output := filepath.Join(fixture.repo, "attestation-output")
@@ -366,7 +454,7 @@ func TestRegenerationCommitRequiresExactPendingAttestation(t *testing.T) {
 		output := filepath.Join(fixture.repo, "attestation-output")
 		env := append(append([]string{}, fixture.env...), "TARGET_REPOSITORY="+dispatchTarget, "GITHUB_OUTPUT="+output)
 		result, runErr := runWorkflowScript(fixture.repo, script, env)
-		if runErr == nil || !strings.Contains(result, "Only the exact regeneration merge may add or modify a receipt") {
+		if runErr == nil || !strings.Contains(result, "Merged regeneration PR association was not visible after 6 attempts") {
 			t.Fatalf("unattested receipt change was accepted: err=%v\n%s", runErr, result)
 		}
 	})
@@ -2217,7 +2305,21 @@ func newReceiptFixture(t *testing.T, forgedLedger, falseDigest bool) *receiptFix
 	writeReleaseTestFile(t, binDir, "gh", `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$*" == *"/commits/"*"/pulls"* ]]; then
+	if [ -n "${REGENERATION_PR_CALL_COUNT:-}" ]; then
+		calls=0
+		if [ -f "$REGENERATION_PR_CALL_COUNT" ]; then
+			calls=$(cat "$REGENERATION_PR_CALL_COUNT")
+		fi
+		calls=$((calls + 1))
+		printf '%s\n' "$calls" > "$REGENERATION_PR_CALL_COUNT"
+		if [ "$calls" -le "${REGENERATION_PR_EMPTY_RESPONSES:-0}" ]; then
+			printf '[]\n'
+			exit 0
+		fi
+	fi
   cat "$REGENERATION_PR_JSON"
+elif [[ "$*" =~ /pulls/[0-9]+$ ]]; then
+	jq -c '.[0]' "$REGENERATION_PR_JSON"
 else
   cat "$RELEASE_JSON"
 fi
@@ -2232,7 +2334,8 @@ fi
 		deliveryID: deliveryID, regenPR: regenPRPath,
 		env: []string{"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"), "RELEASE_JSON=" + releasePath,
 			"REGENERATION_PR_JSON=" + regenPRPath, "PROVIDER_TAG=" + providerTag, "RELEASED_COMMIT=" + releasedCommit,
-			"TARGET_REPOSITORY=" + dispatchTarget, "GITHUB_OUTPUT=" + output, "GH_TOKEN=fixture"},
+			"TARGET_REPOSITORY=" + dispatchTarget, "GITHUB_OUTPUT=" + output, "GH_TOKEN=fixture",
+			"PR_ASSOCIATION_RETRY_DELAY_SECONDS=0"},
 	}
 }
 


### PR DESCRIPTION
## Summary

Prevent regeneration release transactions from rejecting valid receipt-changing squash merges while GitHub's commit-to-PR association index is stale.

## Related Issue

Closes #1730

## Changes

- Resolve the exact PR number embedded in the canonical squash subject through the authoritative pull-request endpoint.
- Retry bare-title commit-to-PR association lookups up to six times with deterministic 10-second delays.
- Preserve exact merge SHA, title, branch, repository, base, labels, and source-commit validation.
- Fail closed with a dedicated error when a receipt-changing commit cannot be attested after all retries.
- Add regression tests for delayed success, retry exhaustion, and direct squash-subject lookup.

## Verification evidence

- TDD red: `go test ./internal/acctest -run TestRegenerationCommitRequiresExactPendingAttestation -count=1` failed on delayed lookup and fail-closed expectations before implementation.
- Focused regression: `go test ./internal/acctest -run TestRegenerationCommitRequiresExactPendingAttestation -count=1` passed.
- Workflow contracts: `go test ./tools -run 'TestProviderWorkflowContracts|TestWorkflowFilesCanonical' -count=1` passed.
- Release integrity: `go test ./internal/acctest -count=1` passed.
- Full suite: `go test ./...` passed.
- Repository hooks: `pre-commit run --all-files` passed, including YAML, GitHub Actions, security, secrets, and repository-specific checks.
- Diff hygiene: `git diff --check` passed.

## Delivery evidence

- Production failure evidence: run `32037596591` queried the merge association 33 seconds after PR #1729 merged and received an empty array, then rejected the receipt change.
- PR checks and the repaired v2.1.219 recovery transaction will be monitored through `MERGED`, publication, receipt, and local cleanup.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides
