### PR TITLE
fix(ci): exclude spec-delivery-receipt PRs from Constitution Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       github.event_name == 'pull_request' &&
       !startsWith(github.head_ref, 'auto-generate/') &&
       !startsWith(github.head_ref, 'auto-regenerate/') &&
+      !startsWith(github.head_ref, 'spec-delivery-receipt/') &&
       github.head_ref != 'docs/auto-update' &&
       github.head_ref != 'openapi-update'
     steps:

--- a/scripts/is-release-recovery-only.sh
+++ b/scripts/is-release-recovery-only.sh
@@ -15,7 +15,11 @@ while IFS= read -r path; do
     scripts/test-check-spec-version-freshness.sh | \
     scripts/prepare-spec-delivery-receipt.sh | \
     scripts/validate-provider-delivery-state.sh | \
-    scripts/is-release-recovery-only.sh) ;;
+    scripts/is-release-recovery-only.sh | \
+    tools/provider-publication-receipts.json | \
+    tools/spec-deliveries.json | \
+    tools/spec-pending-delivery.json | \
+    tools/spec-regeneration-receipt.json) ;;
   *) exit 1 ;;
   esac
 done


### PR DESCRIPTION
## Summary
Exclude `spec-delivery-receipt/*` branches from `check-constitution` in `ci.yml` and add receipt ledger files to `scripts/is-release-recovery-only.sh`.

Closes #1741