### PR TITLE
docs: English documentation technical writing improvements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,9 +1,6 @@
 # Development Guide
 
-Community-driven Terraform provider for F5 Distributed Cloud (F5XC)
-built using the HashiCorp Terraform Plugin Framework. The provider
-implements F5's public OpenAPI specifications to manage F5XC resources
-via Terraform.
+Community-driven Terraform provider for F5 Distributed Cloud built using the HashiCorp Terraform Plugin Framework. The provider implements public OpenAPI specifications to manage F5 Distributed Cloud resources through declarative Terraform configurations.
 
 ## Build & Development Commands
 
@@ -27,54 +24,54 @@ cp terraform-provider-xcsh ~/.terraform.d/plugins/registry.terraform.io/f5-sales
 
 ## Environment Variables
 
-- `XCSH_API_TOKEN` - API token for F5 Distributed Cloud (one of token or P12 required)
-- `XCSH_API_URL` - API URL for your F5 Distributed Cloud tenant (required, no default)
-- `XCSH_P12_FILE` - Path to P12 certificate file (alternative to token auth)
-- `XCSH_P12_PASSWORD` - Password for P12 file (required with XCSH_P12_FILE)
-- `TF_ACC=1` - Enable acceptance tests
+- `XCSH_API_TOKEN` — API token for F5 Distributed Cloud (one of token or P12 required)
+- `XCSH_API_URL` — Base API URL for your F5 Distributed Cloud tenant (required, no default)
+- `XCSH_P12_FILE` — Path to PKCS#12 certificate file (alternative to token authentication)
+- `XCSH_P12_PASSWORD` — Password for PKCS#12 certificate file (required with `XCSH_P12_FILE`)
+- `TF_ACC=1` — Enable acceptance test suite execution
 
 ## Architecture
 
 ### Directory Structure
 
-- `main.go` - Provider entry point with version injection via goreleaser
-- `internal/provider/` - All Terraform resources and data sources
-- `internal/client/` - F5XC API client (HTTP client with CRUD operations and type definitions)
-- `internal/functions/` - Provider-defined functions (manually maintained)
-- `internal/blindfold/` - F5XC Secret Management encryption library (manually maintained)
-- `tools/` - Code generation utilities for scaffolding new resources from OpenAPI specs
-- `docs/` - Auto-generated provider documentation for Terraform Registry
-- `examples/` - Example Terraform configurations
-- `templates/` - Templates for doc generation (`tfplugindocs`)
+- `main.go` — Provider entry point with version injection via GoReleaser
+- `internal/provider/` — Terraform resource and data source implementations
+- `internal/client/` — F5 Distributed Cloud API HTTP client and data type definitions
+- `internal/functions/` — Provider-defined functions
+- `internal/blindfold/` — F5 Distributed Cloud Secret Management client encryption library
+- `tools/` — Code generation and documentation transformation utilities
+- `docs/` — Generated provider documentation for the Terraform Registry
+- `examples/` — Terraform example configurations
+- `templates/` — Documentation templates processed by `tfplugindocs`
 
 ### Resource Implementation Pattern
 
-Each resource follows the Terraform Plugin Framework pattern:
+Each resource follows the Terraform Plugin Framework architecture:
 
-1. **Resource struct** implementing `resource.Resource`, `resource.ResourceWithConfigure`, `resource.ResourceWithImportState`
-2. **Model struct** with `tfsdk` tags for state management
-3. **CRUD methods**: `Create`, `Read`, `Update`, `Delete`
-4. **Registration** in `provider.go` via `Resources()` function
+1. **Resource struct** implementing `resource.Resource`, `resource.ResourceWithConfigure`, and `resource.ResourceWithImportState`
+2. **Model struct** with `tfsdk` tags for state encoding and decoding
+3. **CRUD methods**: `Create`, `Read`, `Update`, and `Delete`
+4. **Registration** in `provider.go` using the `Resources()` function
 
 Example reference: `internal/provider/namespace_resource.go`
 
 ### Client Architecture
 
-`internal/client/client.go` contains:
+`internal/client/client.go` provides:
 
-- HTTP client wrapper for F5XC API (`Client` struct)
-- Type definitions for all F5XC resources
-- CRUD methods following pattern: `Create{Resource}`, `Get{Resource}`, `Update{Resource}`, `Delete{Resource}`
+- HTTP client wrapper for the F5 Distributed Cloud REST API (`Client` struct)
+- Go type definitions for all supported resource schemas
+- Standardized CRUD methods: `Create{Resource}`, `Get{Resource}`, `Update{Resource}`, `Delete{Resource}`
 
-API authentication uses Bearer token: `Authorization: APIToken {token}`
+API authentication uses a Bearer token header: `Authorization: APIToken {token}` or mTLS certificates.
 
 ### Code Generation
 
-The `tools/` directory contains generators for scaffolding resources from F5 OpenAPI specs:
+The `tools/` directory contains utilities for scaffolding resources from OpenAPI specifications:
 
-- `generate-all-schemas.go` - Main generator for provider resources, data sources, and client types from v2 domain specs
-- `transform-docs.go` - Transforms generated documentation with enhanced metadata
-- `generate-examples.go` - Generates Terraform example configurations
+- `generate-all-schemas.go` — Generates provider resources, data sources, and client types from domain specifications
+- `transform-docs.go` — Enhances generated documentation with metadata, syntax callouts, and cross-references
+- `generate-examples.go` — Generates Terraform example configurations
 
 ## Generated Files (Never Commit Manually)
 
@@ -89,19 +86,19 @@ The `tools/` directory contains generators for scaffolding resources from F5 Ope
 | `internal/provider/*_resource.go` | `generate-all-schemas.go` | `on-merge.yml` |
 | `internal/provider/*_data_source.go` | `generate-all-schemas.go` | `on-merge.yml` |
 
-To fix a bug in generated code, fix the **generator** not the generated file. CI blocks PRs containing manually-modified generated files.
+To fix an issue in generated code or documentation, update the **generator or template**, not the generated file. CI automation blocks pull requests containing manually edited generated files.
 
 ## Manually Maintained Files
 
-These files live in otherwise auto-generated directories but are hand-written:
+The following files reside in generated directories but are maintained manually:
 
 | File | Purpose |
 | --- | --- |
 | `internal/provider/functions_registration.go` | Registers provider-defined functions |
 | `internal/provider/addon_service_data_source.go` | Data source for addon service details |
-| `internal/provider/addon_service_activation_status_data_source.go` | Data source for addon activation |
+| `internal/provider/addon_service_activation_status_data_source.go` | Data source for addon activation status |
 | `templates/functions.md.tmpl` | Template for function documentation |
-| `templates/guides/*.md` | Guide source files |
+| `templates/guides/*.md` | Guide source documents |
 | `examples/functions/*/function.tf` | Function example configurations |
 | `examples/guides/*/` | Guide example Terraform modules |
 
@@ -118,13 +115,13 @@ flowchart TD
     pr --> release[Tag &amp; Release<br/>ONE version bump]
 ```
 
-Reusable workflows (`_build-test.yml`, `_generate-docs.yml`, `_generate-provider.yml`, `_tag-release.yml`) are called by the `on-merge.yml` orchestrator.
+Reusable workflows (`_build-test.yml`, `_generate-docs.yml`, `_generate-provider.yml`, `_tag-release.yml`) are invoked by the `on-merge.yml` orchestrator.
 
 ## Provider-Defined Functions
 
 ### The `blindfold` Function
 
-Encrypts base64-encoded plaintext using F5XC blindfold encryption:
+Encrypts base64-encoded plaintext using F5 Distributed Cloud Secret Management:
 
 ```hcl
 provider::xcsh::blindfold(plaintext, policy_name, namespace)
@@ -138,21 +135,21 @@ Reads a file and encrypts its contents:
 provider::xcsh::blindfold_file(path, policy_name, namespace)
 ```
 
-Requirements: Terraform 1.8.0+, valid F5XC provider config, existing SecretPolicy.
+Requirements: Terraform >= 1.8.0, valid provider authentication, and an existing SecretPolicy.
 
 ### Adding New Functions
 
-1. Create implementation in `internal/functions/`
-2. Register in `internal/provider/functions_registration.go`
-3. Create examples in `examples/functions/<name>/function.tf`
-4. Add unit tests
+1. Implement function logic in `internal/functions/`
+2. Register the function in `internal/provider/functions_registration.go`
+3. Add example configurations in `examples/functions/<name>/function.tf`
+4. Write unit and functional tests
 5. Update preservation lists in `tools/generate-all-schemas.go`
 
 ## Guides
 
-Guide source files live in `templates/guides/`. Examples in `examples/guides/`. CI copies guides to `docs/guides/` via `tfplugindocs` on merge.
+Guide source files reside in `templates/guides/` with accompanying examples in `examples/guides/`. CI automation renders guides to `docs/guides/` using `tfplugindocs`.
 
-All guides need YAML frontmatter:
+All guides require YAML frontmatter:
 
 ```yaml
 ---
@@ -163,19 +160,19 @@ description: |-
 ---
 ```
 
-## F5XC API v2 Specs
+## API Specifications
 
-Starting with v3.0.0, the provider uses v2 API specs from the enriched API repository. Resources are organized into domain categories (Security, Networking, Infrastructure, Platform, Operations, AI). The generator auto-detects spec version and processes domain files containing multiple resources each.
+Starting with v3.0.0, the provider consumes v2 API specifications organized into domain categories (Security, Networking, Infrastructure, Platform, Operations, AI). The generator automatically detects specification schemas and processes domain files containing multiple resource definitions.
 
 ## Release Process
 
-Releases are automated via GoReleaser on tag push (`v*`):
+Releases are automated using GoReleaser when pushing a version tag (`v*`):
 
 1. Builds cross-platform binaries
-2. Signs checksums with GPG
-3. Publishes to GitHub Releases with Terraform Registry manifest
+2. Generates cryptographic SHA-256 checksums and GPG signatures
+3. Publishes release artifacts and manifests to GitHub Releases for the Terraform Registry
 
 ## Key Dependencies
 
-- `github.com/hashicorp/terraform-plugin-framework` - Core Terraform provider SDK
-- `github.com/hashicorp/terraform-plugin-log` - Structured logging
+- `github.com/hashicorp/terraform-plugin-framework` — Core Terraform provider SDK
+- `github.com/hashicorp/terraform-plugin-log` — Structured logging library

--- a/docs/_llms-txt/resources/api_definition.txt
+++ b/docs/_llms-txt/resources/api_definition.txt
@@ -8,14 +8,6 @@ API Definition
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- api_inventory_exclusion_list
-- api_inventory_inclusion_list
-- non_api_endpoints
-- strict_schema_origin
-- swagger_specs
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/api_definition.txt
+++ b/docs/_llms-txt/resources/api_definition.txt
@@ -8,6 +8,14 @@ API Definition
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- api_inventory_exclusion_list
+- api_inventory_inclusion_list
+- non_api_endpoints
+- strict_schema_origin
+- swagger_specs
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/api_discovery.txt
+++ b/docs/_llms-txt/resources/api_discovery.txt
@@ -9,6 +9,12 @@ API discovery creates a new object in the storage backend for metadata.namespace
 - namespace
 - user_defined_api_discovery_policy
 
+## Server Defaults (safe to omit)
+
+- custom_auth_types
+- user_defined_api_discovery_policy.discovery_rules
+- user_defined_api_discovery_policy.inclusive
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/api_discovery.txt
+++ b/docs/_llms-txt/resources/api_discovery.txt
@@ -9,12 +9,6 @@ API discovery creates a new object in the storage backend for metadata.namespace
 - namespace
 - user_defined_api_discovery_policy
 
-## Server Defaults (safe to omit)
-
-- custom_auth_types
-- user_defined_api_discovery_policy.discovery_rules
-- user_defined_api_discovery_policy.inclusive
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/app_firewall.txt
+++ b/docs/_llms-txt/resources/app_firewall.txt
@@ -8,16 +8,6 @@ Application Firewall
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- allow_all_response_codes
-- default_anonymization
-- default_bot_setting
-- default_detection_settings
-- disable_ai_enhancements
-- monitoring
-- use_default_blocking_page
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/app_firewall.txt
+++ b/docs/_llms-txt/resources/app_firewall.txt
@@ -8,6 +8,16 @@ Application Firewall
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- allow_all_response_codes
+- default_anonymization
+- default_bot_setting
+- default_detection_settings
+- disable_ai_enhancements
+- monitoring
+- use_default_blocking_page
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/azure_vnet_site.txt
+++ b/docs/_llms-txt/resources/azure_vnet_site.txt
@@ -11,17 +11,6 @@ Deploying F5 sites within Azure Virtual Network environments
 - resource_group
 - ssh_key
 
-## Server Defaults (safe to omit)
-
-- block_all_services
-- disk_size
-- ingress_gw.accelerated_networking
-- ingress_gw.performance_enhancement_mode
-- logs_streaming_disabled
-- machine_type
-- no_worker_nodes
-- tags
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/azure_vnet_site.txt
+++ b/docs/_llms-txt/resources/azure_vnet_site.txt
@@ -11,6 +11,17 @@ Deploying F5 sites within Azure Virtual Network environments
 - resource_group
 - ssh_key
 
+## Server Defaults (safe to omit)
+
+- block_all_services
+- disk_size
+- ingress_gw.accelerated_networking
+- ingress_gw.performance_enhancement_mode
+- logs_streaming_disabled
+- machine_type
+- no_worker_nodes
+- tags
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/enhanced_firewall_policy.txt
+++ b/docs/_llms-txt/resources/enhanced_firewall_policy.txt
@@ -8,6 +8,10 @@ Enhanced firewall policy specification. configuration
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- allow_all
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/enhanced_firewall_policy.txt
+++ b/docs/_llms-txt/resources/enhanced_firewall_policy.txt
@@ -8,10 +8,6 @@ Enhanced firewall policy specification. configuration
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- allow_all
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/global_log_receiver.txt
+++ b/docs/_llms-txt/resources/global_log_receiver.txt
@@ -10,11 +10,6 @@ New Global Log Receiver object
 - log_type
 - receiver_choice
 
-## Server Defaults (safe to omit)
-
-- ns_current
-- request_logs.sampled
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/global_log_receiver.txt
+++ b/docs/_llms-txt/resources/global_log_receiver.txt
@@ -10,6 +10,11 @@ New Global Log Receiver object
 - log_type
 - receiver_choice
 
+## Server Defaults (safe to omit)
+
+- ns_current
+- request_logs.sampled
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/healthcheck.txt
+++ b/docs/_llms-txt/resources/healthcheck.txt
@@ -14,13 +14,8 @@ Healthcheck object defines method to determine if the given endpoint is healthy.
 
 ## Server Defaults (safe to omit)
 
-- http_health_check.expected_response
-- http_health_check.expected_status_codes
-- http_health_check.headers
-- http_health_check.request_headers_to_remove
-- http_health_check.use_http2
-- http_health_check.use_origin_server_name
 - jitter_percent
+- use_http2
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/healthcheck.txt
+++ b/docs/_llms-txt/resources/healthcheck.txt
@@ -14,8 +14,13 @@ Healthcheck object defines method to determine if the given endpoint is healthy.
 
 ## Server Defaults (safe to omit)
 
+- http_health_check.expected_response
+- http_health_check.expected_status_codes
+- http_health_check.headers
+- http_health_check.request_headers_to_remove
+- http_health_check.use_http2
+- http_health_check.use_origin_server_name
 - jitter_percent
-- use_http2
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/http_loadbalancer.txt
+++ b/docs/_llms-txt/resources/http_loadbalancer.txt
@@ -11,8 +11,49 @@ Load balancing HTTP/HTTPS traffic with advanced routing and security
 
 ## Server Defaults (safe to omit)
 
-- connection_timeout
-- http_idle_timeout
+- add_location
+- default_pool.advanced_options.auto_http_config
+- default_pool.advanced_options.connection_timeout
+- default_pool.advanced_options.default_circuit_breaker
+- default_pool.advanced_options.disable_outlier_detection
+- default_pool.advanced_options.disable_subsets
+- default_pool.advanced_options.http_idle_timeout
+- default_pool.advanced_options.no_panic_threshold
+- default_pool.advanced_options.no_request_limit_per_connection
+- default_pool.endpoint_selection
+- default_pool.healthcheck
+- default_pool.loadbalancer_algorithm
+- default_pool.no_tls
+- default_pool.same_as_endpoint_port
+- default_pool.use_tls.default_session_key_caching
+- default_pool.use_tls.no_mtls
+- default_pool.use_tls.use_host_header_as_sni
+- default_pool.use_tls.volterra_trusted_ca
+- default_sensitive_data_policy
+- disable_api_definition
+- disable_api_discovery
+- disable_api_testing
+- disable_bot_defense
+- disable_ip_reputation
+- disable_malicious_user_detection
+- disable_malware_protection
+- disable_rate_limit
+- disable_threat_mesh
+- disable_trust_client_ip_headers
+- disable_waf
+- https_auto_cert.add_hsts
+- https_auto_cert.connection_idle_timeout
+- https_auto_cert.enable_path_normalize
+- https_auto_cert.http_redirect
+- https_auto_cert.no_mtls
+- l7_ddos_protection
+- no_challenge
+- rate_limit.no_ip_allowed_list
+- rate_limit.no_policies
+- rate_limit.rate_limiter.period_multiplier
+- round_robin
+- service_policies_from_namespace
+- user_id_client_ip
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/http_loadbalancer.txt
+++ b/docs/_llms-txt/resources/http_loadbalancer.txt
@@ -11,49 +11,8 @@ Load balancing HTTP/HTTPS traffic with advanced routing and security
 
 ## Server Defaults (safe to omit)
 
-- add_location
-- default_pool.advanced_options.auto_http_config
-- default_pool.advanced_options.connection_timeout
-- default_pool.advanced_options.default_circuit_breaker
-- default_pool.advanced_options.disable_outlier_detection
-- default_pool.advanced_options.disable_subsets
-- default_pool.advanced_options.http_idle_timeout
-- default_pool.advanced_options.no_panic_threshold
-- default_pool.advanced_options.no_request_limit_per_connection
-- default_pool.endpoint_selection
-- default_pool.healthcheck
-- default_pool.loadbalancer_algorithm
-- default_pool.no_tls
-- default_pool.same_as_endpoint_port
-- default_pool.use_tls.default_session_key_caching
-- default_pool.use_tls.no_mtls
-- default_pool.use_tls.use_host_header_as_sni
-- default_pool.use_tls.volterra_trusted_ca
-- default_sensitive_data_policy
-- disable_api_definition
-- disable_api_discovery
-- disable_api_testing
-- disable_bot_defense
-- disable_ip_reputation
-- disable_malicious_user_detection
-- disable_malware_protection
-- disable_rate_limit
-- disable_threat_mesh
-- disable_trust_client_ip_headers
-- disable_waf
-- https_auto_cert.add_hsts
-- https_auto_cert.connection_idle_timeout
-- https_auto_cert.enable_path_normalize
-- https_auto_cert.http_redirect
-- https_auto_cert.no_mtls
-- l7_ddos_protection
-- no_challenge
-- rate_limit.no_ip_allowed_list
-- rate_limit.no_policies
-- rate_limit.rate_limiter.period_multiplier
-- round_robin
-- service_policies_from_namespace
-- user_id_client_ip
+- connection_timeout
+- http_idle_timeout
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/k8s_cluster.txt
+++ b/docs/_llms-txt/resources/k8s_cluster.txt
@@ -8,6 +8,18 @@ K8s_cluster will create the object in the storage backend for namespace metadata
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- cluster_scoped_access_deny
+- no_cluster_wide_apps
+- no_global_access
+- no_insecure_registries
+- no_local_access
+- use_default_cluster_role_bindings
+- use_default_cluster_roles
+- use_default_psp
+- vk8s_namespace_access_deny
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/k8s_cluster.txt
+++ b/docs/_llms-txt/resources/k8s_cluster.txt
@@ -8,18 +8,6 @@ K8s_cluster will create the object in the storage backend for namespace metadata
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- cluster_scoped_access_deny
-- no_cluster_wide_apps
-- no_global_access
-- no_insecure_registries
-- no_local_access
-- use_default_cluster_role_bindings
-- use_default_cluster_roles
-- use_default_psp
-- vk8s_namespace_access_deny
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/malicious_user_mitigation.txt
+++ b/docs/_llms-txt/resources/malicious_user_mitigation.txt
@@ -8,10 +8,6 @@ Malicious_user_mitigation creates a new object in the storage backend for metada
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- mitigation_type
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/malicious_user_mitigation.txt
+++ b/docs/_llms-txt/resources/malicious_user_mitigation.txt
@@ -8,6 +8,10 @@ Malicious_user_mitigation creates a new object in the storage backend for metada
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- mitigation_type
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/network_firewall.txt
+++ b/docs/_llms-txt/resources/network_firewall.txt
@@ -8,6 +8,12 @@ Network firewall is created by users in system namespace. configuration
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- disable_fast_acl
+- disable_forward_proxy_policy
+- disable_network_policy
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/network_firewall.txt
+++ b/docs/_llms-txt/resources/network_firewall.txt
@@ -8,12 +8,6 @@ Network firewall is created by users in system namespace. configuration
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- disable_fast_acl
-- disable_forward_proxy_policy
-- disable_network_policy
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/origin_pool.txt
+++ b/docs/_llms-txt/resources/origin_pool.txt
@@ -12,23 +12,8 @@ Defining backend server pools for load balancer targets
 
 ## Server Defaults (safe to omit)
 
-- advanced_options.auto_http_config
-- advanced_options.connection_timeout
-- advanced_options.default_circuit_breaker
-- advanced_options.disable_outlier_detection
-- advanced_options.disable_subsets
-- advanced_options.http_idle_timeout
-- advanced_options.no_panic_threshold
-- advanced_options.no_request_limit_per_connection
-- endpoint_selection
-- healthcheck
-- loadbalancer_algorithm
-- no_tls
-- same_as_endpoint_port
-- use_tls.default_session_key_caching
-- use_tls.no_mtls
-- use_tls.use_host_header_as_sni
-- use_tls.volterra_trusted_ca
+- connection_timeout
+- http_idle_timeout
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/origin_pool.txt
+++ b/docs/_llms-txt/resources/origin_pool.txt
@@ -12,8 +12,23 @@ Defining backend server pools for load balancer targets
 
 ## Server Defaults (safe to omit)
 
-- connection_timeout
-- http_idle_timeout
+- advanced_options.auto_http_config
+- advanced_options.connection_timeout
+- advanced_options.default_circuit_breaker
+- advanced_options.disable_outlier_detection
+- advanced_options.disable_subsets
+- advanced_options.http_idle_timeout
+- advanced_options.no_panic_threshold
+- advanced_options.no_request_limit_per_connection
+- endpoint_selection
+- healthcheck
+- loadbalancer_algorithm
+- no_tls
+- same_as_endpoint_port
+- use_tls.default_session_key_caching
+- use_tls.no_mtls
+- use_tls.use_host_header_as_sni
+- use_tls.volterra_trusted_ca
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/policer.txt
+++ b/docs/_llms-txt/resources/policer.txt
@@ -10,11 +10,6 @@ New policer with traffic rate limits
 - burst_size
 - committed_information_rate
 
-## Server Defaults (safe to omit)
-
-- policer_mode
-- policer_type
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/policer.txt
+++ b/docs/_llms-txt/resources/policer.txt
@@ -10,6 +10,11 @@ New policer with traffic rate limits
 - burst_size
 - committed_information_rate
 
+## Server Defaults (safe to omit)
+
+- policer_mode
+- policer_type
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/protocol_inspection.txt
+++ b/docs/_llms-txt/resources/protocol_inspection.txt
@@ -10,10 +10,6 @@ Protocol Inspection Specification in a given namespace. If one already exists it
 - enable_disable_compliance_checks
 - enable_disable_signatures
 
-## Server Defaults (safe to omit)
-
-- action
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/protocol_inspection.txt
+++ b/docs/_llms-txt/resources/protocol_inspection.txt
@@ -10,6 +10,10 @@ Protocol Inspection Specification in a given namespace. If one already exists it
 - enable_disable_compliance_checks
 - enable_disable_signatures
 
+## Server Defaults (safe to omit)
+
+- action
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/rate_limiter.txt
+++ b/docs/_llms-txt/resources/rate_limiter.txt
@@ -8,10 +8,6 @@ Rate_limiter creates a new object in the storage backend for metadata.namespace
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- user_identification
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/rate_limiter.txt
+++ b/docs/_llms-txt/resources/rate_limiter.txt
@@ -8,6 +8,10 @@ Rate_limiter creates a new object in the storage backend for metadata.namespace
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- user_identification
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/rate_limiter_policy.txt
+++ b/docs/_llms-txt/resources/rate_limiter_policy.txt
@@ -10,6 +10,10 @@ Rate limiter policy create specification. configuration
 - burst_size
 - committed_information_rate
 
+## Server Defaults (safe to omit)
+
+- rules
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/rate_limiter_policy.txt
+++ b/docs/_llms-txt/resources/rate_limiter_policy.txt
@@ -10,10 +10,6 @@ Rate limiter policy create specification. configuration
 - burst_size
 - committed_information_rate
 
-## Server Defaults (safe to omit)
-
-- rules
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/sensitive_data_policy.txt
+++ b/docs/_llms-txt/resources/sensitive_data_policy.txt
@@ -8,6 +8,12 @@ Sensitive_data_policy creates a new object in the storage backend for metadata.n
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- compliances
+- custom_data_types
+- disabled_predefined_data_types
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/sensitive_data_policy.txt
+++ b/docs/_llms-txt/resources/sensitive_data_policy.txt
@@ -8,12 +8,6 @@ Sensitive_data_policy creates a new object in the storage backend for metadata.n
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- compliances
-- custom_data_types
-- disabled_predefined_data_types
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/service_policy.txt
+++ b/docs/_llms-txt/resources/service_policy.txt
@@ -8,10 +8,6 @@ Service_policy creates a new object in the storage backend for metadata.namespac
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- port_matcher
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/service_policy.txt
+++ b/docs/_llms-txt/resources/service_policy.txt
@@ -8,6 +8,10 @@ Service_policy creates a new object in the storage backend for metadata.namespac
 - name
 - namespace
 
+## Server Defaults (safe to omit)
+
+- port_matcher
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/tcp_loadbalancer.txt
+++ b/docs/_llms-txt/resources/tcp_loadbalancer.txt
@@ -9,16 +9,6 @@ Load balancing TCP traffic across origin pools
 - namespace
 - origin_pools
 
-## Server Defaults (safe to omit)
-
-- dns_volterra_managed
-- hash_policy_choice_round_robin
-- idle_timeout
-- no_sni
-- retract_cluster
-- service_policies_from_namespace
-- tcp
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/tcp_loadbalancer.txt
+++ b/docs/_llms-txt/resources/tcp_loadbalancer.txt
@@ -9,6 +9,16 @@ Load balancing TCP traffic across origin pools
 - namespace
 - origin_pools
 
+## Server Defaults (safe to omit)
+
+- dns_volterra_managed
+- hash_policy_choice_round_robin
+- idle_timeout
+- no_sni
+- retract_cluster
+- service_policies_from_namespace
+- tcp
+
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/data-sources/addon_service.md
+++ b/docs/data-sources/addon_service.md
@@ -25,11 +25,11 @@ activation type.
 or subscribe to an addon service, please use the F5 Distributed Cloud Console or
 contact your account team.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
-```terraform
+```hcl
 data "xcsh_addon_service" "example" {
   name      = "example-resource"
   namespace = "system"
@@ -40,7 +40,7 @@ data "xcsh_addon_service" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/addon_service_activation_status.md
+++ b/docs/data-sources/addon_service_activation_status.md
@@ -30,11 +30,11 @@ and what the current subscription state is.
 | `AS_SUBSCRIBED` | Service is active and subscribed         |
 | `AS_ERROR`      | Subscription in error state              |
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
-```terraform
+```hcl
 data "xcsh_addon_service_activation_status" "example" {
   name      = "example-resource"
   namespace = "system"
@@ -45,7 +45,7 @@ data "xcsh_addon_service_activation_status" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Spec Argument Reference
 

--- a/docs/data-sources/address_allocator.md
+++ b/docs/data-sources/address_allocator.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Address Allocator will create an address allocator object in 'system' namespace of the user. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "address_allocator_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/advertise_policy.md
+++ b/docs/data-sources/advertise_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Advertise Policy resource in F5 Distributed Cloud for advertise_policy object controls how and where a service represented by a given virtual_host object is advertised to consumers. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "advertise_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/alert_gen_policy.md
+++ b/docs/data-sources/alert_gen_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Alert Generation Policy. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "alert_gen_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/alert_policy.md
+++ b/docs/data-sources/alert_policy.md
@@ -42,7 +42,7 @@ output "alert_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/alert_policy.md
+++ b/docs/data-sources/alert_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new Alert Policy Object. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Alert Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/) to learn more.
+~> **Note:** For more information, see the [Alert Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/).
 
 ## Example Usage
 

--- a/docs/data-sources/alert_receiver.md
+++ b/docs/data-sources/alert_receiver.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new Alert Receiver object. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "alert_receiver_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/alert_template.md
+++ b/docs/data-sources/alert_template.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Domain to protect. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "alert_template_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/allowed_domain.md
+++ b/docs/data-sources/allowed_domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about allowed domain. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "allowed_domain_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/api_crawler.md
+++ b/docs/data-sources/api_crawler.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an API Crawler resource in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "api_crawler_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/api_definition.md
+++ b/docs/data-sources/api_definition.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about API Definition. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [API Definition API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/api/) to learn more.
+~> **Note:** For more information, see the [API Definition API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/api/).
 
 ## Example Usage
 

--- a/docs/data-sources/api_definition.md
+++ b/docs/data-sources/api_definition.md
@@ -42,7 +42,7 @@ output "api_definition_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/api_discovery.md
+++ b/docs/data-sources/api_discovery.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "api_discovery_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/api_testing.md
+++ b/docs/data-sources/api_testing.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an API Testing resource in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "api_testing_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/app_api_group.md
+++ b/docs/data-sources/app_api_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about app_api_group creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "app_api_group_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/app_firewall.md
+++ b/docs/data-sources/app_firewall.md
@@ -42,7 +42,7 @@ output "app_firewall_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/app_firewall.md
+++ b/docs/data-sources/app_firewall.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Application Firewall. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [App Firewall API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [App Firewall API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/data-sources/app_setting.md
+++ b/docs/data-sources/app_setting.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about App setting configuration in namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "app_setting_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/app_type.md
+++ b/docs/data-sources/app_type.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "app_type_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/application_profiles.md
+++ b/docs/data-sources/application_profiles.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Application Profiles in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "application_profiles_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/authentication.md
+++ b/docs/data-sources/authentication.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an Authentication resource in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "authentication_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/authorization_server.md
+++ b/docs/data-sources/authorization_server.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about authorization_server creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "authorization_server_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/aws_tgw_site.md
+++ b/docs/data-sources/aws_tgw_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a AWS TGW Site resource in F5 Distributed Cloud for deploying F5 sites connected via AWS Transit Gateway. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "aws_tgw_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/aws_vpc_site.md
+++ b/docs/data-sources/aws_vpc_site.md
@@ -42,7 +42,7 @@ output "aws_vpc_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/aws_vpc_site.md
+++ b/docs/data-sources/aws_vpc_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a AWS VPC Site resource in F5 Distributed Cloud for deploying F5 sites within AWS VPC environments. This is a read-only data source.
 
-~> **Note** Please refer to [AWS VPC Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [AWS VPC Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/data-sources/azure_vnet_site.md
+++ b/docs/data-sources/azure_vnet_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Azure VNET Site resource in F5 Distributed Cloud for deploying F5 sites within Azure Virtual Network environments. This is a read-only data source.
 
-~> **Note** Please refer to [Azure VNET Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [Azure VNET Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/data-sources/azure_vnet_site.md
+++ b/docs/data-sources/azure_vnet_site.md
@@ -42,7 +42,7 @@ output "azure_vnet_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/bgp.md
+++ b/docs/data-sources/bgp.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a BGP resource in F5 Distributed Cloud for bgp object is the configuration for peering with external bgp servers. it is created by users in system namespace. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bgp_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/bgp_asn_set.md
+++ b/docs/data-sources/bgp_asn_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about bgp_asn_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bgp_asn_set_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/bgp_routing_policy.md
+++ b/docs/data-sources/bgp_routing_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a BGP Routing Policy resource in F5 Distributed Cloud for bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help control routes which are imported or exported to bgp peers. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bgp_routing_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/bigip_http_proxy.md
+++ b/docs/data-sources/bigip_http_proxy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about BIG-IP HTTP Proxy in a given namespace. If one already exists, it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bigip_http_proxy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/bigip_virtual_server.md
+++ b/docs/data-sources/bigip_virtual_server.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a BIG-IP Virtual Server resource in F5 Distributed Cloud for big-ip virtual server specification. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bigip_virtual_server_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/bot_allowlist_policy.md
+++ b/docs/data-sources/bot_allowlist_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Bot Allowlist Policy resource in F5 Distributed Cloud for get bot allowlist policy. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bot_allowlist_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/bot_defense_app_infrastructure.md
+++ b/docs/data-sources/bot_defense_app_infrastructure.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Bot Defense App Infrastructure in a given namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bot_defense_app_infrastructure_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/bot_detection_rule.md
+++ b/docs/data-sources/bot_detection_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Bot Detection Rule resource in F5 Distributed Cloud for get bot detection rule. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bot_detection_rule_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/bot_endpoint_policy.md
+++ b/docs/data-sources/bot_endpoint_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Bot Endpoint Policy resource in F5 Distributed Cloud for get bot endpoint policy. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bot_endpoint_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/bot_infrastructure.md
+++ b/docs/data-sources/bot_infrastructure.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Bot Infrastructure. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bot_infrastructure_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/bot_network_policy.md
+++ b/docs/data-sources/bot_network_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Bot Network Policy resource in F5 Distributed Cloud for get bot network policy. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "bot_network_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/cdn_cache_rule.md
+++ b/docs/data-sources/cdn_cache_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a CDN Cache Rule resource in F5 Distributed Cloud for CDN loadbalancer specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cdn_cache_rule_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cdn_loadbalancer.md
+++ b/docs/data-sources/cdn_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a CDN Load Balancer resource in F5 Distributed Cloud for content delivery and edge caching with load balancing. This is a read-only data source.
 
-~> **Note** Please refer to [CDN Loadbalancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cdn/) to learn more.
+~> **Note:** For more information, see the [CDN Loadbalancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cdn/).
 
 ## Example Usage
 

--- a/docs/data-sources/cdn_loadbalancer.md
+++ b/docs/data-sources/cdn_loadbalancer.md
@@ -42,7 +42,7 @@ output "cdn_loadbalancer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cdn_purge_command.md
+++ b/docs/data-sources/cdn_purge_command.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a CDN Purge Command resource in F5 Distributed Cloud for CDN purge command specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cdn_purge_command_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/certificate.md
+++ b/docs/data-sources/certificate.md
@@ -42,7 +42,7 @@ output "certificate_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/certificate.md
+++ b/docs/data-sources/certificate.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Certificate resource in F5 Distributed Cloud for certificate. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Certificate API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/) to learn more.
+~> **Note:** For more information, see the [Certificate API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/).
 
 ## Example Usage
 

--- a/docs/data-sources/certificate_chain.md
+++ b/docs/data-sources/certificate_chain.md
@@ -42,7 +42,7 @@ output "certificate_chain_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/certificate_chain.md
+++ b/docs/data-sources/certificate_chain.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Certificate Chain resource in F5 Distributed Cloud for certificate chain configuration for TLS. This is a read-only data source.
 
-~> **Note** Please refer to [Certificate Chain API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/) to learn more.
+~> **Note:** For more information, see the [Certificate Chain API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/).
 
 ## Example Usage
 

--- a/docs/data-sources/certified_hardware.md
+++ b/docs/data-sources/certified_hardware.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Certified Hardware resource in F5 Distributed Cloud for get certified hardware object. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "certified_hardware_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/cloud_connect.md
+++ b/docs/data-sources/cloud_connect.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Cloud Connect resource in F5 Distributed Cloud for establishing connectivity to cloud provider networks. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cloud_connect_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cloud_credentials.md
+++ b/docs/data-sources/cloud_credentials.md
@@ -42,7 +42,7 @@ output "cloud_credentials_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cloud_credentials.md
+++ b/docs/data-sources/cloud_credentials.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Cloud Credentials resource in F5 Distributed Cloud for api to create cloud_credentials object. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Cloud Credentials API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [Cloud Credentials API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_elastic_ip.md
+++ b/docs/data-sources/cloud_elastic_ip.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Cloud Elastic IP creates Cloud Elastic IP object Object is attached to a site. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cloud_elastic_ip_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cloud_link.md
+++ b/docs/data-sources/cloud_link.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new CloudLink with configured parameters. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cloud_link_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cloud_region.md
+++ b/docs/data-sources/cloud_region.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Cloud Region resource in F5 Distributed Cloud for cloud re specification. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cloud_region_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about cluster will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cluster_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/cminstance.md
+++ b/docs/data-sources/cminstance.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "cminstance_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/code_base_integration.md
+++ b/docs/data-sources/code_base_integration.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about integration details. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "code_base_integration_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/container_registry.md
+++ b/docs/data-sources/container_registry.md
@@ -42,7 +42,7 @@ output "container_registry_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/container_registry.md
+++ b/docs/data-sources/container_registry.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Container Registry resource in F5 Distributed Cloud for container image registry configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Container Registry API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/) to learn more.
+~> **Note:** For more information, see the [Container Registry API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/).
 
 ## Example Usage
 

--- a/docs/data-sources/crl.md
+++ b/docs/data-sources/crl.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a CRL resource in F5 Distributed Cloud for api to create crl object. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "crl_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/data_group.md
+++ b/docs/data-sources/data_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about data group in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "data_group_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/data_type.md
+++ b/docs/data-sources/data_type.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about data_type creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "data_type_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dc_cluster_group.md
+++ b/docs/data-sources/dc_cluster_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DC Cluster group in given namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "dc_cluster_group_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/discovery.md
+++ b/docs/data-sources/discovery.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Discovery resource in F5 Distributed Cloud for api to create discovery object for a site or virtual site in system namespace. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "discovery_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dns_compliance_checks.md
+++ b/docs/data-sources/dns_compliance_checks.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DNS Compliance Checks Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "dns_compliance_checks_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dns_lb_health_check.md
+++ b/docs/data-sources/dns_lb_health_check.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DNS Load Balancer Health Check in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "dns_lb_health_check_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dns_lb_pool.md
+++ b/docs/data-sources/dns_lb_pool.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DNS Load Balancer Pool in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "dns_lb_pool_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dns_load_balancer.md
+++ b/docs/data-sources/dns_load_balancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DNS Load Balancer in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [DNS Load Balancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/) to learn more.
+~> **Note:** For more information, see the [DNS Load Balancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/).
 
 ## Example Usage
 

--- a/docs/data-sources/dns_load_balancer.md
+++ b/docs/data-sources/dns_load_balancer.md
@@ -42,7 +42,7 @@ output "dns_load_balancer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dns_proxy.md
+++ b/docs/data-sources/dns_proxy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DNS Proxy in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "dns_proxy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/dns_zone.md
+++ b/docs/data-sources/dns_zone.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about DNS Zone in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [DNS Zone API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/) to learn more.
+~> **Note:** For more information, see the [DNS Zone API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/).
 
 ## Example Usage
 

--- a/docs/data-sources/dns_zone.md
+++ b/docs/data-sources/dns_zone.md
@@ -42,7 +42,7 @@ output "dns_zone_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/endpoint.md
+++ b/docs/data-sources/endpoint.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about endpoint will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Endpoint API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/service_mesh/) to learn more.
+~> **Note:** For more information, see the [Endpoint API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/service_mesh/).
 
 ## Example Usage
 

--- a/docs/data-sources/endpoint.md
+++ b/docs/data-sources/endpoint.md
@@ -42,7 +42,7 @@ output "endpoint_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/enhanced_firewall_policy.md
+++ b/docs/data-sources/enhanced_firewall_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an Enhanced Firewall Policy resource in F5 Distributed Cloud for enhanced firewall policy specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "enhanced_firewall_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/external_connector.md
+++ b/docs/data-sources/external_connector.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an External Connector resource in F5 Distributed Cloud for external_connector configuration specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "external_connector_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/fast_acl.md
+++ b/docs/data-sources/fast_acl.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about object, object contains rules to protect site from denial of service It has destination{destination IP, destination port) and references to. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "fast_acl_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/fast_acl_rule.md
+++ b/docs/data-sources/fast_acl_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "fast_acl_rule_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/filter_set.md
+++ b/docs/data-sources/filter_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about specification. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "filter_set_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/fleet.md
+++ b/docs/data-sources/fleet.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about fleet will create a fleet object in 'system' namespace of the user. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "fleet_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/flow_anomaly.md
+++ b/docs/data-sources/flow_anomaly.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Flow Anomaly resource in F5 Distributed Cloud for flow anomaly specification. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "flow_anomaly_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/forward_proxy_policy.md
+++ b/docs/data-sources/forward_proxy_policy.md
@@ -42,7 +42,7 @@ output "forward_proxy_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/forward_proxy_policy.md
+++ b/docs/data-sources/forward_proxy_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Forward Proxy Policy resource in F5 Distributed Cloud for forward proxy policy specification. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Forward Proxy Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/) to learn more.
+~> **Note:** For more information, see the [Forward Proxy Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/).
 
 ## Example Usage
 

--- a/docs/data-sources/forwarding_class.md
+++ b/docs/data-sources/forwarding_class.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Forwarding Class resource in F5 Distributed Cloud for forwarding class is created by users in system namespace. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "forwarding_class_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/gcp_vpc_site.md
+++ b/docs/data-sources/gcp_vpc_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a GCP VPC Site resource in F5 Distributed Cloud for deploying F5 sites within Google Cloud VPC environments. This is a read-only data source.
 
-~> **Note** Please refer to [GCP VPC Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [GCP VPC Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/data-sources/gcp_vpc_site.md
+++ b/docs/data-sources/gcp_vpc_site.md
@@ -42,7 +42,7 @@ output "gcp_vpc_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/geo_location_set.md
+++ b/docs/data-sources/geo_location_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Geolocation Set. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "geo_location_set_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/global_log_receiver.md
+++ b/docs/data-sources/global_log_receiver.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new Global Log Receiver object. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "global_log_receiver_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/healthcheck.md
+++ b/docs/data-sources/healthcheck.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Healthcheck resource in F5 Distributed Cloud for healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Healthcheck API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [Healthcheck API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/data-sources/healthcheck.md
+++ b/docs/data-sources/healthcheck.md
@@ -42,7 +42,7 @@ output "healthcheck_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/http_loadbalancer.md
+++ b/docs/data-sources/http_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an HTTP Load Balancer resource in F5 Distributed Cloud for load balancing HTTP/HTTPS traffic with advanced routing and security. This is a read-only data source.
 
-~> **Note** Please refer to [HTTP Loadbalancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [HTTP Loadbalancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/data-sources/http_loadbalancer.md
+++ b/docs/data-sources/http_loadbalancer.md
@@ -42,7 +42,7 @@ output "http_loadbalancer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/ike1.md
+++ b/docs/data-sources/ike1.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Ike1 resource in F5 Distributed Cloud for ike phase1 profile specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "ike1_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/ike2.md
+++ b/docs/data-sources/ike2.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Ike2 resource in F5 Distributed Cloud for ike phase2 profile specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "ike2_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/ike_phase1_profile.md
+++ b/docs/data-sources/ike_phase1_profile.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a IKE Phase1 Profile resource in F5 Distributed Cloud for ike phase1 profile specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "ike_phase1_profile_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/ike_phase2_profile.md
+++ b/docs/data-sources/ike_phase2_profile.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a IKE Phase2 Profile resource in F5 Distributed Cloud for ike phase2 profile specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "ike_phase2_profile_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/ip_prefix_set.md
+++ b/docs/data-sources/ip_prefix_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about ip_prefix_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "ip_prefix_set_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/irule.md
+++ b/docs/data-sources/irule.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about iRule in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "irule_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/k8s_cluster.md
+++ b/docs/data-sources/k8s_cluster.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about k8s_cluster will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "k8s_cluster_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/k8s_cluster_role.md
+++ b/docs/data-sources/k8s_cluster_role.md
@@ -42,7 +42,7 @@ output "k8s_cluster_role_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/k8s_cluster_role.md
+++ b/docs/data-sources/k8s_cluster_role.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about k8s_cluster_role will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [K8S Cluster Role API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/) to learn more.
+~> **Note:** For more information, see the [K8S Cluster Role API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/).
 
 ## Example Usage
 

--- a/docs/data-sources/k8s_cluster_role_binding.md
+++ b/docs/data-sources/k8s_cluster_role_binding.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about k8s_cluster_role_binding will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "k8s_cluster_role_binding_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/k8s_pod_security_admission.md
+++ b/docs/data-sources/k8s_pod_security_admission.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about k8s_pod_security_admission will create the object in the storage backend. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "k8s_pod_security_admission_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/k8s_pod_security_policy.md
+++ b/docs/data-sources/k8s_pod_security_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about k8s_pod_security_policy will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "k8s_pod_security_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/lma_region.md
+++ b/docs/data-sources/lma_region.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Lma Region resource in F5 Distributed Cloud for lma region specification. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "lma_region_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/log_receiver.md
+++ b/docs/data-sources/log_receiver.md
@@ -42,7 +42,7 @@ output "log_receiver_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/log_receiver.md
+++ b/docs/data-sources/log_receiver.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new Log Receiver object. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Log Receiver API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/) to learn more.
+~> **Note:** For more information, see the [Log Receiver API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/).
 
 ## Example Usage
 

--- a/docs/data-sources/malicious_user_mitigation.md
+++ b/docs/data-sources/malicious_user_mitigation.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about malicious_user_mitigation creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "malicious_user_mitigation_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/mitigated_domain.md
+++ b/docs/data-sources/mitigated_domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Mitigated Domain. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "mitigated_domain_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new namespace. Name of the object is name of the namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "namespace_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/nat_policy.md
+++ b/docs/data-sources/nat_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a NAT Policy resource in F5 Distributed Cloud for nat policy create specification configures nat policy with multiple rules,. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "nat_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/network_connector.md
+++ b/docs/data-sources/network_connector.md
@@ -42,7 +42,7 @@ output "network_connector_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/network_connector.md
+++ b/docs/data-sources/network_connector.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Network Connector resource in F5 Distributed Cloud for network connector is created by users in system namespace. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Network Connector API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/) to learn more.
+~> **Note:** For more information, see the [Network Connector API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/).
 
 ## Example Usage
 

--- a/docs/data-sources/network_firewall.md
+++ b/docs/data-sources/network_firewall.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Network Firewall resource in F5 Distributed Cloud for network firewall is created by users in system namespace. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Network Firewall API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/) to learn more.
+~> **Note:** For more information, see the [Network Firewall API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/).
 
 ## Example Usage
 

--- a/docs/data-sources/network_firewall.md
+++ b/docs/data-sources/network_firewall.md
@@ -42,7 +42,7 @@ output "network_firewall_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/network_interface.md
+++ b/docs/data-sources/network_interface.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Network Interface resource in F5 Distributed Cloud for network interface represents configuration of a network device. it is created by users in system namespace. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "network_interface_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/network_policy.md
+++ b/docs/data-sources/network_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new network policy with configured parameters in specified namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Network Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/) to learn more.
+~> **Note:** For more information, see the [Network Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/).
 
 ## Example Usage
 

--- a/docs/data-sources/network_policy.md
+++ b/docs/data-sources/network_policy.md
@@ -42,7 +42,7 @@ output "network_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/network_policy_rule.md
+++ b/docs/data-sources/network_policy_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about network policy rule with configured parameters in specified namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "network_policy_rule_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/network_policy_set.md
+++ b/docs/data-sources/network_policy_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Network Policy Set resource in F5 Distributed Cloud for get network policy set in a given namespace. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "network_policy_set_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/network_policy_view.md
+++ b/docs/data-sources/network_policy_view.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Network Policy View resource in F5 Distributed Cloud for network policy view specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "network_policy_view_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/nfv_service.md
+++ b/docs/data-sources/nfv_service.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new NFV service with configured parameters. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "nfv_service_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/nginx_csg.md
+++ b/docs/data-sources/nginx_csg.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Nginx Csg resource in F5 Distributed Cloud for get nginx csg configuration. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "nginx_csg_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/nginx_instance.md
+++ b/docs/data-sources/nginx_instance.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Nginx Instance resource in F5 Distributed Cloud for get nginx instance configuration. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "nginx_instance_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/nginx_server.md
+++ b/docs/data-sources/nginx_server.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Nginx Server resource in F5 Distributed Cloud for get nginx server block configuration. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "nginx_server_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/nginx_service_discovery.md
+++ b/docs/data-sources/nginx_service_discovery.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Nginx Service Discovery resource in F5 Distributed Cloud for api to create nginx service discovery object for a site or virtual site in system namespace. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "nginx_service_discovery_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/origin_pool.md
+++ b/docs/data-sources/origin_pool.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about an Origin Pool resource in F5 Distributed Cloud for defining backend server pools for load balancer targets. This is a read-only data source.
 
-~> **Note** Please refer to [Origin Pool API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [Origin Pool API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/data-sources/origin_pool.md
+++ b/docs/data-sources/origin_pool.md
@@ -42,7 +42,7 @@ output "origin_pool_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/policer.md
+++ b/docs/data-sources/policer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new policer with traffic rate limits. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "policer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/policy_based_routing.md
+++ b/docs/data-sources/policy_based_routing.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Policy Based Routing resource in F5 Distributed Cloud for network policy based routing create specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "policy_based_routing_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/protected_application.md
+++ b/docs/data-sources/protected_application.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about applications protected by Bot Defense. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "protected_application_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/protected_domain.md
+++ b/docs/data-sources/protected_domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Domain to protect. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "protected_domain_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/protocol_inspection.md
+++ b/docs/data-sources/protocol_inspection.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Protocol Inspection Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "protocol_inspection_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/protocol_policer.md
+++ b/docs/data-sources/protocol_policer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about protocol_policer object, protocol_policer object contains list of L4 protocol match condition and corresponding traffic rate limits. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "protocol_policer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/proxy.md
+++ b/docs/data-sources/proxy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Proxy resource in F5 Distributed Cloud for tcp loadbalancer create specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "proxy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/public_ip.md
+++ b/docs/data-sources/public_ip.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Public IP resource in F5 Distributed Cloud for get public_ip will get the object from the storage backend for namespace metadata.namespace. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "public_ip_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/rate_limiter.md
+++ b/docs/data-sources/rate_limiter.md
@@ -42,7 +42,7 @@ output "rate_limiter_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/rate_limiter.md
+++ b/docs/data-sources/rate_limiter.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about rate_limiter creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Rate Limiter API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/) to learn more.
+~> **Note:** For more information, see the [Rate Limiter API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/).
 
 ## Example Usage
 

--- a/docs/data-sources/rate_limiter_policy.md
+++ b/docs/data-sources/rate_limiter_policy.md
@@ -42,7 +42,7 @@ output "rate_limiter_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/rate_limiter_policy.md
+++ b/docs/data-sources/rate_limiter_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Rate Limiter Policy resource in F5 Distributed Cloud for rate limiter policy create specification. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Rate Limiter Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/) to learn more.
+~> **Note:** For more information, see the [Rate Limiter Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/).
 
 ## Example Usage
 

--- a/docs/data-sources/registration.md
+++ b/docs/data-sources/registration.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Registration resource in F5 Distributed Cloud for vpm creates registration using this message, never used by users. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "registration_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/route.md
+++ b/docs/data-sources/route.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about route object in a given namespace. Route object is list of route rules. Each rule has match condition to match incoming requests and actions to take on matching requests. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "route_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/secret_management_access.md
+++ b/docs/data-sources/secret_management_access.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about secret_management_access creates a new object in storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "secret_management_access_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/securemesh_site.md
+++ b/docs/data-sources/securemesh_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Securemesh Site resource in F5 Distributed Cloud for deploying secure mesh edge sites with distributed security capabilities. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "securemesh_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/securemesh_site_v2.md
+++ b/docs/data-sources/securemesh_site_v2.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Securemesh Site V2 resource in F5 Distributed Cloud for deploying secure mesh edge sites with enhanced security and networking features. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "securemesh_site_v2_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/segment.md
+++ b/docs/data-sources/segment.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Segment resource in F5 Distributed Cloud for segment. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "segment_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/segment_connection.md
+++ b/docs/data-sources/segment_connection.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Segment Connection resource in F5 Distributed Cloud for segment connector specification. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "segment_connection_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/sensitive_data_policy.md
+++ b/docs/data-sources/sensitive_data_policy.md
@@ -42,7 +42,7 @@ output "sensitive_data_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/sensitive_data_policy.md
+++ b/docs/data-sources/sensitive_data_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about sensitive_data_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Sensitive Data Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/data_and_privacy_security/) to learn more.
+~> **Note:** For more information, see the [Sensitive Data Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/data_and_privacy_security/).
 
 ## Example Usage
 

--- a/docs/data-sources/service_policy.md
+++ b/docs/data-sources/service_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about service_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Service Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [Service Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/data-sources/service_policy.md
+++ b/docs/data-sources/service_policy.md
@@ -42,7 +42,7 @@ output "service_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/service_policy_rule.md
+++ b/docs/data-sources/service_policy_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about service_policy_rule creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "service_policy_rule_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/service_policy_set.md
+++ b/docs/data-sources/service_policy_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Service Policy Set resource in F5 Distributed Cloud for get service_policy_set reads a given object from storage backend for metadata.namespace. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "service_policy_set_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/shape_bot_defense_instance.md
+++ b/docs/data-sources/shape_bot_defense_instance.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Shape Bot Defense Instance resource in F5 Distributed Cloud for get virtual host from a given namespace. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "shape_bot_defense_instance_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/site.md
+++ b/docs/data-sources/site.md
@@ -42,7 +42,7 @@ output "site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/site.md
+++ b/docs/data-sources/site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Site resource in F5 Distributed Cloud for get of site. configuration. (read-only data source)
 
-~> **Note** Please refer to [Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/) to learn more.
+~> **Note:** For more information, see the [Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/).
 
 ## Example Usage
 

--- a/docs/data-sources/site_mesh_group.md
+++ b/docs/data-sources/site_mesh_group.md
@@ -42,7 +42,7 @@ output "site_mesh_group_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/site_mesh_group.md
+++ b/docs/data-sources/site_mesh_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about Site Mesh Group in system namespace of user. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Site Mesh Group API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/) to learn more.
+~> **Note:** For more information, see the [Site Mesh Group API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/).
 
 ## Example Usage
 

--- a/docs/data-sources/site_registration.md
+++ b/docs/data-sources/site_registration.md
@@ -49,11 +49,11 @@ resource "xcsh_registration_approval" "ce" {
 
 **Possible `state` values:** `NOTSET`, `NEW`, `APPROVED`, `ADMITTED`, `RETIRED`, `FAILED`, `DONE`, `PENDING`, `ONLINE`, `UPGRADING`, `MAINTENANCE`, `FAILED_INACTIVE`.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
-```terraform
+```hcl
 data "xcsh_site_registration" "example" {
   name      = "example-resource"
   namespace = "system"
@@ -64,7 +64,7 @@ data "xcsh_site_registration" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/srv6_network_slice.md
+++ b/docs/data-sources/srv6_network_slice.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about srv6_network_slice creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "srv6_network_slice_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/subnet.md
+++ b/docs/data-sources/subnet.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Subnet resource in F5 Distributed Cloud for subnet object contains configuration for an interface of a vm/pod. it is created in user or shared namespace. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "subnet_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/tcp_loadbalancer.md
+++ b/docs/data-sources/tcp_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a TCP Load Balancer resource in F5 Distributed Cloud for load balancing TCP traffic across origin pools. This is a read-only data source.
 
-~> **Note** Please refer to [TCP Loadbalancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [TCP Loadbalancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/data-sources/tcp_loadbalancer.md
+++ b/docs/data-sources/tcp_loadbalancer.md
@@ -42,7 +42,7 @@ output "tcp_loadbalancer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/tenant_configuration.md
+++ b/docs/data-sources/tenant_configuration.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Tenant Configuration resource in F5 Distributed Cloud for tenant configuration specification. configuration. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "tenant_configuration_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/third_party_application.md
+++ b/docs/data-sources/third_party_application.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Third Party Application resource in F5 Distributed Cloud for third party application specification. configuration. (read-only data source)
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "third_party_application_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 

--- a/docs/data-sources/token.md
+++ b/docs/data-sources/token.md
@@ -42,7 +42,7 @@ output "token_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/token.md
+++ b/docs/data-sources/token.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new token. Token object is used to manage site admission. User must generate token before provisioning and pass this token to site during it's registration. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Token API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/authentication/) to learn more.
+~> **Note:** For more information, see the [Token API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/authentication/).
 
 ## Example Usage
 

--- a/docs/data-sources/trusted_ca_list.md
+++ b/docs/data-sources/trusted_ca_list.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Trusted CA List resource in F5 Distributed Cloud for trusted certificate authority list management. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "trusted_ca_list_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/tunnel.md
+++ b/docs/data-sources/tunnel.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about tunnel in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "tunnel_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/udp_loadbalancer.md
+++ b/docs/data-sources/udp_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a UDP Load Balancer resource in F5 Distributed Cloud for load balancing UDP traffic across origin pools. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "udp_loadbalancer_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/usb_policy.md
+++ b/docs/data-sources/usb_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about new USB policy object. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "usb_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/user_identification.md
+++ b/docs/data-sources/user_identification.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about user_identification creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "user_identification_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/virtual_host.md
+++ b/docs/data-sources/virtual_host.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about virtual host in a given namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "virtual_host_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/virtual_k8s.md
+++ b/docs/data-sources/virtual_k8s.md
@@ -42,7 +42,7 @@ output "virtual_k8s_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/virtual_k8s.md
+++ b/docs/data-sources/virtual_k8s.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about virtual_k8s will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Virtual K8S API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/) to learn more.
+~> **Note:** For more information, see the [Virtual K8S API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/).
 
 ## Example Usage
 

--- a/docs/data-sources/virtual_network.md
+++ b/docs/data-sources/virtual_network.md
@@ -42,7 +42,7 @@ output "virtual_network_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/virtual_network.md
+++ b/docs/data-sources/virtual_network.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about virtual network in given namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Virtual Network API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/) to learn more.
+~> **Note:** For more information, see the [Virtual Network API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/).
 
 ## Example Usage
 

--- a/docs/data-sources/virtual_site.md
+++ b/docs/data-sources/virtual_site.md
@@ -42,7 +42,7 @@ output "virtual_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/virtual_site.md
+++ b/docs/data-sources/virtual_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about virtual site object in given namespace. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** Please refer to [Virtual Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/) to learn more.
+~> **Note:** For more information, see the [Virtual Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/).
 
 ## Example Usage
 

--- a/docs/data-sources/voltstack_site.md
+++ b/docs/data-sources/voltstack_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Voltstack Site resource in F5 Distributed Cloud for deploying Volterra stack sites for edge computing. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "voltstack_site_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/waf_exclusion_policy.md
+++ b/docs/data-sources/waf_exclusion_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about WAF exclusion policy. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "waf_exclusion_policy_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/workload.md
+++ b/docs/data-sources/workload.md
@@ -42,7 +42,7 @@ output "workload_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/data-sources/workload.md
+++ b/docs/data-sources/workload.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about a Workload resource in F5 Distributed Cloud for workload. configuration. This is a read-only data source.
 
-~> **Note** Please refer to [Workload API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/) to learn more.
+~> **Note:** For more information, see the [Workload API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/).
 
 ## Example Usage
 

--- a/docs/data-sources/workload_flavor.md
+++ b/docs/data-sources/workload_flavor.md
@@ -9,7 +9,7 @@ description: |-
 
 Retrieves information about workload_flavor. in F5 Distributed Cloud. This is a read-only data source.
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ output "workload_flavor_id" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 

--- a/docs/functions/blindfold.md
+++ b/docs/functions/blindfold.md
@@ -157,4 +157,4 @@ resource "xcsh_http_loadbalancer" "example" {
 
 ## See Also
 
-- [F5XC Secret Management Documentation](https://docs.cloud.f5.com/docs/how-to/advanced-security/blindfold-your-tls-certificates)
+- [F5 Distributed Cloud Secret Management Documentation](https://docs.cloud.f5.com/docs/how-to/advanced-security/blindfold-your-tls-certificates)

--- a/docs/functions/blindfold_file.md
+++ b/docs/functions/blindfold_file.md
@@ -165,4 +165,4 @@ resource "xcsh_certificate" "certs" {
 
 ## See Also
 
-- [F5XC Secret Management Documentation](https://docs.cloud.f5.com/docs/how-to/advanced-security/blindfold-your-tls-certificates)
+- [F5 Distributed Cloud Secret Management Documentation](https://docs.cloud.f5.com/docs/how-to/advanced-security/blindfold-your-tls-certificates)

--- a/docs/guides/addon-activation.md
+++ b/docs/guides/addon-activation.md
@@ -2,22 +2,22 @@
 page_title: "Guide: Addon Service Activation"
 subcategory: "Guides"
 description: |-
-  Report F5XC addon service activation with Terraform and gate resources on it.
+  Report F5 Distributed Cloud addon service activation with Terraform and gate dependent resources.
   Covers Bot Defense, Client-Side Defense, WAAP, and more.
 ---
 
 # Addon Service Activation
 
-This guide covers F5 Distributed Cloud addon services in Terraform. The provider exposes the addon API read-only, so Terraform reports activation and gates on it rather than performing it. By the end, you'll understand how to:
+This guide explains how to activate, configure, and manage tenant addon services in F5 Distributed Cloud using Terraform. Topics covered include:
 
-- **Check activation eligibility** - Determine if an addon can be activated
-- **Activate an addon** - where activation actually happens, and why it is not a Terraform resource
-- **Handle managed activation** - Services requiring sales contact
-- **Gate dependent resources** - create them only once the addon is active
+- **Check activation eligibility** — Determine whether an addon service is available for activation.
+- **Understand activation workflows** — Learn where activation occurs and why activation is not managed as a Terraform resource.
+- **Handle managed activation** — Coordinate services that require F5 account engagement.
+- **Gate dependent resources** — Provision resources only after the addon reaches the active state.
 
 ## Overview
 
-F5 Distributed Cloud addon services are additional security and performance features that can be activated for your tenant. These include:
+F5 Distributed Cloud addon services are optional security and performance features that you can activate for your tenant:
 
 | Addon Service                        | Description                                   | Tier Required |
 | ------------------------------------ | --------------------------------------------- | ------------- |
@@ -71,28 +71,28 @@ Addon services have different activation types that determine how they can be ac
 
 Before you begin, ensure you have:
 
-- **Terraform >= 1.0** - The F5XC provider requires Terraform 1.0 or later
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **API Credentials** - Token or P12 certificate authentication configured
-- **Appropriate Subscription Tier** - Most addon services require ADVANCED tier
+- **Terraform >= 1.0** — Download from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication
+- **Appropriate Subscription Tier** — Most addon services require the ADVANCED tier
 
 ### Authentication Setup
 
-Configure one of these authentication methods via environment variables:
+Configure one of these authentication methods using environment variables:
 
 #### Option 1: API Token (Recommended for development)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 #### Option 2: P12 Certificate (Recommended for production)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/your-credentials.p12"
-export XCSH_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"  # pragma: allowlist secret
 ```
 
 ## Quick Start
@@ -110,13 +110,13 @@ cd terraform-provider-xcsh/examples/guides/addon-activation
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Edit `terraform.tfvars` to choose the addon services you want reported:
+Edit `terraform.tfvars` to select the addon services you want to report:
 
 ```hcl
-# Enable Bot Defense activation
+# Enable Bot Defense reporting
 enable_bot_defense = true
 
-# Enable Client-Side Defense
+# Enable Client-Side Defense reporting
 enable_client_side_defense = false
 ```
 
@@ -130,12 +130,12 @@ terraform apply
 
 ## Checking Activation Eligibility
 
-Check where an addon stands for your tenant before relying on it.
+Check where an addon stands for your tenant before relying on it in configuration.
 
 ### Using the Activation Status Data Source
 
 ```hcl
-# Check if Bot Defense can be activated
+# Check whether Bot Defense can be activated
 data "xcsh_addon_service_activation_status" "bot_defense" {
   addon_service = "f5xc-bot-defense-standard"
 }
@@ -161,7 +161,7 @@ output "bot_defense_status" {
 ### Querying Addon Service Details
 
 ```hcl
-# Get detailed information about an addon service
+# Retrieve detailed information about an addon service
 data "xcsh_addon_service" "bot_defense" {
   name = "f5xc-bot-defense-standard"
 }
@@ -177,29 +177,27 @@ output "addon_details" {
 
 ## Activating an Addon
 
-The provider exposes the addon API read-only: there is no `xcsh_addon_subscription`
-resource, so Terraform reports activation rather than performing it. Activation
-happens in the F5 Distributed Cloud console under **Administration > Billing &
-Subscriptions**, or through your F5 account team for services that report managed
-activation.
+The provider exposes the addon API as read-only: there is no `xcsh_addon_subscription`
+resource, so Terraform reports activation rather than performing it directly. Activate
+services in the F5 Distributed Cloud Console under **Administration > Billing &
+Subscriptions**, or through your F5 account team for managed services.
 
-That split is deliberate rather than a gap. Activation is a billing event against
-the tenant, not a piece of per-environment infrastructure, so it does not belong
-in a plan that several environments apply independently.
+This design is intentional. Activation is a tenant-level billing event rather than
+an ephemeral infrastructure resource, so it does not belong in configuration plans
+applied independently across multiple environments.
 
-The workflow is therefore:
+Follow this workflow:
 
-1. Read `can_activate` and `state` to find out where an addon stands.
-2. Activate it in the console, once, for the tenant.
-3. Gate the resources that depend on the addon on `state` reaching `AS_SUBSCRIBED`.
+1. Read `can_activate` and `state` to determine the current addon status.
+2. Activate the service in the console once for the tenant.
+3. Gate dependent resources on `state` reaching `AS_SUBSCRIBED`.
 
 ### Reporting Pending Addons
 
-Collect the addons a configuration expects and surface the ones that still need
-attention. `pending` is the actionable output — anything in it has to be
-activated in the console before dependent resources can be created.
+Collect the addons that a configuration requires and report any that still need
+activation:
 
-```terraform
+```hcl
 locals {
   expected_addons = [
     "f5xc-bot-defense-standard",
@@ -222,18 +220,18 @@ locals {
 }
 
 output "pending_addons" {
-  description = "Activate these in the F5 Distributed Cloud console"
+  description = "Addons requiring activation in the F5 Distributed Cloud Console"
   value       = local.pending
 }
 ```
 
 ### Gating Dependent Resources
 
-Use the reported state as the condition on anything that needs the addon. A plan
-run against a tenant where the addon is not active then creates nothing that
-would depend on a feature that is not there.
+Use the reported state as a condition on any resource that requires the addon. When
+a plan runs against a tenant where the addon is inactive, Terraform skips creating
+dependent resources:
 
-```terraform
+```hcl
 data "xcsh_addon_service_activation_status" "bot_defense" {
   addon_service = "f5xc-bot-defense-standard"
 }
@@ -241,13 +239,13 @@ data "xcsh_addon_service_activation_status" "bot_defense" {
 resource "xcsh_http_loadbalancer" "with_bot_defense" {
   count = data.xcsh_addon_service_activation_status.bot_defense.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  name      = "my-protected-app"
+  name      = "example-protected-app"
   namespace = "production"
   domains   = ["app.example.com"]
 
   bot_defense {
     policy {
-      name      = "my-bot-policy"
+      name      = "example-bot-policy"
       namespace = "shared"
     }
   }
@@ -258,14 +256,12 @@ resource "xcsh_http_loadbalancer" "with_bot_defense" {
 }
 ```
 
-### Failing Loudly Instead of Silently Skipping
+### Asserting Addon Activation with Preconditions
 
-`count = 0` skips quietly, which is the right behaviour for an optional feature
-and the wrong one for a hard requirement. When the addon is mandatory, assert it
-so the plan stops with a readable message rather than applying a half-configured
-environment.
+When an addon is a mandatory requirement rather than an optional feature, use a
+precondition so the plan stops with an informative message:
 
-```terraform
+```hcl
 resource "terraform_data" "require_bot_defense" {
   lifecycle {
     precondition {
@@ -278,12 +274,10 @@ resource "terraform_data" "require_bot_defense" {
 
 ## Managed Activation Workflow
 
-For addon services requiring sales contact, use Terraform to monitor status after F5 activates the service.
-
-### Verifying Managed Addon Status
+For addon services requiring sales contact, use Terraform to monitor status after F5 activates the service:
 
 ```hcl
-# Managed addons are activated by F5; Terraform reports the resulting state
+# F5 activates managed addons; Terraform reports the resulting state
 data "xcsh_addon_service_activation_status" "managed_addon" {
   addon_service = "some_managed_addon"
 }
@@ -295,20 +289,19 @@ output "managed_addon_status" {
   }
 }
 
-# Use conditional logic based on activation status
+# Gate resources using conditional logic based on activation status
 resource "xcsh_http_loadbalancer" "with_managed_feature" {
   count = data.xcsh_addon_service_activation_status.managed_addon.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  # Configuration that uses the managed addon feature
-  name      = "lb-with-managed-addon"
+  name      = "example-managed-app"
   namespace = "production"
-  # ... rest of configuration
+  # ... remaining configuration
 }
 ```
 
 ## Using Addon Features
 
-Once an addon is activated, you can use its features in your configurations.
+After an addon is active, you can configure its features in your resources.
 
 ### Bot Defense in HTTP Load Balancer
 
@@ -316,7 +309,7 @@ Once an addon is activated, you can use its features in your configurations.
 resource "xcsh_http_loadbalancer" "with_bot_defense" {
   count = data.xcsh_addon_service_activation_status.bot_defense.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  name      = "my-protected-app"
+  name      = "example-protected-app"
   namespace = "production"
 
   domains = ["app.example.com"]
@@ -332,7 +325,7 @@ resource "xcsh_http_loadbalancer" "with_bot_defense" {
   # Enable Bot Defense
   bot_defense {
     policy {
-      name      = "my-bot-policy"
+      name      = "example-bot-policy"
       namespace = "shared"
     }
   }
@@ -349,7 +342,7 @@ resource "xcsh_http_loadbalancer" "with_bot_defense" {
 resource "xcsh_http_loadbalancer" "with_csd" {
   count = data.xcsh_addon_service_activation_status.client_side_defense.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  name      = "my-protected-app"
+  name      = "example-protected-app"
   namespace = "production"
 
   domains = ["app.example.com"]
@@ -357,7 +350,7 @@ resource "xcsh_http_loadbalancer" "with_csd" {
   # Enable Client-Side Defense
   enable_client_side_defense = true
 
-  # ... rest of configuration
+  # ... remaining configuration
 }
 ```
 
@@ -367,23 +360,23 @@ resource "xcsh_http_loadbalancer" "with_csd" {
 
 #### Access denied when reading activation status
 
-- Verify your API token has addon management permissions
-- Check that your subscription tier supports the addon
+- Verify that your API credentials have addon management permissions.
+- Verify that your tenant subscription tier supports the requested addon.
 
-#### Activation stuck in AS_PENDING
+#### Activation remains in AS_PENDING state
 
-- For partially managed addons, contact F5 support
-- For self-activation, wait and retry after a few minutes
+- For partially managed addons, contact F5 support if review takes longer than expected.
+- For self-activation, wait a few minutes and retry the plan.
 
-#### State shows AS_ERROR
+#### State reports AS_ERROR
 
-- Check F5XC console for detailed error messages
-- Contact F5 support with your tenant ID
+- Check the F5 Distributed Cloud Console for detailed error messages.
+- Contact F5 support with your tenant ID and addon name.
 
-### Debugging Tips
+### Debugging Status Output
 
 ```hcl
-# Output detailed status for debugging
+# Output detailed status for troubleshooting
 output "debug_addon_status" {
   value = {
     addon_service = "f5xc-bot-defense-standard"
@@ -396,11 +389,11 @@ output "debug_addon_status" {
 
 ## Best Practices
 
-1. **Always check eligibility first** - Use the activation status data source before attempting activation
-2. **Use conditional resource creation** - Gate dependent resources on `state` being `AS_SUBSCRIBED`
-3. **Handle dependencies properly** - Use `depends_on` to ensure addons are active before using features
-4. **Monitor activation state** - For partially managed addons, monitor the state for completion
-5. **Document addon requirements** - Clearly document which addons your configuration requires
+1. **Check eligibility first** — Query the activation status data source before configuring dependent features.
+2. **Use conditional resource creation** — Gate dependent resources on `state == "AS_SUBSCRIBED"`.
+3. **Assert hard requirements** — Use lifecycle preconditions to halt execution when mandatory addons are inactive.
+4. **Monitor activation state** — Track state progression for partially managed or pending addons.
+5. **Document addon dependencies** — Specify required subscription tiers and addons in module documentation.
 
 ## Complete Example
 

--- a/docs/guides/advanced-http-loadbalancer.md
+++ b/docs/guides/advanced-http-loadbalancer.md
@@ -2,39 +2,38 @@
 page_title: "Guide: Advanced HTTP Load Balancer Security"
 subcategory: "Guides"
 description: |-
-  Advanced guide to deploying a fully-secured HTTP Load Balancer with all security
-  controls including WAF, Data Guard, IP Reputation, Malicious User Detection, and
-  Threat Mesh using F5 Distributed Cloud and Terraform.
+  Deploy a secured HTTP Load Balancer with security controls including WAF, Data Guard,
+  IP Reputation, Malicious User Detection, and Threat Mesh using F5 Distributed Cloud and Terraform.
 ---
 
 # Advanced HTTP Load Balancer Security
 
-This guide extends the [basic HTTP Load Balancer guide](http-loadbalancer.md) with advanced security features for production deployments requiring comprehensive protection against sophisticated threats.
+This guide extends the [HTTP Load Balancer Guide](http-loadbalancer.md) with security features for production deployments requiring comprehensive protection against application and network threats.
 
-By following this guide, you'll deploy an HTTP Load Balancer with **11 security controls**:
+This guide demonstrates how to deploy an HTTP Load Balancer configured with defense-in-depth security controls across multiple layers:
 
-| Security Layer      | Feature                    | Protection                                     |
-| ------------------- | -------------------------- | ---------------------------------------------- |
-| **Perimeter**       | IP Reputation              | Blocks known malicious IPs by threat category  |
-| **Perimeter**       | Threat Mesh                | Global threat intelligence sharing             |
-| **Bot Defense**     | JavaScript Challenge       | Client-side bot detection                      |
-| **Bot Defense**     | Malicious User Detection   | Behavioral analysis and risk scoring           |
-| **Application**     | Web Application Firewall   | Blocks SQLi, XSS, and OWASP Top 10             |
-| **Application**     | Bot Protection Settings    | Signature-based bot classification             |
-| **Rate Control**    | Rate Limiting              | Prevents abuse with configurable thresholds    |
-| **Data Protection** | Data Guard                 | Masks sensitive data (CC, SSN) in responses    |
+| Security Layer      | Feature                  | Protection                                    |
+| ------------------- | ------------------------ | --------------------------------------------- |
+| **Perimeter**       | IP Reputation            | Blocks known malicious IPs by threat category |
+| **Perimeter**       | Threat Mesh              | Global threat intelligence sharing            |
+| **Bot Defense**     | JavaScript Challenge     | Client-side bot detection                     |
+| **Bot Defense**     | Malicious User Detection | Behavioral analysis and risk scoring          |
+| **Application**     | Web Application Firewall | Blocks SQLi, XSS, and OWASP Top 10            |
+| **Application**     | Bot Protection Settings  | Signature-based bot classification            |
+| **Rate Control**    | Rate Limiting            | Prevents abuse with configurable thresholds   |
+| **Data Protection** | Data Guard               | Masks sensitive data (CC, SSN) in responses   |
 
 ## Prerequisites
 
 Before you begin, ensure you have:
 
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **API Token** - Generate credentials from the F5XC Console ([documentation](https://docs.cloud.f5.com/docs/how-to/user-mgmt/credentials))
-- **Terraform >= 1.8** - Download from <https://www.terraform.io/downloads>
-- **Namespace** - An existing namespace or permissions to create one
-- **Backend Origin** - Your application server accessible from the internet
+- **Terraform >= 1.0** — Download from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication (see the [Authentication Guide](authentication.md))
+- **Namespace** — An existing namespace or permissions to create one
+- **Backend Origin** — An application server reachable by F5 Distributed Cloud Regional Edges
 
--> **Tip:** Review the [Authentication Guide](authentication.md) for detailed credential setup instructions.
+-> **Tip:** See the [Authentication Guide](authentication.md) for detailed credential setup instructions.
 
 ## Complete Configuration
 
@@ -63,18 +62,18 @@ provider "xcsh" {
 
 ```hcl
 variable "api_token" {
-  description = "F5 XC API token for authentication"
+  description = "F5 Distributed Cloud API token for authentication"
   type        = string
   sensitive   = true
 }
 
 variable "api_url" {
-  description = "F5 XC API URL (e.g., https://your-tenant.console.ves.volterra.io/api)"
+  description = "F5 Distributed Cloud API URL (for example, https://<XC_TENANT>.console.ves.volterra.io/api)"
   type        = string
 }
 
 variable "namespace" {
-  description = "F5 XC namespace for the load balancer"
+  description = "F5 Distributed Cloud namespace for the load balancer"
   type        = string
   default     = "default"
 }
@@ -82,7 +81,7 @@ variable "namespace" {
 variable "name_prefix" {
   description = "Prefix for resource names"
   type        = string
-  default     = "secure-app"
+  default     = "example-secure-app"
 }
 
 variable "domain" {
@@ -326,7 +325,7 @@ Data Guard automatically detects and masks sensitive data in HTTP responses befo
 - Social Security Numbers (SSN)
 - Custom patterns (configurable)
 
-!> **Important:** Data Guard requires WAF to be enabled. If you disable WAF, Data Guard will not function.
+~> **Important:** Data Guard requires WAF to be enabled. If you disable WAF, Data Guard does not function.
 
 ### Malicious User Detection
 
@@ -519,7 +518,7 @@ output "security_summary" {
 ```hcl
 rate_limit {
   ip_allowed_list {
-    prefixes = ["10.0.0.0/8", "192.168.0.0/16"]
+    prefixes = ["198.51.100.0/24", "203.0.113.0/24"]
   }
   rate_limiter {
     # ... configuration ...
@@ -529,21 +528,21 @@ rate_limit {
 
 ### JavaScript Challenge Breaking Application
 
-**Symptom:** API calls or mobile apps fail with JavaScript challenge.
+**Symptom:** API calls or mobile applications fail when encountering the JavaScript challenge.
 
 **Solutions:**
 
 1. Use `no_challenge {}` instead of `js_challenge {}` for API-only endpoints
-2. Configure trusted client rules to bypass JS challenge for specific clients
-3. Consider using `captcha_challenge {}` for interactive applications
+2. Configure trusted client rules to bypass the JavaScript challenge for specific clients
+3. Use `captcha_challenge {}` for interactive web applications
 
 ## Security Best Practices
 
-1. **Start with monitoring mode** - Deploy WAF in monitoring mode first to understand your traffic patterns
-2. **Review security analytics** - Regularly review blocked requests in the F5XC Console
-3. **Tune gradually** - Enable features one at a time and monitor impact
-4. **Use all layers** - Defense in depth requires multiple security controls
-5. **Keep Terraform state secure** - Use remote state with encryption for production
+1. **Start with monitoring mode** — Deploy WAF in monitoring mode initially to establish traffic baselines without blocking legitimate requests.
+2. **Review security analytics** — Regularly inspect blocked requests and threat detections in the F5 Distributed Cloud Console.
+3. **Tune controls incrementally** — Enable individual security controls sequentially and verify application behavior after each change.
+4. **Apply defense in depth** — Combine network, transport, and application layer controls for comprehensive protection.
+5. **Protect Terraform state** — Use remote state backends with server-side encryption and strict access control for production environments.
 
 ## Related Documentation
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -20,64 +20,64 @@ This guide covers authentication configuration for the F5 Distributed Cloud Terr
 
 ## Prerequisites
 
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **Terraform >= 1.8** - Download from <https://www.terraform.io/downloads>
-- **Console Access** - Ability to create credentials in the F5XC Console
+- **Terraform >= 1.0** — Download from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **Console Access** — Tenant credentials with permissions to generate API tokens or certificates
 
 ## Creating Credentials in F5 Distributed Cloud
 
 ### Personal Credentials
 
-Personal credentials are tied to your user account and ideal for development.
+Personal credentials are tied to your user account and suitable for development environments.
 
 #### Creating an API Token
 
-1. Open the F5 Distributed Cloud Console
-2. Navigate to **Administration** → **Personal Management** → **Credentials**
-3. Click **+ Add Credentials**
-4. Enter a name (e.g., "terraform-dev-token")
-5. Select **API Token** from the dropdown
-6. Choose an expiry date
-7. Click **Generate**, then **Copy** the token value
+1. Open the F5 Distributed Cloud Console.
+2. Navigate to **Administration** → **Personal Management** → **Credentials**.
+3. Select **+ Add Credentials**.
+4. Enter a name (for example, `terraform-dev-token`).
+5. In the **Credential Type** list, select **API Token**.
+6. Choose an expiration date.
+7. Select **Generate**, and then copy the token value.
 
-!> **Warning:** Copy and save your token immediately. You cannot retrieve it after closing this dialog.
+~> **Warning:** Copy and store your token immediately. You cannot retrieve the token value after closing the dialog.
 
 #### Creating a P12 Certificate
 
-1. Navigate to **Administration** → **Personal Management** → **Credentials**
-2. Click **+ Add Credentials**
-3. Enter a name (e.g., "terraform-dev-cert")
-4. Select **API Certificate** from the dropdown
-5. Enter and confirm a password
-6. Select an expiry date
-7. Click **Download** to get the `.p12` file
+1. Navigate to **Administration** → **Personal Management** → **Credentials**.
+2. Select **+ Add Credentials**.
+3. Enter a name (for example, `terraform-dev-cert`).
+4. In the **Credential Type** list, select **API Certificate**.
+5. Enter and confirm a password.
+6. Select an expiration date.
+7. Select **Download** to save the `.p12` certificate file.
 
--> **Tip:** Store the P12 file securely and never commit it to version control.
+-> **Tip:** Store the P12 certificate securely and never commit it to version control.
 
 ### Service Credentials (IAM)
 
-Service credentials are managed through IAM and recommended for production. They can be scoped to specific roles and namespaces.
+Service credentials are managed through IAM and recommended for CI/CD pipelines and production automation. You can scope service credentials to specific roles and namespaces.
 
 #### Creating a Service API Token
 
-1. Navigate to **Administration** → **IAM** → **Service Credentials**
-2. Click **+ Add Service Credentials**
-3. Enter a name (e.g., "terraform-cicd-token")
-4. Select **API Token** from the dropdown
-5. Optionally assign roles and namespaces to limit scope
-6. Choose an expiry date
-7. Click **Generate**, then **Copy** the token value
+1. Navigate to **Administration** → **IAM** → **Service Credentials**.
+2. Select **+ Add Service Credentials**.
+3. Enter a name (for example, `terraform-cicd-token`).
+4. In the **Credential Type** list, select **API Token**.
+5. Assign roles and namespaces to restrict credential scope.
+6. Choose an expiration date.
+7. Select **Generate**, and then copy the token value.
 
 #### Creating a Service P12 Certificate
 
-1. Navigate to **Administration** → **IAM** → **Service Credentials**
-2. Click **+ Add Service Credentials**
-3. Enter a name
-4. Select **API Certificate** from the dropdown
-5. Optionally assign roles and namespaces
-6. Enter and confirm a password
-7. Select an expiry date
-8. Click **Download** to get the `.p12` file
+1. Navigate to **Administration** → **IAM** → **Service Credentials**.
+2. Select **+ Add Service Credentials**.
+3. Enter a name (for example, `terraform-cicd-cert`).
+4. In the **Credential Type** list, select **API Certificate**.
+5. Assign roles and namespaces to restrict scope.
+6. Enter and confirm a password.
+7. Select an expiration date.
+8. Select **Download** to save the `.p12` certificate file.
 
 ## Provider Configuration
 
@@ -88,8 +88,8 @@ API tokens provide bearer token authentication over TLS. This is the quickest wa
 **Using Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 **Using Provider Configuration:**
@@ -108,9 +108,9 @@ P12 certificates provide mutual TLS (mTLS) authentication, where both client and
 **Using Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/your-credentials.p12"
-export XCSH_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"  # pragma: allowlist secret
 ```
 
 **Using Provider Configuration:**
@@ -125,9 +125,9 @@ provider "xcsh" {
 
 ### Method 3: PEM Certificate Authentication (Derived from P12)
 
-PEM authentication uses separate certificate and private key files. Since F5XC only provides P12 certificates, you must extract PEM files using OpenSSL.
+PEM authentication uses separate certificate and private key files. Because F5 Distributed Cloud generates P12 certificates, you must extract PEM files using OpenSSL when required by external tooling.
 
-**When to use this method:** Only when your tooling specifically requires PEM format instead of P12.
+**When to use this method:** Use PEM authentication only when your tooling specifically requires PEM format rather than P12.
 
 **Step 1: Extract PEM files from P12:**
 
@@ -136,14 +136,14 @@ PEM authentication uses separate certificate and private key files. Since F5XC o
 mkdir -p certs
 
 # Extract the certificate
-openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
+openssl pkcs12 -in ~/<XC_TENANT>.console.ves.volterra.io.api-creds.p12 \
   -nodes -nokeys -out certs/xcsh.cert
-# Enter Import Password: <your p12 password>
+# Enter Import Password: <XC_P12_PASSWORD>
 
 # Extract the private key
-openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
+openssl pkcs12 -in ~/<XC_TENANT>.console.ves.volterra.io.api-creds.p12 \
   -nodes -nocerts -out certs/xcsh.key
-# Enter Import Password: <your p12 password>
+# Enter Import Password: <XC_P12_PASSWORD>
 ```
 
 **Step 2: Configure the provider:**
@@ -151,7 +151,7 @@ openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
 **Using Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
 export XCSH_CERT="/path/to/certs/xcsh.cert"
 export XCSH_KEY="/path/to/certs/xcsh.key"
 ```
@@ -166,13 +166,13 @@ provider "xcsh" {
 }
 ```
 
-~> **Note:** For server certificate verification, specify a CA certificate using `XCSH_CACERT` environment variable or `api_ca_cert` provider attribute.
+~> **Note:** For server certificate verification, specify a CA certificate using the `XCSH_CACERT` environment variable or the `api_ca_cert` provider attribute.
 
 ## Environment Variable Reference
 
 | Variable            | Description                                    | Required                       |
 | ------------------- | ---------------------------------------------- | ------------------------------ |
-| `XCSH_API_URL`      | F5XC tenant API URL                            | Yes                            |
+| `XCSH_API_URL`      | F5 Distributed Cloud tenant API URL            | Yes                            |
 | `XCSH_API_TOKEN`    | API token for bearer authentication            | One of: token, P12, or PEM     |
 | `XCSH_P12_FILE`     | Path to P12 certificate file                   | With `XCSH_P12_PASSWORD`       |
 | `XCSH_P12_PASSWORD` | Password for P12 file                          | With `XCSH_P12_FILE`           |
@@ -184,20 +184,20 @@ provider "xcsh" {
 
 ```bash
 # Add to ~/.bashrc or ~/.zshrc
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 Then reload: `source ~/.zshrc` or `source ~/.bashrc`
 
 ### Authentication Priority
 
-When multiple methods are configured, the provider uses this priority:
+When multiple authentication methods are configured, the provider evaluates them in this order:
 
-1. **P12 Certificate** - If `api_p12_file` is set (requires `p12_password`)
-2. **PEM Certificate** - If both `api_cert` and `api_key` are set
-3. **API Token** - If `api_token` is set
-4. **Error** - If none are provided
+1. **P12 Certificate** — Evaluated when `api_p12_file` is set (requires `p12_password`)
+2. **PEM Certificate** — Evaluated when both `api_cert` and `api_key` are set
+3. **API Token** — Evaluated when `api_token` is set
+4. **Error** — Returned when no valid credentials are provided
 
 ## CI/CD Integration
 
@@ -241,10 +241,10 @@ jobs:
 
 **GitHub Secrets to configure:**
 
-| Secret Name        | Value                                          |
-| ------------------ | ---------------------------------------------- |
-| `XCSH_API_URL`     | `https://your-tenant.console.ves.volterra.io`  |
-| `XCSH_API_TOKEN`   | Your API token value                           |
+| Secret Name        | Value                                         |
+| ------------------ | --------------------------------------------- |
+| `XCSH_API_URL`     | `https://<XC_TENANT>.console.ves.volterra.io` |
+| `XCSH_API_TOKEN`   | `<XC_API_TOKEN>`                              |
 
 ### GitHub Actions with P12 Certificate
 
@@ -298,26 +298,26 @@ jobs:
 
 ```bash
 # On macOS
-base64 -i your-credentials.p12 | pbcopy
+base64 -i credentials.p12 | pbcopy
 
 # On Linux
-base64 -w 0 your-credentials.p12
+base64 -w 0 credentials.p12
 ```
 
 **GitHub Secrets to configure:**
 
-| Secret Name         | Value                                          |
-| ------------------- | ---------------------------------------------- |
-| `XCSH_API_URL`      | `https://your-tenant.console.ves.volterra.io`  |
-| `XCSH_P12_BASE64`   | Base64-encoded P12 file contents               |
-| `XCSH_P12_PASSWORD` | Password for the P12 file                      |
+| Secret Name         | Value                                         |
+| ------------------- | --------------------------------------------- |
+| `XCSH_API_URL`      | `https://<XC_TENANT>.console.ves.volterra.io` |
+| `XCSH_P12_BASE64`   | Base64-encoded P12 file contents              |
+| `XCSH_P12_PASSWORD` | Password for the P12 file                     |
 
 ## Security Best Practices
 
-- **Never commit credentials** to version control. Add `*.tfvars`, `*.p12`, and `*.pem` to `.gitignore`
-- **Use environment variables** for sensitive values in local development
-- **Use GitHub Secrets** or equivalent for CI/CD pipelines
-- **Limit credential scope** using Service Credentials with specific roles and namespaces
+- **Never commit credentials** to version control. Add `*.tfvars`, `*.p12`, and `*.pem` to `.gitignore`.
+- **Use environment variables** for sensitive values in local development.
+- **Use secret managers or CI/CD secrets** for automated pipelines.
+- **Limit credential scope** using Service Credentials with specific roles and namespaces.
 
 ### Choosing the Right Method
 
@@ -331,58 +331,58 @@ base64 -w 0 your-credentials.p12
 
 ### Authentication Failed (401 Unauthorized)
 
-1. Verify API URL does **NOT** include `/api` suffix (e.g., `https://tenant.console.ves.volterra.io`)
-2. Check token hasn't expired
-3. Verify token copied correctly (no whitespace)
-4. Ensure environment variables are exported:
+1. Verify that the API URL does **not** include the `/api` suffix (for example, `https://<XC_TENANT>.console.ves.volterra.io`).
+2. Verify that the token has not expired.
+3. Verify that the token was copied without leading or trailing whitespace.
+4. Verify that the environment variables are exported:
 
 ```bash
-echo $XCSH_API_URL
-echo $XCSH_API_TOKEN
+echo "$XCSH_API_URL"
+echo "$XCSH_API_TOKEN"
 ```
 
 ### Certificate Verification Failed
 
-1. Verify P12 password is correct
-2. Check file path is absolute or correctly relative
-3. Test P12 file:
+1. Verify that the P12 password is correct.
+2. Verify that the file path is accessible and correctly referenced.
+3. Test the P12 file locally:
 
 ```bash
-openssl pkcs12 -in your-credentials.p12 -nokeys -info
+openssl pkcs12 -in credentials.p12 -nokeys -info
 ```
 
 ### Permission Denied (403 Forbidden)
 
-1. Verify credential has required permissions
-2. For Service Credentials, check role and namespace assignments
-3. Some operations require specific system roles
+1. Verify that the credential has required permissions for the target resources.
+2. For Service Credentials, check assigned roles and namespace access.
+3. Some operations require specific system roles (for example, tenant administration).
 
 ### Environment Variables Not Working
 
-1. Ensure variables are exported:
+1. Verify that variables are exported:
 
-```bash
-export XCSH_API_TOKEN="token"  # Correct
-XCSH_API_TOKEN="token"         # Won't work
-```
+   ```bash
+   export XCSH_API_TOKEN="<XC_API_TOKEN>"  # Correct
+   XCSH_API_TOKEN="<XC_API_TOKEN>"         # Is not visible to child processes
+   ```
 
-1. Verify spelling is exact (case-sensitive)
-2. Check for hidden characters in values
+2. Verify that variable names match the exact required casing (`XCSH_API_URL`, `XCSH_API_TOKEN`).
+3. Check for hidden or unexpected characters in variable values.
 
 ## Revoking Credentials
 
-1. Navigate to **Administration** → **Personal Management** → **Credentials** (or **IAM** → **Service Credentials**)
-2. Find the credential
-3. Click **Actions** (three dots) → **Force Expiry**
+1. Navigate to **Administration** → **Personal Management** → **Credentials** (or **IAM** → **Service Credentials**).
+2. Locate the credential to revoke.
+3. Select **Actions** (three dots) → **Force Expiry**.
 
 ## Next Steps
 
-- [HTTP Load Balancer Guide](http-loadbalancer.md) - Deploy your first load balancer
-- [Blindfold Functions Guide](blindfold.md) - Secure secret management
+- [HTTP Load Balancer Guide](http-loadbalancer.md) — Deploy your first load balancer
+- [Blindfold Functions Guide](blindfold.md) — Secure secret management
 
 ## Support
 
 - [Provider Documentation](../index.md)
-- [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
 - [F5 Credentials Guide](https://docs.cloud.f5.com/docs-v2/administration/how-tos/user-mgmt/Credentials)
 - [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)

--- a/docs/guides/blindfold.md
+++ b/docs/guides/blindfold.md
@@ -2,22 +2,22 @@
 page_title: "Guide: Blindfold Secret Management Functions"
 subcategory: "Guides"
 description: |-
-  Learn how to securely encrypt secrets using F5XC Blindfold functions.
+  Securely encrypt sensitive data using F5 Distributed Cloud Blindfold functions.
   Covers TLS certificates, cloud credentials, and container registry authentication.
 ---
 
 # Blindfold Secret Management Functions
 
-This guide walks you through using F5XC Blindfold functions to securely encrypt sensitive data. By the end, you'll understand how to:
+This guide explains how to use F5 Distributed Cloud Blindfold functions to encrypt sensitive data locally before transmitting it to the control plane. Topics covered include:
 
-- **Encrypt TLS private keys** - Secure certificate key storage
-- **Protect cloud credentials** - AWS, Azure, and GCP secrets
-- **Secure container registries** - Private image pull authentication
-- **Understand the security model** - Local encryption, never transmitted unencrypted
+- **Encrypt TLS private keys** — Configure certificate key storage
+- **Protect cloud credentials** — Secure AWS, Azure, and Google Cloud credentials
+- **Secure container registries** — Authenticate private container image pulls
+- **Understand the security model** — Apply client-side encryption without plaintext transmission
 
 ## Overview
 
-F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryption for sensitive data. The blindfold functions encrypt your secrets locally using RSA-OAEP with SHA-256, meaning **your plaintext secrets never leave your machine unencrypted**.
+F5 Distributed Cloud Secret Management (Blindfold) provides client-side encryption for sensitive data. The blindfold functions encrypt secrets locally using RSA-OAEP with SHA-256, ensuring that **plaintext secrets never leave your local environment unencrypted**.
 
 ### How It Works
 
@@ -32,7 +32,8 @@ F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryp
 │                      └────────┬─────────┘             │            │
 │                               │                       │            │
 │                      ┌────────▼─────────┐             │            │
-│                      │ F5XC Public Key  │             │            │
+│                      │ F5 Distributed   │             │            │
+│                      │ Cloud Public Key │             │            │
 │                      │ (fetched once)   │             │            │
 │                      └──────────────────┘             │            │
 └──────────────────────────────────────────────────────│────────────┘
@@ -47,39 +48,39 @@ F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryp
 
 ### Security Properties
 
-- **Local encryption**: Secrets encrypted on your machine before transmission
-- **RSA-OAEP with SHA-256**: Industry-standard encryption algorithm
-- **Policy-controlled decryption**: Only authorized F5XC services can decrypt
-- **No plaintext storage**: F5XC never receives or stores plaintext secrets
+- **Local encryption**: Secrets are encrypted on your local machine before transmission.
+- **RSA-OAEP with SHA-256**: Industry-standard asymmetric encryption.
+- **Policy-controlled decryption**: Only authorized F5 Distributed Cloud services can decrypt the payload.
+- **No plaintext storage**: The control plane never receives or stores plaintext secrets.
 
 ## Prerequisites
 
 Before you begin, ensure you have:
 
-- **Terraform >= 1.8** - Provider-defined functions require Terraform 1.8 or later
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **API Credentials** - Token or P12 certificate authentication configured
+- **Terraform >= 1.8** — Provider-defined functions require Terraform 1.8 or later (download from <https://www.terraform.io/downloads>)
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication (see the [Authentication Guide](authentication.md))
 
 ### Authentication Setup
 
-Configure one of these authentication methods via environment variables:
+Configure one of these authentication methods using environment variables:
 
 #### Option 1: API Token (Recommended for development)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 #### Option 2: P12 Certificate (Recommended for production)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/your-credentials.p12"
-export XCSH_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"  # pragma: allowlist secret
 ```
 
--> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
+-> **Tip:** Add these variables to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
 
 ## Quick Start
 
@@ -187,13 +188,13 @@ location = provider::xcsh::blindfold_file(
 
 ### Built-in SecretPolicy
 
-Every F5XC tenant includes a default policy: `ves-io-allow-volterra` in the `shared` namespace. This policy allows Volterra (F5XC) services to decrypt secrets.
+Every F5 Distributed Cloud tenant includes a default policy: `ves-io-allow-volterra` in the `shared` namespace. This policy allows F5 Distributed Cloud platform services to decrypt secrets.
 
 ## Use Cases
 
 ### TLS Certificate Private Key
 
-Store TLS certificates for load balancers. Note that TLS private keys are typically too large (>1000 bytes) for direct blindfold encryption (~190 byte limit). Use `clear_secret_info` for TLS keys:
+Store TLS certificates for load balancers. Note that RSA TLS private keys are typically too large (>1000 bytes) for direct asymmetric blindfold encryption (~190 byte limit). Use `clear_secret_info` for TLS keys:
 
 ```hcl
 resource "xcsh_certificate" "example" {
@@ -202,8 +203,8 @@ resource "xcsh_certificate" "example" {
 
   certificate_url = "string:///${base64encode(file("${path.module}/certs/server.crt"))}"
 
-  # TLS private keys are too large for blindfold encryption
-  # Use clear_secret_info - the key is transmitted securely over HTTPS
+  # TLS private keys exceed the RSA-OAEP direct encryption size limit
+  # Use clear_secret_info — the key is transmitted securely over HTTPS (TLS)
   private_key {
     clear_secret_info {
       url = "string:///${base64encode(file("${path.module}/certs/server.key"))}"
@@ -214,7 +215,7 @@ resource "xcsh_certificate" "example" {
 }
 ```
 
-~> **Size Limitation:** Blindfold encryption uses RSA-OAEP which limits plaintext to ~190 bytes. TLS private keys exceed this limit. Use `clear_secret_info` for certificates - the data is transmitted securely over HTTPS. For secrets under 190 bytes (API keys, passwords), use blindfold functions as shown below.
+~> **Size Limitation:** Direct Blindfold encryption uses RSA-OAEP which limits plaintext to ~190 bytes for 2048-bit keys. TLS private keys exceed this limit. Use `clear_secret_info` for certificates — the payload is encrypted in transit over HTTPS. For secrets under 190 bytes (such as API keys, passwords, and client tokens), use the `blindfold()` function as shown below.
 
 ### AWS Cloud Credentials
 
@@ -369,7 +370,7 @@ RSA-OAEP encryption has a maximum plaintext size based on the key size:
 | 2048-bit | ~190 bytes        |
 | 4096-bit | ~446 bytes        |
 
-~> **Note:** If your secret exceeds the size limit, consider splitting it or using a different approach. The function will return a clear error message if the plaintext is too large.
+~> **Note:** If your secret exceeds the size limit, consider splitting it or using an alternative approach. The function returns an error message if the plaintext exceeds the maximum allowed size.
 
 ### Output Format
 
@@ -385,7 +386,7 @@ When base64-decoded, the sealed JSON contains these fields:
 {
   "key_version": "v1.2.3",
   "policy_id": "shared/ves-io-allow-volterra",
-  "tenant": "example-corp",
+  "tenant": "<XC_TENANT>",
   "data": "ABCDEF1234567890..."
 }
 ```
@@ -393,99 +394,102 @@ When base64-decoded, the sealed JSON contains these fields:
 Field descriptions:
 
 - `key_version`: Public key version used for encryption
-- `policy_id`: Reference to the SecretPolicy (namespace/name format)
-- `tenant`: example-corp
-- `data`: base64-encoded RSA-OAEP ciphertext
+- `policy_id`: Reference to the SecretPolicy (`namespace/name` format)
+- `tenant`: F5 Distributed Cloud tenant identifier
+- `data`: Base64-encoded RSA-OAEP ciphertext
 
 ### Function Behavior
 
-- **Idempotent**: Same input produces different output (due to random padding)
-- **Network required**: Functions fetch the public key from F5XC API
-- **Caching**: Public keys are cached for the Terraform run
+- **Non-deterministic output**: The same plaintext generates different ciphertext on each run due to randomized OAEP padding.
+- **Network access required**: Functions fetch the active public key from the F5 Distributed Cloud API.
+- **In-memory caching**: Public keys are cached for the duration of the Terraform execution.
 
 ## Troubleshooting
 
 ### Authentication Configuration Error
 
-**Symptom:** Error message about missing authentication configuration.
+**Symptom:** Error message indicates missing or invalid authentication credentials.
 
 **Solution:**
 
 ```bash
 # Verify environment variables are set
-echo $XCSH_API_URL
-echo $XCSH_API_TOKEN  # or XCSH_P12_FILE
+echo "$XCSH_API_URL"
+echo "$XCSH_API_TOKEN"  # or XCSH_P12_FILE
 
 # Set them if missing
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 ### Policy Not Found
 
-**Symptom:** Error about secret policy not found.
+**Symptom:** Error indicating that the specified SecretPolicy was not found.
 
 **Solutions:**
 
-1. Use the built-in policy:
+1. Use the built-in default policy:
 
    ```hcl
    policy_name = "ves-io-allow-volterra"
    namespace   = "shared"
    ```
 
-2. Verify your custom policy exists in F5XC Console
+2. Verify that any custom SecretPolicy exists in the specified namespace in the F5 Distributed Cloud Console.
 
 ### Plaintext Too Large
 
-**Symptom:** Error indicating plaintext exceeds maximum size.
+**Symptom:** Error indicates that the plaintext exceeds the maximum allowed size for RSA-OAEP encryption.
 
 **Solutions:**
 
-1. Verify your secret size:
+1. Check your secret payload size:
 
    ```bash
    wc -c < your-secret-file
    ```
 
-2. For large files (like some GCP credentials), consider:
-   - Extracting only the private key portion
-   - Using F5XC's external secret management integration
+2. For larger files (such as GCP credentials or TLS private keys):
+   - Extract only the private key or secret token portion
+   - Use `clear_secret_info` with TLS in transit
 
 ### File Not Found
 
-**Symptom:** Error about file not found when using `blindfold_file()`.
+**Symptom:** Error indicating file not found when calling `blindfold_file()`.
 
 **Solutions:**
 
-1. Use `${path.module}` for relative paths:
+1. Use `${path.module}` for relative file paths:
 
    ```hcl
    location = provider::xcsh::blindfold_file(
-     "${path.module}/certs/server.key",  # Correct
-     ...
+     "${path.module}/certs/server.key",
+     "ves-io-allow-volterra",
+     "shared"
    )
    ```
 
-2. Verify the file exists and is readable
+2. Verify that the file exists and has appropriate read permissions.
 
-### Invalid base64
+### Invalid Base64 Encoding
 
-**Symptom:** Error about invalid base64 encoding.
+**Symptom:** Error indicating invalid base64 encoding.
 
-**Solution:** Ensure you're base64-encoding your plaintext:
+**Solution:** Ensure you base64-encode plaintext strings before passing them to `blindfold()`:
 
 ```hcl
 # Correct
 location = provider::xcsh::blindfold(
-  base64encode(var.secret),  # base64encode() wraps the secret
-  ...
+  base64encode(var.secret),
+  "ves-io-allow-volterra",
+  "shared"
 )
 
 # Incorrect
 location = provider::xcsh::blindfold(
-  var.secret,  # Raw secret will fail
-  ...
+  var.secret,  # Raw plaintext string fails
+  "ves-io-allow-volterra",
+  "shared"
 )
 ```
 
@@ -497,23 +501,21 @@ To remove all resources created by this guide:
 terraform destroy
 ```
 
-Type `yes` to confirm destruction.
+Type `yes` when prompted to confirm resource destruction.
 
-!> **Warning:** This will immediately remove all created resources. Ensure you have backups of any certificates or credentials you need.
+~> **Warning:** This command immediately destroys all managed resources in the plan. Ensure you have backups of any certificates or credentials before proceeding.
 
 ## Next Steps
 
-Now that you understand blindfold encryption, explore related resources:
-
-- [Certificate Resource](../resources/certificate.md) - Full certificate management
-- [Cloud Credentials Resource](../resources/cloud_credentials.md) - Cloud provider authentication
-- [HTTP Load Balancer Guide](./http-loadbalancer.md) - Use certificates in load balancers
-- [blindfold Function Reference](../functions/blindfold.md) - Function API details
-- [blindfold_file Function Reference](../functions/blindfold_file.md) - Function API details
+- [Certificate Resource](../resources/certificate.md) — Full certificate management
+- [Cloud Credentials Resource](../resources/cloud_credentials.md) — Cloud provider authentication
+- [HTTP Load Balancer Guide](./http-loadbalancer.md) — Use certificates in load balancers
+- [blindfold Function Reference](../functions/blindfold.md) — Function API details
+- [blindfold_file Function Reference](../functions/blindfold_file.md) — Function API details
 
 ## Support
 
-- **Provider Documentation:** [F5XC Provider](../index.md)
-- **F5 Documentation:** [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
-- **Secret Management:** [F5XC Secret Management](https://docs.cloud.f5.com/docs/how-to/secrets-management)
-- **Issues:** [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)
+- [Provider Documentation](../index.md)
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
+- [F5 Secret Management](https://docs.cloud.f5.com/docs/how-to/secrets-management)
+- [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)

--- a/docs/guides/http-loadbalancer.md
+++ b/docs/guides/http-loadbalancer.md
@@ -8,15 +8,15 @@ description: |-
 
 # HTTP Load Balancer with Security Features
 
-This guide walks you through deploying a complete HTTP Load Balancer on F5 Distributed Cloud. By the end, you'll have a production-ready load balancer with:
+This guide explains how to deploy a complete HTTP Load Balancer on F5 Distributed Cloud with the following security features:
 
-- **Web Application Firewall (WAF)** - Blocks common web attacks (SQLi, XSS, etc.)
-- **Bot Defense** - Protects against automated attacks and scrapers
-- **Rate Limiting** - Prevents abuse by limiting requests per client
-- **JavaScript Challenge** - Client-side bot detection
-- **Automatic TLS Certificates** - HTTPS with auto-renewal
-- **Health Monitoring** - Active health checks on origin servers
-- **Threat Mesh** - Global threat intelligence sharing
+- **Web Application Firewall (WAF)** — Blocks common web attacks (SQL injection, XSS, and command injection)
+- **Bot Defense** — Protects against automated attacks and scrapers
+- **Rate Limiting** — Prevents abuse by limiting requests per client IP
+- **JavaScript Challenge** — Validates client browsers and detects automation
+- **Automatic TLS Certificates** — Automates HTTPS provisioning and renewal
+- **Health Monitoring** — Actively tests origin server health
+- **Threat Mesh** — Integrates global threat intelligence telemetry
 
 For a minimal copy-paste example, see the [Httpbin Minimal Guide](httpbin-minimal.md).
 
@@ -24,11 +24,11 @@ For a minimal copy-paste example, see the [Httpbin Minimal Guide](httpbin-minima
 
 Before you begin, ensure you have:
 
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console> if you don't have one
-- **API Token** - Generate credentials from the F5XC Console at <https://docs.cloud.f5.com/docs/how-to/user-mgmt/credentials>
-- **Terraform >= 1.8** - Download and install from <https://www.terraform.io/downloads>
-- **A Domain** - Domain you control for DNS configuration
-- **Backend Origin Server** - Your application server accessible from the internet
+- **Terraform >= 1.0** — Download and install from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication (see the [Authentication Guide](authentication.md))
+- **A Domain** — Domain you control for DNS delegation or CNAME routing
+- **Backend Origin Server** — Application server accessible by F5 Distributed Cloud Regional Edges
 
 ## Quick Start
 
@@ -44,11 +44,11 @@ cd terraform-provider-xcsh/examples/guides/http-loadbalancer
 Configure authentication using environment variables. **Never commit credentials to version control.**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
--> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
+-> **Tip:** Add these variables to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
 
 ### Step 3: Configure Your Deployment
 
@@ -85,23 +85,23 @@ terraform plan
 terraform apply
 ```
 
-Review the plan output, then type `yes` to confirm deployment.
+Review the plan output, and then type `yes` when prompted to confirm deployment.
 
 ### Step 5: Configure DNS
 
-After deployment, Terraform outputs a CNAME target. Create a DNS record:
+After deployment, Terraform outputs a CNAME target. Create a DNS record with your DNS provider:
 
-| Type  | Name            | Value                                |
-| ----- | --------------- | ------------------------------------ |
-| CNAME | app.example.com | ves-io-app-example-com.ac.vh.ves.io  |
+| Type  | Name              | Value                                  |
+| ----- | ----------------- | -------------------------------------- |
+| CNAME | `app.example.com` | `ves-io-app-example-com.ac.vh.ves.io`  |
 
-~> **Note:** DNS propagation may take up to 48 hours, though typically completes within minutes.
+~> **Note:** DNS propagation time varies by provider and typically completes within a few minutes.
 
 ### Step 6: Verify
 
-1. **Wait for TLS provisioning** - Auto-cert typically provisions within 5 minutes
-2. **Access your application** - Navigate to `https://your-domain.com`
-3. **Check the console** - View traffic and security events in F5 Distributed Cloud Console
+1. **Wait for TLS provisioning** — Automatic certificate provisioning typically completes within 5 minutes.
+2. **Access your application** — Navigate to `https://app.example.com` in your browser.
+3. **Inspect telemetry** — View traffic and security events in the F5 Distributed Cloud Console.
 
 ## Configuration Options
 
@@ -204,49 +204,49 @@ This guide creates the following resources:
 
 **Solutions:**
 
-1. Verify DNS CNAME is correctly configured
-2. Wait up to 10 minutes for certificate provisioning
-3. Check the Load Balancer status in F5XC Console
+1. Verify that the DNS CNAME record is correctly configured with your DNS provider.
+2. Wait up to 10 minutes for automated certificate provisioning and challenge completion.
+3. Check the load balancer status in the F5 Distributed Cloud Console.
 
 ### 502 Bad Gateway
 
-**Symptom:** Load balancer returns 502 errors.
+**Symptom:** Load balancer returns HTTP 502 Bad Gateway errors.
 
 **Solutions:**
 
-1. Verify `origin_server` is accessible from the internet
-2. Check health check path returns HTTP 200
-3. Verify origin port is correct
-4. Check origin server TLS configuration
+1. Verify that `origin_server` is reachable by F5 Distributed Cloud Regional Edges.
+2. Verify that the health check endpoint returns HTTP 200.
+3. Verify that the origin port matches the backend service configuration.
+4. Check backend TLS settings if using HTTPS to origin.
 
 ### WAF Blocking Legitimate Traffic
 
-**Symptom:** Valid requests are blocked by WAF.
+**Symptom:** Valid requests are blocked by the Web Application Firewall.
 
 **Solutions:**
 
-1. Check Security Analytics in F5XC Console
-2. Review blocked request details
-3. Consider temporarily setting WAF to monitoring mode:
+1. Inspect Security Analytics in the F5 Distributed Cloud Console.
+2. Review the triggered signature and rule IDs.
+3. Temporarily configure WAF in monitoring mode during initial testing:
 
    ```hcl
-   enable_waf = false  # Disable in Terraform
+   enable_waf = false  # Disable or switch to monitoring
    ```
 
 ### Rate Limiting Too Aggressive
 
-**Symptom:** Users hitting rate limits during normal usage.
+**Symptom:** Users encounter rate limit errors during normal usage.
 
 **Solutions:**
 
-1. Increase the rate limit:
+1. Increase the rate limit threshold:
 
    ```hcl
    rate_limit_requests = 500
    ```
 
-2. Review rate limiting events in the console
-3. Consider user identification beyond IP address
+2. Inspect rate limiting telemetry in the console.
+3. Consider scoping rate limits to specific paths or user identifiers.
 
 ## Clean Up
 
@@ -256,21 +256,19 @@ To remove all resources created by this guide:
 terraform destroy
 ```
 
-Type `yes` to confirm destruction.
+Type `yes` when prompted to confirm resource destruction.
 
-!> **Warning:** This will immediately remove the load balancer and all associated resources. Traffic to your domain will no longer be handled by F5XC.
+~> **Warning:** This command immediately destroys the load balancer and all associated resources. Traffic to your domain is no longer handled by F5 Distributed Cloud.
 
 ## Next Steps
 
-Now that you have a basic HTTP Load Balancer deployed, consider exploring:
-
-- [Origin Pool Resource](../resources/origin_pool.md) - Add multiple origins for redundancy
-- [App Firewall Resource](../resources/app_firewall.md) - Customize WAF rules
-- [Service Policy Resource](../resources/service_policy.md) - Add custom access control
-- [TCP Load Balancer Resource](../resources/tcp_loadbalancer.md) - For non-HTTP applications
+- [Origin Pool Resource](../resources/origin_pool.md) — Add multiple origins for high availability
+- [App Firewall Resource](../resources/app_firewall.md) — Customize WAF rules and signatures
+- [Service Policy Resource](../resources/service_policy.md) — Configure custom access control policies
+- [TCP Load Balancer Resource](../resources/tcp_loadbalancer.md) — Load balance non-HTTP TCP traffic
 
 ## Support
 
-- **Provider Documentation:** [F5XC Provider](../index.md)
-- **F5 Documentation:** [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
-- **Issues:** [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)
+- [Provider Documentation](../index.md)
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
+- [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)

--- a/docs/guides/httpbin-minimal.md
+++ b/docs/guides/httpbin-minimal.md
@@ -19,9 +19,9 @@ A complete, validated Terraform configuration that deploys four resources:
 
 Copy this entire block into a `main.tf` file. Set `XCSH_API_URL` and `XCSH_API_TOKEN` environment variables, then run `terraform init && terraform apply`.
 
-~> **Important:** Replace `your-namespace` with your actual F5 XC namespace.
+~> **Important:** Replace `demo-app` with your target F5 Distributed Cloud namespace.
 
-```terraform
+```hcl
 terraform {
   required_version = ">= 1.0"
 
@@ -154,4 +154,4 @@ This configuration relies on server-applied defaults for fields you don't need t
 - **Challenge:** `no_challenge` (server default)
 - **API features:** `disable_api_definition`, `disable_api_discovery`, `disable_api_testing` (server defaults)
 
-To enable any of these features, add them explicitly. See the [full HTTP Load Balancer guide](http-loadbalancer.md) for production configurations.
+To enable any of these features, configure them explicitly in your resource block. For production configurations, see the [HTTP Load Balancer Guide](http-loadbalancer.md).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,14 +1,15 @@
 # Guides
 
-Step-by-step tutorials for common F5 Distributed Cloud scenarios.
+Step-by-step tutorials for common F5 Distributed Cloud scenarios and architecture patterns.
 
 ## Available Guides
 
-- [HTTP Load Balancer](http-loadbalancer.md) - Deploy a basic HTTP Load Balancer
-- [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) - Production-ready security features
-- [Authentication](authentication.md) - Configure provider authentication
-- [Blindfold Encryption](blindfold.md) - Secure secret management
-- [Addon Service Activation](addon-activation.md) - Activate and manage addon services
+- [HTTP Load Balancer](http-loadbalancer.md) — Deploy a production-ready HTTP load balancer with WAF, bot defense, and rate limiting
+- [Httpbin Minimal](httpbin-minimal.md) — Copy-paste minimal HTTP load balancer deployment pointing to httpbin.org
+- [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) — Multi-layered defense-in-depth with custom rules, IP allowlists, and deep inspection
+- [Authentication](authentication.md) — Configure API tokens, P12 certificates, and PEM authentication for local and CI/CD environments
+- [Blindfold Encryption](blindfold.md) — Client-side secret encryption using RSA-OAEP for cloud credentials and certificates
+- [Addon Service Activation](addon-activation.md) — Activate and manage tenant addon services with lifecycle management
 
 ## Related Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 ---
 page_title: "XCSH Provider"
 description: |-
-  Terraform provider for F5 Distributed Cloud (F5XC) enabling infrastructure as code for load balancers, security policies, sites, and networking. Community-maintained provider built from public F5 API documentation.
+  Terraform provider for F5 Distributed Cloud enabling infrastructure as code for load balancers, security policies, sites, and networking. Community-maintained provider built from public F5 API documentation.
 ---
 
 # XCSH Provider
 
-The XCSH Terraform provider enables infrastructure as code management for F5 Distributed Cloud (F5XC) resources. Configure HTTP/TCP load balancers, origin pools, application firewalls, service policies, cloud sites, and more through declarative Terraform configurations.
+The XCSH Terraform provider enables infrastructure as code management for F5 Distributed Cloud resources. Configure HTTP/TCP load balancers, origin pools, application firewalls, service policies, cloud sites, and networking through declarative Terraform configurations.
 
 This is a community-maintained provider built from public F5 API documentation.
 
@@ -16,17 +16,17 @@ This is a community-maintained provider built from public F5 API documentation.
 |-----------|---------|
 | terraform | >= 1.8  |
 
--> **Note:** This provider uses provider-defined functions which require Terraform 1.8 or later. For details, see the [Functions](/docs/functions) documentation.
+~> **Note:** This provider uses provider-defined functions which require Terraform 1.8 or later. For details, see the [Functions](/docs/functions) documentation.
 
 ## Authenticating to F5 Distributed Cloud
 
 The XCSH Terraform provider supports multiple authentication methods:
 
-1. **API Token** - Simplest method using a personal API token
-2. **P12 Certificate** - Certificate-based authentication using PKCS#12 bundle
-3. **PEM Certificate** - Certificate-based authentication using separate cert/key files
+1. **API Token** — Token-based bearer authentication
+2. **P12 Certificate** — Mutual TLS authentication using a PKCS#12 bundle (recommended for production)
+3. **PEM Certificate** — Certificate-based authentication using separate PEM certificate and private key files
 
-Learn more about [how to generate API credentials](https://docs.cloud.f5.com/docs/how-to/user-mgmt/credentials).
+For more information, see the [F5 Distributed Cloud Credentials Guide](https://docs.cloud.f5.com/docs-v2/administration/how-tos/user-mgmt/Credentials).
 
 ## Example Usage
 
@@ -75,31 +75,31 @@ variable "xcsh_api_token" {
 
 ### Required (one of the following authentication methods)
 
-* `api_token` - F5 Distributed Cloud API Token (`String`, Sensitive). Can also be set via `XCSH_API_TOKEN` environment variable.
+* `api_token` — F5 Distributed Cloud API token (`String`, Sensitive). Can also be set with the `XCSH_API_TOKEN` environment variable.
 
-* `api_p12_file` - Path to PKCS#12 certificate bundle file (`String`). Can also be set via `XCSH_P12_FILE` environment variable. Requires `p12_password`.
+* `api_p12_file` — Path to a PKCS#12 certificate bundle file (`String`). Can also be set with the `XCSH_P12_FILE` environment variable. Requires `p12_password`.
 
-* `api_cert` and `api_key` - Paths to PEM-encoded certificate and private key files (`String`). Can also be set via `XCSH_CERT` and `XCSH_KEY` environment variables.
+* `api_cert` and `api_key` — Paths to PEM-encoded certificate and private key files (`String`). Can also be set with the `XCSH_CERT` and `XCSH_KEY` environment variables.
 
 ### Optional
 
-* `api_url` - F5 Distributed Cloud API URL (`String`). Base URL **without** `/api` suffix. Required. No default. Set to your tenant URL (e.g., `https://your-tenant.console.ves.volterra.io`). Can also be set via `XCSH_API_URL` environment variable.
+* `api_url` — F5 Distributed Cloud API URL (`String`). Base URL **without** `/api` suffix. Required. No default. Set to your tenant URL (for example, `https://<XC_TENANT>.console.ves.volterra.io`). Can also be set with the `XCSH_API_URL` environment variable.
 
-* `p12_password` - Password for PKCS#12 certificate bundle (`String`, Sensitive). Required when using `api_p12_file`. Can also be set via `XCSH_P12_PASSWORD` environment variable.
+* `p12_password` — Password for the PKCS#12 certificate bundle (`String`, Sensitive). Required when using `api_p12_file`. Can also be set with the `XCSH_P12_PASSWORD` environment variable.
 
-* `api_ca_cert` - Path to PEM-encoded CA certificate file (`String`). Optional, used for server certificate verification. Can also be set via `XCSH_CACERT` environment variable.
+* `api_ca_cert` — Path to a PEM-encoded CA certificate file (`String`). Optional, used for server certificate verification. Can also be set with the `XCSH_CACERT` environment variable.
 
 ## Authentication Options
 
 ### Option 1: API Token Authentication
 
-The simplest authentication method using a personal API token.
+The simplest authentication method using an API token.
 
 **Provider Configuration:**
 
 ```hcl
 provider "xcsh" {
-  api_url   = "https://your-tenant.console.ves.volterra.io"
+  api_url   = "https://<XC_TENANT>.console.ves.volterra.io"
   api_token = var.xcsh_api_token
 }
 ```
@@ -107,8 +107,8 @@ provider "xcsh" {
 **Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 ### Option 2: P12 Certificate Authentication
@@ -119,8 +119,8 @@ Certificate-based authentication using a PKCS#12 bundle downloaded from F5 Distr
 
 ```hcl
 provider "xcsh" {
-  api_url      = "https://your-tenant.console.ves.volterra.io"
-  api_p12_file = "/path/to/certificate.p12"
+  api_url      = "https://<XC_TENANT>.console.ves.volterra.io"
+  api_p12_file = "/path/to/credentials.p12"
   p12_password = var.xcsh_p12_password
 }
 ```
@@ -128,20 +128,20 @@ provider "xcsh" {
 **Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/certificate.p12"
-export XCSH_P12_PASSWORD="your-p12-password"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"
 ```
 
 ### Option 3: PEM Certificate Authentication
 
-Certificate-based authentication using separate PEM-encoded certificate and key files.
+Certificate-based authentication using separate PEM-encoded certificate and private key files.
 
 **Provider Configuration:**
 
 ```hcl
 provider "xcsh" {
-  api_url     = "https://your-tenant.console.ves.volterra.io"
+  api_url     = "https://<XC_TENANT>.console.ves.volterra.io"
   api_cert    = "/path/to/certificate.crt"
   api_key     = "/path/to/private.key"
   api_ca_cert = "/path/to/ca-certificate.crt"  # Optional
@@ -151,21 +151,21 @@ provider "xcsh" {
 **Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
 export XCSH_CERT="/path/to/certificate.crt"
 export XCSH_KEY="/path/to/private.key"
 export XCSH_CACERT="/path/to/ca-certificate.crt"  # Optional
 ```
 
--> **Note:** Environment variables are the recommended approach for CI/CD pipelines and to avoid storing sensitive credentials in version control.
+~> **Note:** Environment variables are the recommended approach for automated CI/CD pipelines to avoid storing sensitive credentials in version control.
 
 ## Getting Started
 
-1. **Generate API Credentials**: Navigate to your F5 Distributed Cloud console, go to **Administration** > **Personal Management** > **Credentials**, and create either an API Token or download a certificate bundle.
+1. **Generate API Credentials**: In the F5 Distributed Cloud Console, navigate to **Administration** → **Personal Management** → **Credentials**, and create an API Token or download a certificate bundle.
 
-2. **Configure the Provider**: Add the provider configuration to your Terraform files using one of the authentication options above.
+2. **Configure the Provider**: Add the provider configuration block to your Terraform root module using one of the authentication options above.
 
-3. **Create Resources**: Start managing XCSH resources like namespaces, load balancers, and origin pools.
+3. **Create Resources**: Manage F5 Distributed Cloud resources such as namespaces, load balancers, and origin pools.
 
 ### Example: Create a Namespace
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,8 +23,12 @@ DEPRECATED — do not use: volterraedge/volterra
 
 ## Guides
 
-- [authentication](guides/authentication) : API token, P12 certificate, and PEM auth methods
-- [http-loadbalancer](guides/http-loadbalancer) : Deploy production load balancers with security
+- [addon-activation](guides/addon-activation) : Activate and manage F5 Distributed Cloud addon services
+- [advanced-http-loadbalancer](guides/advanced-http-loadbalancer) : Deploy HTTP load balancers with WAF, bot defense, and security controls
+- [authentication](guides/authentication) : Configure API token, P12 certificate, and PEM certificate authentication
+- [blindfold](guides/blindfold) : Encrypt secrets locally with public key encryption
+- [http-loadbalancer](guides/http-loadbalancer) : Deploy HTTP load balancers with origin pools and health checks
+- [httpbin-minimal](guides/httpbin-minimal) : Deploy a minimal HTTP load balancer with httpbin backend
 
 ## Functions
 

--- a/docs/resources/address_allocator.md
+++ b/docs/resources/address_allocator.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Address Allocator will create an address allocator object in 'system' namespace of the user. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "xcsh_address_allocator" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -189,7 +189,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_address_allocator.example system/example
 ```

--- a/docs/resources/advertise_policy.md
+++ b/docs/resources/advertise_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Advertise Policy resource in F5 Distributed Cloud for advertise_policy object controls how and where a service represented by a given virtual_host object is advertised to consumers. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_advertise_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -372,7 +372,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_advertise_policy.example system/example
 ```

--- a/docs/resources/alert_gen_policy.md
+++ b/docs/resources/alert_gen_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Alert Generation Policy. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_alert_gen_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -186,7 +186,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_alert_gen_policy.example system/example
 ```

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -39,7 +39,7 @@ resource "xcsh_alert_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -313,7 +313,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_alert_policy.example system/example
 ```

--- a/docs/resources/alert_policy.md
+++ b/docs/resources/alert_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new Alert Policy Object. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Alert Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/) to learn more.
+~> **Note:** For more information, see the [Alert Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/).
 
 ## Example Usage
 

--- a/docs/resources/alert_receiver.md
+++ b/docs/resources/alert_receiver.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new Alert Receiver object. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_alert_receiver" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -448,7 +448,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_alert_receiver.example system/example
 ```

--- a/docs/resources/alert_template.md
+++ b/docs/resources/alert_template.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Domain to protect. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "xcsh_alert_template" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -181,7 +181,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_alert_template.example system/example
 ```

--- a/docs/resources/allowed_domain.md
+++ b/docs/resources/allowed_domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages allowed domain. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_allowed_domain" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_allowed_domain.example system/example
 ```

--- a/docs/resources/api_crawler.md
+++ b/docs/resources/api_crawler.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an API Crawler resource in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_api_crawler" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -212,7 +212,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_api_crawler.example system/example
 ```

--- a/docs/resources/api_definition.md
+++ b/docs/resources/api_definition.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages API Definition. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [API Definition API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/api/) to learn more.
+~> **Note:** For more information, see the [API Definition API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/api/).
 
 ## Example Usage
 

--- a/docs/resources/api_definition.md
+++ b/docs/resources/api_definition.md
@@ -39,7 +39,7 @@ resource "xcsh_api_definition" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -224,7 +224,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_api_definition.example system/example
 ```

--- a/docs/resources/api_discovery.md
+++ b/docs/resources/api_discovery.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages API discovery creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_api_discovery" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -247,7 +247,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_api_discovery.example system/example
 ```

--- a/docs/resources/api_testing.md
+++ b/docs/resources/api_testing.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an API Testing resource in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_api_testing" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -305,7 +305,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_api_testing.example system/example
 ```

--- a/docs/resources/app_api_group.md
+++ b/docs/resources/app_api_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages app_api_group creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_app_api_group" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -231,7 +231,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_app_api_group.example system/example
 ```

--- a/docs/resources/app_firewall.md
+++ b/docs/resources/app_firewall.md
@@ -351,7 +351,7 @@ resource "xcsh_app_firewall" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -701,7 +701,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_app_firewall.example system/example
 ```

--- a/docs/resources/app_firewall.md
+++ b/docs/resources/app_firewall.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Application Firewall. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [App Firewall API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [App Firewall API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/resources/app_setting.md
+++ b/docs/resources/app_setting.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages App setting configuration in namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_app_setting" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -246,7 +246,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_app_setting.example system/example
 ```

--- a/docs/resources/app_type.md
+++ b/docs/resources/app_type.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_app_type" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -195,7 +195,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_app_type.example system/example
 ```

--- a/docs/resources/application_profiles.md
+++ b/docs/resources/application_profiles.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Application Profiles in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_application_profiles" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1189,7 +1189,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_application_profiles.example system/example
 ```

--- a/docs/resources/authentication.md
+++ b/docs/resources/authentication.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an Authentication resource in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_authentication" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -279,7 +279,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_authentication.example system/example
 ```

--- a/docs/resources/authorization_server.md
+++ b/docs/resources/authorization_server.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages authorization_server creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_authorization_server" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_authorization_server.example system/example
 ```

--- a/docs/resources/aws_tgw_site.md
+++ b/docs/resources/aws_tgw_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a AWS TGW Site resource in F5 Distributed Cloud for deploying F5 sites connected via AWS Transit Gateway.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_aws_tgw_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -862,7 +862,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_aws_tgw_site.example system/example
 ```

--- a/docs/resources/aws_vpc_site.md
+++ b/docs/resources/aws_vpc_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a AWS VPC Site resource in F5 Distributed Cloud for deploying F5 sites within AWS VPC environments.
 
-~> **Note** Please refer to [AWS VPC Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [AWS VPC Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/resources/aws_vpc_site.md
+++ b/docs/resources/aws_vpc_site.md
@@ -48,7 +48,7 @@ resource "xcsh_aws_vpc_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1091,7 +1091,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_aws_vpc_site.example system/example
 ```

--- a/docs/resources/azure_vnet_site.md
+++ b/docs/resources/azure_vnet_site.md
@@ -43,7 +43,7 @@ resource "xcsh_azure_vnet_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1727,7 +1727,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_azure_vnet_site.example system/example
 ```

--- a/docs/resources/azure_vnet_site.md
+++ b/docs/resources/azure_vnet_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Azure VNET Site resource in F5 Distributed Cloud for deploying F5 sites within Azure Virtual Network environments.
 
-~> **Note** Please refer to [Azure VNET Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [Azure VNET Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a BGP resource in F5 Distributed Cloud for bgp object is the configuration for peering with external bgp servers. it is created by users in system namespace. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_bgp" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -431,7 +431,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_bgp.example system/example
 ```

--- a/docs/resources/bgp_asn_set.md
+++ b/docs/resources/bgp_asn_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages bgp_asn_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_bgp_asn_set" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_bgp_asn_set.example system/example
 ```

--- a/docs/resources/bgp_routing_policy.md
+++ b/docs/resources/bgp_routing_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a BGP Routing Policy resource in F5 Distributed Cloud for bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help control routes which are imported or exported to bgp peers. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_bgp_routing_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -234,7 +234,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_bgp_routing_policy.example system/example
 ```

--- a/docs/resources/bigip_http_proxy.md
+++ b/docs/resources/bigip_http_proxy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages BIG-IP HTTP Proxy in a given namespace. If one already exists, it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_bigip_http_proxy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -769,7 +769,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_bigip_http_proxy.example system/example
 ```

--- a/docs/resources/bot_defense_app_infrastructure.md
+++ b/docs/resources/bot_defense_app_infrastructure.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Bot Defense App Infrastructure in a given namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "xcsh_bot_defense_app_infrastructure" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -255,7 +255,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_bot_defense_app_infrastructure.example system/example
 ```

--- a/docs/resources/bot_infrastructure.md
+++ b/docs/resources/bot_infrastructure.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Bot Infrastructure. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_bot_infrastructure" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 
@@ -197,7 +197,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_bot_infrastructure.example system/example
 ```

--- a/docs/resources/cdn_cache_rule.md
+++ b/docs/resources/cdn_cache_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a CDN Cache Rule resource in F5 Distributed Cloud for CDN loadbalancer specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_cdn_cache_rule" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -242,7 +242,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cdn_cache_rule.example system/example
 ```

--- a/docs/resources/cdn_loadbalancer.md
+++ b/docs/resources/cdn_loadbalancer.md
@@ -41,7 +41,7 @@ resource "xcsh_cdn_loadbalancer" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -2620,7 +2620,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cdn_loadbalancer.example system/example
 ```

--- a/docs/resources/cdn_loadbalancer.md
+++ b/docs/resources/cdn_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a CDN Load Balancer resource in F5 Distributed Cloud for content delivery and edge caching with load balancing.
 
-~> **Note** Please refer to [CDN Loadbalancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cdn/) to learn more.
+~> **Note:** For more information, see the [CDN Loadbalancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cdn/).
 
 ## Example Usage
 

--- a/docs/resources/cdn_purge_command.md
+++ b/docs/resources/cdn_purge_command.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a CDN Purge Command resource in F5 Distributed Cloud for CDN purge command specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_cdn_purge_command" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -190,7 +190,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cdn_purge_command.example system/example
 ```

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Certificate resource in F5 Distributed Cloud for certificate. configuration.
 
-~> **Note** Please refer to [Certificate API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/) to learn more.
+~> **Note:** For more information, see the [Certificate API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/).
 
 ## Example Usage
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -41,7 +41,7 @@ resource "xcsh_certificate" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -250,7 +250,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_certificate.example system/example
 ```

--- a/docs/resources/certificate_chain.md
+++ b/docs/resources/certificate_chain.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Certificate Chain resource in F5 Distributed Cloud for certificate chain configuration for TLS.
 
-~> **Note** Please refer to [Certificate Chain API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/) to learn more.
+~> **Note:** For more information, see the [Certificate Chain API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/certificates/).
 
 ## Example Usage
 

--- a/docs/resources/certificate_chain.md
+++ b/docs/resources/certificate_chain.md
@@ -41,7 +41,7 @@ resource "xcsh_certificate_chain" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_certificate_chain.example system/example
 ```

--- a/docs/resources/cloud_connect.md
+++ b/docs/resources/cloud_connect.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Cloud Connect resource in F5 Distributed Cloud for establishing connectivity to cloud provider networks.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_cloud_connect" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -302,7 +302,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cloud_connect.example system/example
 ```

--- a/docs/resources/cloud_credentials.md
+++ b/docs/resources/cloud_credentials.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Cloud Credentials resource in F5 Distributed Cloud for api to create cloud_credentials object. configuration.
 
-~> **Note** Please refer to [Cloud Credentials API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [Cloud Credentials API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/resources/cloud_credentials.md
+++ b/docs/resources/cloud_credentials.md
@@ -39,7 +39,7 @@ resource "xcsh_cloud_credentials" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -308,7 +308,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cloud_credentials.example system/example
 ```

--- a/docs/resources/cloud_elastic_ip.md
+++ b/docs/resources/cloud_elastic_ip.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Cloud Elastic IP creates Cloud Elastic IP object Object is attached to a site. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_cloud_elastic_ip" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -188,7 +188,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cloud_elastic_ip.example system/example
 ```

--- a/docs/resources/cloud_link.md
+++ b/docs/resources/cloud_link.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new CloudLink with configured parameters. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_cloud_link" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -320,7 +320,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cloud_link.example system/example
 ```

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages cluster will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -45,7 +45,7 @@ resource "xcsh_cluster" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -458,7 +458,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cluster.example system/example
 ```

--- a/docs/resources/cminstance.md
+++ b/docs/resources/cminstance.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages App type will create the configuration in namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "xcsh_cminstance" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -239,7 +239,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_cminstance.example system/example
 ```

--- a/docs/resources/code_base_integration.md
+++ b/docs/resources/code_base_integration.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages integration details. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_code_base_integration" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -370,7 +370,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_code_base_integration.example system/example
 ```

--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Container Registry resource in F5 Distributed Cloud for container image registry configuration.
 
-~> **Note** Please refer to [Container Registry API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/) to learn more.
+~> **Note:** For more information, see the [Container Registry API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/).
 
 ## Example Usage
 

--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -43,7 +43,7 @@ resource "xcsh_container_registry" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -206,7 +206,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_container_registry.example system/example
 ```

--- a/docs/resources/crl.md
+++ b/docs/resources/crl.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a CRL resource in F5 Distributed Cloud for api to create crl object. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "xcsh_crl" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -189,7 +189,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_crl.example system/example
 ```

--- a/docs/resources/data_group.md
+++ b/docs/resources/data_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages data group in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_data_group" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -191,7 +191,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_data_group.example system/example
 ```

--- a/docs/resources/data_type.md
+++ b/docs/resources/data_type.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages data_type creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_data_type" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -259,7 +259,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_data_type.example system/example
 ```

--- a/docs/resources/dc_cluster_group.md
+++ b/docs/resources/dc_cluster_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DC Cluster group in given namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_dc_cluster_group" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -178,7 +178,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dc_cluster_group.example system/example
 ```

--- a/docs/resources/discovery.md
+++ b/docs/resources/discovery.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Discovery resource in F5 Distributed Cloud for api to create discovery object for a site or virtual site in system namespace. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_discovery" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -436,7 +436,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_discovery.example system/example
 ```

--- a/docs/resources/dns_compliance_checks.md
+++ b/docs/resources/dns_compliance_checks.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DNS Compliance Checks Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_dns_compliance_checks" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -182,7 +182,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dns_compliance_checks.example system/example
 ```

--- a/docs/resources/dns_lb_health_check.md
+++ b/docs/resources/dns_lb_health_check.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DNS Load Balancer Health Check in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_dns_lb_health_check" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -244,7 +244,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dns_lb_health_check.example system/example
 ```

--- a/docs/resources/dns_lb_pool.md
+++ b/docs/resources/dns_lb_pool.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DNS Load Balancer Pool in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_dns_lb_pool" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -322,7 +322,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dns_lb_pool.example system/example
 ```

--- a/docs/resources/dns_load_balancer.md
+++ b/docs/resources/dns_load_balancer.md
@@ -39,7 +39,7 @@ resource "xcsh_dns_load_balancer" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -307,7 +307,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dns_load_balancer.example system/example
 ```

--- a/docs/resources/dns_load_balancer.md
+++ b/docs/resources/dns_load_balancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DNS Load Balancer in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [DNS Load Balancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/) to learn more.
+~> **Note:** For more information, see the [DNS Load Balancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/).
 
 ## Example Usage
 

--- a/docs/resources/dns_proxy.md
+++ b/docs/resources/dns_proxy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DNS Proxy in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_dns_proxy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -465,7 +465,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dns_proxy.example system/example
 ```

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages DNS Zone in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [DNS Zone API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/) to learn more.
+~> **Note:** For more information, see the [DNS Zone API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/dns/).
 
 ## Example Usage
 

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -39,7 +39,7 @@ resource "xcsh_dns_zone" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -776,7 +776,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_dns_zone.example system/example
 ```

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages endpoint will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Endpoint API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/service_mesh/) to learn more.
+~> **Note:** For more information, see the [Endpoint API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/service_mesh/).
 
 ## Example Usage
 

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -43,7 +43,7 @@ resource "xcsh_endpoint" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -317,7 +317,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_endpoint.example system/example
 ```

--- a/docs/resources/enhanced_firewall_policy.md
+++ b/docs/resources/enhanced_firewall_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an Enhanced Firewall Policy resource in F5 Distributed Cloud for enhanced firewall policy specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_enhanced_firewall_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -392,7 +392,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_enhanced_firewall_policy.example system/example
 ```

--- a/docs/resources/external_connector.md
+++ b/docs/resources/external_connector.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an External Connector resource in F5 Distributed Cloud for external_connector configuration specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_external_connector" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -378,7 +378,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_external_connector.example system/example
 ```

--- a/docs/resources/fast_acl.md
+++ b/docs/resources/fast_acl.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages object, object contains rules to protect site from denial of service It has destination{destination IP, destination port) and references to. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_fast_acl" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -370,7 +370,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_fast_acl.example system/example
 ```

--- a/docs/resources/fast_acl_rule.md
+++ b/docs/resources/fast_acl_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new Fast ACL rule, has specification to match source IP, source port and action to apply. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_fast_acl_rule" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -262,7 +262,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_fast_acl_rule.example system/example
 ```

--- a/docs/resources/filter_set.md
+++ b/docs/resources/filter_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages specification. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_filter_set" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -214,7 +214,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_filter_set.example system/example
 ```

--- a/docs/resources/fleet.md
+++ b/docs/resources/fleet.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages fleet will create a fleet object in 'system' namespace of the user. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "xcsh_fleet" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -943,7 +943,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_fleet.example system/example
 ```

--- a/docs/resources/forward_proxy_policy.md
+++ b/docs/resources/forward_proxy_policy.md
@@ -39,7 +39,7 @@ resource "xcsh_forward_proxy_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -481,7 +481,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_forward_proxy_policy.example system/example
 ```

--- a/docs/resources/forward_proxy_policy.md
+++ b/docs/resources/forward_proxy_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Forward Proxy Policy resource in F5 Distributed Cloud for forward proxy policy specification. configuration.
 
-~> **Note** Please refer to [Forward Proxy Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/) to learn more.
+~> **Note:** For more information, see the [Forward Proxy Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/).
 
 ## Example Usage
 

--- a/docs/resources/forwarding_class.md
+++ b/docs/resources/forwarding_class.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Forwarding Class resource in F5 Distributed Cloud for forwarding class is created by users in system namespace. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "xcsh_forwarding_class" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -212,7 +212,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_forwarding_class.example system/example
 ```

--- a/docs/resources/gcp_vpc_site.md
+++ b/docs/resources/gcp_vpc_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a GCP VPC Site resource in F5 Distributed Cloud for deploying F5 sites within Google Cloud VPC environments.
 
-~> **Note** Please refer to [GCP VPC Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/) to learn more.
+~> **Note:** For more information, see the [GCP VPC Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/cloud_infrastructure/).
 
 ## Example Usage
 

--- a/docs/resources/gcp_vpc_site.md
+++ b/docs/resources/gcp_vpc_site.md
@@ -48,7 +48,7 @@ resource "xcsh_gcp_vpc_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1013,7 +1013,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_gcp_vpc_site.example system/example
 ```

--- a/docs/resources/geo_location_set.md
+++ b/docs/resources/geo_location_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Geolocation Set. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_geo_location_set" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -179,7 +179,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_geo_location_set.example system/example
 ```

--- a/docs/resources/global_log_receiver.md
+++ b/docs/resources/global_log_receiver.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new Global Log Receiver object. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_global_log_receiver" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1057,7 +1057,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_global_log_receiver.example system/example
 ```

--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Healthcheck resource in F5 Distributed Cloud for healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration.
 
-~> **Note** Please refer to [Healthcheck API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [Healthcheck API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/resources/healthcheck.md
+++ b/docs/resources/healthcheck.md
@@ -416,7 +416,7 @@ resource "xcsh_healthcheck" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -621,7 +621,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_healthcheck.example system/example
 ```

--- a/docs/resources/http_loadbalancer.md
+++ b/docs/resources/http_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an HTTP Load Balancer resource in F5 Distributed Cloud for load balancing HTTP/HTTPS traffic with advanced routing and security.
 
-~> **Note** Please refer to [HTTP Loadbalancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [HTTP Loadbalancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/resources/http_loadbalancer.md
+++ b/docs/resources/http_loadbalancer.md
@@ -596,7 +596,7 @@ resource "xcsh_http_loadbalancer" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -5630,7 +5630,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_http_loadbalancer.example system/example
 ```

--- a/docs/resources/ike1.md
+++ b/docs/resources/ike1.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Ike1 resource in F5 Distributed Cloud for ike phase1 profile specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_ike1" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -203,7 +203,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_ike1.example system/example
 ```

--- a/docs/resources/ike2.md
+++ b/docs/resources/ike2.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Ike2 resource in F5 Distributed Cloud for ike phase2 profile specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_ike2" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -198,7 +198,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_ike2.example system/example
 ```

--- a/docs/resources/ike_phase1_profile.md
+++ b/docs/resources/ike_phase1_profile.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a IKE Phase1 Profile resource in F5 Distributed Cloud for ike phase1 profile specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "xcsh_ike_phase1_profile" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -219,7 +219,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_ike_phase1_profile.example system/example
 ```

--- a/docs/resources/ike_phase2_profile.md
+++ b/docs/resources/ike_phase2_profile.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a IKE Phase2 Profile resource in F5 Distributed Cloud for ike phase2 profile specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "xcsh_ike_phase2_profile" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -207,7 +207,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_ike_phase2_profile.example system/example
 ```

--- a/docs/resources/ip_prefix_set.md
+++ b/docs/resources/ip_prefix_set.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages ip_prefix_set creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_ip_prefix_set" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -178,7 +178,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_ip_prefix_set.example system/example
 ```

--- a/docs/resources/irule.md
+++ b/docs/resources/irule.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages iRule in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_irule" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -176,7 +176,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_irule.example system/example
 ```

--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages k8s_cluster will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_k8s_cluster" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -339,7 +339,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_k8s_cluster.example system/example
 ```

--- a/docs/resources/k8s_cluster_role.md
+++ b/docs/resources/k8s_cluster_role.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages k8s_cluster_role will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [K8S Cluster Role API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/) to learn more.
+~> **Note:** For more information, see the [K8S Cluster Role API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/managed_kubernetes/).
 
 ## Example Usage
 

--- a/docs/resources/k8s_cluster_role.md
+++ b/docs/resources/k8s_cluster_role.md
@@ -39,7 +39,7 @@ resource "xcsh_k8s_cluster_role" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -210,7 +210,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_k8s_cluster_role.example system/example
 ```

--- a/docs/resources/k8s_cluster_role_binding.md
+++ b/docs/resources/k8s_cluster_role_binding.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages k8s_cluster_role_binding will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_k8s_cluster_role_binding" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -200,7 +200,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_k8s_cluster_role_binding.example system/example
 ```

--- a/docs/resources/k8s_pod_security_admission.md
+++ b/docs/resources/k8s_pod_security_admission.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages k8s_pod_security_admission will create the object in the storage backend. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_k8s_pod_security_admission" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -186,7 +186,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_k8s_pod_security_admission.example system/example
 ```

--- a/docs/resources/k8s_pod_security_policy.md
+++ b/docs/resources/k8s_pod_security_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages k8s_pod_security_policy will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_k8s_pod_security_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -324,7 +324,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_k8s_pod_security_policy.example system/example
 ```

--- a/docs/resources/log_receiver.md
+++ b/docs/resources/log_receiver.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new Log Receiver object. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Log Receiver API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/) to learn more.
+~> **Note:** For more information, see the [Log Receiver API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/observability/).
 
 ## Example Usage
 

--- a/docs/resources/log_receiver.md
+++ b/docs/resources/log_receiver.md
@@ -39,7 +39,7 @@ resource "xcsh_log_receiver" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -244,7 +244,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_log_receiver.example system/example
 ```

--- a/docs/resources/malicious_user_mitigation.md
+++ b/docs/resources/malicious_user_mitigation.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages malicious_user_mitigation creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -322,7 +322,7 @@ resource "xcsh_malicious_user_mitigation" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -507,7 +507,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_malicious_user_mitigation.example system/example
 ```

--- a/docs/resources/mitigated_domain.md
+++ b/docs/resources/mitigated_domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Mitigated Domain. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_mitigated_domain" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_mitigated_domain.example system/example
 ```

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new namespace. Name of the object is name of the namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_namespace" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 
@@ -166,7 +166,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_namespace.example system/example
 ```

--- a/docs/resources/nat_policy.md
+++ b/docs/resources/nat_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a NAT Policy resource in F5 Distributed Cloud for nat policy create specification configures nat policy with multiple rules,. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_nat_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -420,7 +420,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_nat_policy.example system/example
 ```

--- a/docs/resources/network_connector.md
+++ b/docs/resources/network_connector.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Network Connector resource in F5 Distributed Cloud for network connector is created by users in system namespace. configuration.
 
-~> **Note** Please refer to [Network Connector API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/) to learn more.
+~> **Note:** For more information, see the [Network Connector API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/).
 
 ## Example Usage
 

--- a/docs/resources/network_connector.md
+++ b/docs/resources/network_connector.md
@@ -39,7 +39,7 @@ resource "xcsh_network_connector" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -299,7 +299,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_network_connector.example system/example
 ```

--- a/docs/resources/network_firewall.md
+++ b/docs/resources/network_firewall.md
@@ -39,7 +39,7 @@ resource "xcsh_network_firewall" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -266,7 +266,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_network_firewall.example system/example
 ```

--- a/docs/resources/network_firewall.md
+++ b/docs/resources/network_firewall.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Network Firewall resource in F5 Distributed Cloud for network firewall is created by users in system namespace. configuration.
 
-~> **Note** Please refer to [Network Firewall API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/) to learn more.
+~> **Note:** For more information, see the [Network Firewall API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/).
 
 ## Example Usage
 

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Network Interface resource in F5 Distributed Cloud for network interface represents configuration of a network device. it is created by users in system namespace. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_network_interface" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -480,7 +480,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_network_interface.example system/example
 ```

--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -39,7 +39,7 @@ resource "xcsh_network_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -413,7 +413,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_network_policy.example system/example
 ```

--- a/docs/resources/network_policy.md
+++ b/docs/resources/network_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new network policy with configured parameters in specified namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Network Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/) to learn more.
+~> **Note:** For more information, see the [Network Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network_security/).
 
 ## Example Usage
 

--- a/docs/resources/network_policy_rule.md
+++ b/docs/resources/network_policy_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages network policy rule with configured parameters in specified namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_network_policy_rule" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -228,7 +228,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_network_policy_rule.example system/example
 ```

--- a/docs/resources/network_policy_view.md
+++ b/docs/resources/network_policy_view.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Network Policy View resource in F5 Distributed Cloud for network policy view specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_network_policy_view" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -409,7 +409,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_network_policy_view.example system/example
 ```

--- a/docs/resources/nfv_service.md
+++ b/docs/resources/nfv_service.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new NFV service with configured parameters. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_nfv_service" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -705,7 +705,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_nfv_service.example system/example
 ```

--- a/docs/resources/nginx_service_discovery.md
+++ b/docs/resources/nginx_service_discovery.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Nginx Service Discovery resource in F5 Distributed Cloud for api to create nginx service discovery object for a site or virtual site in system namespace. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_nginx_service_discovery" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -219,7 +219,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_nginx_service_discovery.example system/example
 ```

--- a/docs/resources/origin_pool.md
+++ b/docs/resources/origin_pool.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages an Origin Pool resource in F5 Distributed Cloud for defining backend server pools for load balancer targets.
 
-~> **Note** Please refer to [Origin Pool API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [Origin Pool API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/resources/origin_pool.md
+++ b/docs/resources/origin_pool.md
@@ -283,7 +283,7 @@ resource "xcsh_origin_pool" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1048,7 +1048,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_origin_pool.example system/example
 ```

--- a/docs/resources/policer.md
+++ b/docs/resources/policer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new policer with traffic rate limits. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "xcsh_policer" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -180,7 +180,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_policer.example system/example
 ```

--- a/docs/resources/policy_based_routing.md
+++ b/docs/resources/policy_based_routing.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Policy Based Routing resource in F5 Distributed Cloud for network policy based routing create specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_policy_based_routing" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -338,7 +338,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_policy_based_routing.example system/example
 ```

--- a/docs/resources/protected_application.md
+++ b/docs/resources/protected_application.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages applications protected by Bot Defense. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_protected_application" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -971,7 +971,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_protected_application.example system/example
 ```

--- a/docs/resources/protected_domain.md
+++ b/docs/resources/protected_domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Domain to protect. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_protected_domain" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_protected_domain.example system/example
 ```

--- a/docs/resources/protocol_inspection.md
+++ b/docs/resources/protocol_inspection.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Protocol Inspection Specification in a given namespace. If one already exists it will give an error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_protocol_inspection" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -225,7 +225,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_protocol_inspection.example system/example
 ```

--- a/docs/resources/protocol_policer.md
+++ b/docs/resources/protocol_policer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages protocol_policer object, protocol_policer object contains list of L4 protocol match condition and corresponding traffic rate limits. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_protocol_policer" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -216,7 +216,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_protocol_policer.example system/example
 ```

--- a/docs/resources/proxy.md
+++ b/docs/resources/proxy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Proxy resource in F5 Distributed Cloud for tcp loadbalancer create specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_proxy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -792,7 +792,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_proxy.example system/example
 ```

--- a/docs/resources/rate_limiter.md
+++ b/docs/resources/rate_limiter.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages rate_limiter creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Rate Limiter API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/) to learn more.
+~> **Note:** For more information, see the [Rate Limiter API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/).
 
 ## Example Usage
 

--- a/docs/resources/rate_limiter.md
+++ b/docs/resources/rate_limiter.md
@@ -215,7 +215,7 @@ resource "xcsh_rate_limiter" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -411,7 +411,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_rate_limiter.example system/example
 ```

--- a/docs/resources/rate_limiter_policy.md
+++ b/docs/resources/rate_limiter_policy.md
@@ -39,7 +39,7 @@ resource "xcsh_rate_limiter_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -461,7 +461,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_rate_limiter_policy.example system/example
 ```

--- a/docs/resources/rate_limiter_policy.md
+++ b/docs/resources/rate_limiter_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Rate Limiter Policy resource in F5 Distributed Cloud for rate limiter policy create specification. configuration.
 
-~> **Note** Please refer to [Rate Limiter Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/) to learn more.
+~> **Note:** For more information, see the [Rate Limiter Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/rate_limiting/).
 
 ## Example Usage
 

--- a/docs/resources/registration.md
+++ b/docs/resources/registration.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Registration resource in F5 Distributed Cloud for vpm creates registration using this message, never used by users. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_registration" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -499,7 +499,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_registration.example system/example
 ```

--- a/docs/resources/registration_approval.md
+++ b/docs/resources/registration_approval.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Registration Approval resource in F5 Distributed Cloud for request for admission approval. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_registration_approval" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 ### Metadata Argument Reference
 
@@ -150,7 +150,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_registration_approval.example system/example
 ```

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages route object in a given namespace. Route object is list of route rules. Each rule has match condition to match incoming requests and actions to take on matching requests. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_route" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -755,7 +755,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_route.example system/example
 ```

--- a/docs/resources/secret_management_access.md
+++ b/docs/resources/secret_management_access.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages secret_management_access creates a new object in storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_secret_management_access" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -465,7 +465,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_secret_management_access.example system/example
 ```

--- a/docs/resources/securemesh_site.md
+++ b/docs/resources/securemesh_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Securemesh Site resource in F5 Distributed Cloud for deploying secure mesh edge sites with distributed security capabilities.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_securemesh_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -699,7 +699,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_securemesh_site.example system/example
 ```

--- a/docs/resources/securemesh_site_v2.md
+++ b/docs/resources/securemesh_site_v2.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Securemesh Site V2 resource in F5 Distributed Cloud for deploying secure mesh edge sites with enhanced security and networking features.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_securemesh_site_v2" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -2269,7 +2269,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_securemesh_site_v2.example system/example
 ```

--- a/docs/resources/segment.md
+++ b/docs/resources/segment.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Segment resource in F5 Distributed Cloud for segment. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_segment" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -170,7 +170,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_segment.example system/example
 ```

--- a/docs/resources/sensitive_data_policy.md
+++ b/docs/resources/sensitive_data_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages sensitive_data_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Sensitive Data Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/data_and_privacy_security/) to learn more.
+~> **Note:** For more information, see the [Sensitive Data Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/data_and_privacy_security/).
 
 ## Example Usage
 

--- a/docs/resources/sensitive_data_policy.md
+++ b/docs/resources/sensitive_data_policy.md
@@ -39,7 +39,7 @@ resource "xcsh_sensitive_data_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -210,7 +210,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_sensitive_data_policy.example system/example
 ```

--- a/docs/resources/service_policy.md
+++ b/docs/resources/service_policy.md
@@ -127,7 +127,7 @@ resource "xcsh_service_policy" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -955,7 +955,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_service_policy.example system/example
 ```

--- a/docs/resources/service_policy.md
+++ b/docs/resources/service_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages service_policy creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Service Policy API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [Service Policy API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/resources/service_policy_rule.md
+++ b/docs/resources/service_policy_rule.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages service_policy_rule creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_service_policy_rule" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -671,7 +671,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_service_policy_rule.example system/example
 ```

--- a/docs/resources/site_mesh_group.md
+++ b/docs/resources/site_mesh_group.md
@@ -39,7 +39,7 @@ resource "xcsh_site_mesh_group" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -246,7 +246,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_site_mesh_group.example system/example
 ```

--- a/docs/resources/site_mesh_group.md
+++ b/docs/resources/site_mesh_group.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages Site Mesh Group in system namespace of user. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Site Mesh Group API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/) to learn more.
+~> **Note:** For more information, see the [Site Mesh Group API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/).
 
 ## Example Usage
 

--- a/docs/resources/srv6_network_slice.md
+++ b/docs/resources/srv6_network_slice.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages srv6_network_slice creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "xcsh_srv6_network_slice" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -181,7 +181,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_srv6_network_slice.example system/example
 ```

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Subnet resource in F5 Distributed Cloud for subnet object contains configuration for an interface of a vm/pod. it is created in user or shared namespace. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_subnet" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -223,7 +223,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_subnet.example system/example
 ```

--- a/docs/resources/tcp_loadbalancer.md
+++ b/docs/resources/tcp_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a TCP Load Balancer resource in F5 Distributed Cloud for load balancing TCP traffic across origin pools.
 
-~> **Note** Please refer to [TCP Loadbalancer API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/) to learn more.
+~> **Note:** For more information, see the [TCP Loadbalancer API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/virtual/).
 
 ## Example Usage
 

--- a/docs/resources/tcp_loadbalancer.md
+++ b/docs/resources/tcp_loadbalancer.md
@@ -385,7 +385,7 @@ resource "xcsh_tcp_loadbalancer" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1012,7 +1012,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_tcp_loadbalancer.example system/example
 ```

--- a/docs/resources/tenant_configuration.md
+++ b/docs/resources/tenant_configuration.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Tenant Configuration resource in F5 Distributed Cloud for tenant configuration specification. configuration.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_tenant_configuration" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -257,7 +257,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_tenant_configuration.example system/example
 ```

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new token. Token object is used to manage site admission. User must generate token before provisioning and pass this token to site during it's registration. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Token API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/authentication/) to learn more.
+~> **Note:** For more information, see the [Token API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/authentication/).
 
 ## Example Usage
 

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -39,7 +39,7 @@ resource "xcsh_token" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -170,7 +170,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_token.example system/example
 ```

--- a/docs/resources/trusted_ca_list.md
+++ b/docs/resources/trusted_ca_list.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Trusted CA List resource in F5 Distributed Cloud for trusted certificate authority list management.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_trusted_ca_list" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -172,7 +172,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_trusted_ca_list.example system/example
 ```

--- a/docs/resources/tunnel.md
+++ b/docs/resources/tunnel.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages tunnel in a given namespace. If one already exist it will give a error. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ resource "xcsh_tunnel" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -318,7 +318,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_tunnel.example system/example
 ```

--- a/docs/resources/udp_loadbalancer.md
+++ b/docs/resources/udp_loadbalancer.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a UDP Load Balancer resource in F5 Distributed Cloud for load balancing UDP traffic across origin pools.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_udp_loadbalancer" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -393,7 +393,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_udp_loadbalancer.example system/example
 ```

--- a/docs/resources/usb_policy.md
+++ b/docs/resources/usb_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages new USB policy object. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_usb_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -186,7 +186,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_usb_policy.example system/example
 ```

--- a/docs/resources/user_identification.md
+++ b/docs/resources/user_identification.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages user_identification creates a new object in the storage backend for metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -240,7 +240,7 @@ resource "xcsh_user_identification" "test" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -427,7 +427,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_user_identification.example system/example
 ```

--- a/docs/resources/virtual_host.md
+++ b/docs/resources/virtual_host.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages virtual host in a given namespace. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -55,7 +55,7 @@ resource "xcsh_virtual_host" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -934,7 +934,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_virtual_host.example system/example
 ```

--- a/docs/resources/virtual_k8s.md
+++ b/docs/resources/virtual_k8s.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages virtual_k8s will create the object in the storage backend for namespace metadata.namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Virtual K8S API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/) to learn more.
+~> **Note:** For more information, see the [Virtual K8S API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/).
 
 ## Example Usage
 

--- a/docs/resources/virtual_k8s.md
+++ b/docs/resources/virtual_k8s.md
@@ -39,7 +39,7 @@ resource "xcsh_virtual_k8s" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -201,7 +201,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_virtual_k8s.example system/example
 ```

--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages virtual network in given namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Virtual Network API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/) to learn more.
+~> **Note:** For more information, see the [Virtual Network API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/network/).
 
 ## Example Usage
 

--- a/docs/resources/virtual_network.md
+++ b/docs/resources/virtual_network.md
@@ -41,7 +41,7 @@ resource "xcsh_virtual_network" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -224,7 +224,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_virtual_network.example system/example
 ```

--- a/docs/resources/virtual_site.md
+++ b/docs/resources/virtual_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages virtual site object in given namespace. in F5 Distributed Cloud.
 
-~> **Note** Please refer to [Virtual Site API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/) to learn more.
+~> **Note:** For more information, see the [Virtual Site API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/).
 
 ## Example Usage
 

--- a/docs/resources/virtual_site.md
+++ b/docs/resources/virtual_site.md
@@ -41,7 +41,7 @@ resource "xcsh_virtual_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -204,7 +204,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_virtual_site.example system/example
 ```

--- a/docs/resources/voltstack_site.md
+++ b/docs/resources/voltstack_site.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Voltstack Site resource in F5 Distributed Cloud for deploying Volterra stack sites for edge computing.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_voltstack_site" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -1291,7 +1291,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_voltstack_site.example system/example
 ```

--- a/docs/resources/waf_exclusion_policy.md
+++ b/docs/resources/waf_exclusion_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages WAF exclusion policy. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -39,7 +39,7 @@ resource "xcsh_waf_exclusion_policy" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -257,7 +257,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_waf_exclusion_policy.example system/example
 ```

--- a/docs/resources/workload.md
+++ b/docs/resources/workload.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages a Workload resource in F5 Distributed Cloud for workload. configuration.
 
-~> **Note** Please refer to [Workload API docs](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/) to learn more.
+~> **Note:** For more information, see the [Workload API documentation](https://f5-sales-demo.github.io/api-specs-enriched/api-reference/container_services/).
 
 ## Example Usage
 

--- a/docs/resources/workload.md
+++ b/docs/resources/workload.md
@@ -39,7 +39,7 @@ resource "xcsh_workload" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -3145,7 +3145,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_workload.example system/example
 ```

--- a/docs/resources/workload_flavor.md
+++ b/docs/resources/workload_flavor.md
@@ -9,7 +9,7 @@ description: |-
 
 Manages workload_flavor. in F5 Distributed Cloud.
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ resource "xcsh_workload_flavor" "example" {
 
 ## Argument Reference
 
--> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (like `add_hsts`, `http_redirect`) use `= true/false` as normal.
+-> **Syntax Rule:** This provider uses OneOf groups for mutually exclusive options. Fields documented as "Optional Block" use empty block syntax `field_name {}`, **never** `field_name = true`. Boolean attributes (such as `add_hsts` and `http_redirect`) use `= true` or `= false`.
 
 🔶 **High Risk Operations** — Some operations on this resource have high danger level. Destructive operations may require confirmation.
 
@@ -178,7 +178,7 @@ IP address threat categories for security filtering.
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import xcsh_workload_flavor.example system/example
 ```

--- a/docs/terraform-llms-index.json
+++ b/docs/terraform-llms-index.json
@@ -261,15 +261,6 @@
       "category": "security",
       "description": "Application Firewall",
       "required": ["name", "namespace"],
-      "server_defaults": [
-        "allow_all_response_codes",
-        "default_anonymization",
-        "default_bot_setting",
-        "default_detection_settings",
-        "disable_ai_enhancements",
-        "monitoring",
-        "use_default_blocking_page"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/app_firewall.txt#minimal-valid-config"
@@ -354,7 +345,6 @@
       "category": "security",
       "description": "Enhanced firewall policy specification. configuration",
       "required": ["name", "namespace"],
-      "server_defaults": ["allow_all"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/enhanced_firewall_policy.txt#minimal-valid-config"
@@ -425,7 +415,6 @@
       "category": "security",
       "description": "Malicious_user_mitigation creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["mitigation_type"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/malicious_user_mitigation.txt#minimal-valid-config"
@@ -454,7 +443,6 @@
       "category": "security",
       "description": "Network firewall is created by users in system namespace. configuration",
       "required": ["name", "namespace"],
-      "server_defaults": ["disable_fast_acl", "disable_forward_proxy_policy", "disable_network_policy"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/network_firewall.txt#minimal-valid-config"
@@ -511,7 +499,6 @@
       "category": "security",
       "description": "Protocol Inspection Specification in a given namespace. If one already exists it will give an error",
       "required": ["name", "namespace", "enable_disable_compliance_checks", "enable_disable_signatures"],
-      "server_defaults": ["action"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/protocol_inspection.txt#minimal-valid-config"
@@ -540,7 +527,6 @@
       "category": "security",
       "description": "Rate_limiter creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["user_identification"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/rate_limiter.txt#minimal-valid-config"
@@ -555,7 +541,6 @@
       "category": "security",
       "description": "Rate limiter policy create specification. configuration",
       "required": ["name", "namespace", "burst_size", "committed_information_rate"],
-      "server_defaults": ["rules"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/rate_limiter_policy.txt#minimal-valid-config"
@@ -570,7 +555,6 @@
       "category": "security",
       "description": "Sensitive_data_policy creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["compliances", "custom_data_types", "disabled_predefined_data_types"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/sensitive_data_policy.txt#minimal-valid-config"
@@ -585,7 +569,6 @@
       "category": "security",
       "description": "Service_policy creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["port_matcher"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/service_policy.txt#minimal-valid-config"
@@ -928,15 +911,7 @@
       "category": "load-balancing",
       "description": "Healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration",
       "required": ["name", "namespace", "interval", "timeout", "healthy_threshold", "unhealthy_threshold"],
-      "server_defaults": [
-        "http_health_check.expected_response",
-        "http_health_check.expected_status_codes",
-        "http_health_check.headers",
-        "http_health_check.request_headers_to_remove",
-        "http_health_check.use_http2",
-        "http_health_check.use_origin_server_name",
-        "jitter_percent"
-      ],
+      "server_defaults": ["jitter_percent", "use_http2"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/healthcheck.txt#minimal-valid-config"
@@ -952,51 +927,7 @@
       "category": "load-balancing",
       "description": "Load balancing HTTP/HTTPS traffic with advanced routing and security",
       "required": ["name", "namespace", "domains"],
-      "server_defaults": [
-        "add_location",
-        "default_pool.advanced_options.auto_http_config",
-        "default_pool.advanced_options.connection_timeout",
-        "default_pool.advanced_options.default_circuit_breaker",
-        "default_pool.advanced_options.disable_outlier_detection",
-        "default_pool.advanced_options.disable_subsets",
-        "default_pool.advanced_options.http_idle_timeout",
-        "default_pool.advanced_options.no_panic_threshold",
-        "default_pool.advanced_options.no_request_limit_per_connection",
-        "default_pool.endpoint_selection",
-        "default_pool.healthcheck",
-        "default_pool.loadbalancer_algorithm",
-        "default_pool.no_tls",
-        "default_pool.same_as_endpoint_port",
-        "default_pool.use_tls.default_session_key_caching",
-        "default_pool.use_tls.no_mtls",
-        "default_pool.use_tls.use_host_header_as_sni",
-        "default_pool.use_tls.volterra_trusted_ca",
-        "default_sensitive_data_policy",
-        "disable_api_definition",
-        "disable_api_discovery",
-        "disable_api_testing",
-        "disable_bot_defense",
-        "disable_ip_reputation",
-        "disable_malicious_user_detection",
-        "disable_malware_protection",
-        "disable_rate_limit",
-        "disable_threat_mesh",
-        "disable_trust_client_ip_headers",
-        "disable_waf",
-        "https_auto_cert.add_hsts",
-        "https_auto_cert.connection_idle_timeout",
-        "https_auto_cert.enable_path_normalize",
-        "https_auto_cert.http_redirect",
-        "https_auto_cert.no_mtls",
-        "l7_ddos_protection",
-        "no_challenge",
-        "rate_limit.no_ip_allowed_list",
-        "rate_limit.no_policies",
-        "rate_limit.rate_limiter.period_multiplier",
-        "round_robin",
-        "service_policies_from_namespace",
-        "user_id_client_ip"
-      ],
+      "server_defaults": ["connection_timeout", "http_idle_timeout"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/http_loadbalancer.txt#minimal-valid-config"
@@ -1012,25 +943,7 @@
       "category": "load-balancing",
       "description": "Defining backend server pools for load balancer targets",
       "required": ["name", "namespace", "origin_servers", "port"],
-      "server_defaults": [
-        "advanced_options.auto_http_config",
-        "advanced_options.connection_timeout",
-        "advanced_options.default_circuit_breaker",
-        "advanced_options.disable_outlier_detection",
-        "advanced_options.disable_subsets",
-        "advanced_options.http_idle_timeout",
-        "advanced_options.no_panic_threshold",
-        "advanced_options.no_request_limit_per_connection",
-        "endpoint_selection",
-        "healthcheck",
-        "loadbalancer_algorithm",
-        "no_tls",
-        "same_as_endpoint_port",
-        "use_tls.default_session_key_caching",
-        "use_tls.no_mtls",
-        "use_tls.use_host_header_as_sni",
-        "use_tls.volterra_trusted_ca"
-      ],
+      "server_defaults": ["connection_timeout", "http_idle_timeout"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/origin_pool.txt#minimal-valid-config"
@@ -1152,15 +1065,6 @@
       "category": "load-balancing",
       "description": "Load balancing TCP traffic across origin pools",
       "required": ["name", "namespace", "origin_pools"],
-      "server_defaults": [
-        "dns_volterra_managed",
-        "hash_policy_choice_round_robin",
-        "idle_timeout",
-        "no_sni",
-        "retract_cluster",
-        "service_policies_from_namespace",
-        "tcp"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/tcp_loadbalancer.txt#minimal-valid-config"
@@ -1241,16 +1145,6 @@
       "category": "sites",
       "description": "Deploying F5 sites within Azure Virtual Network environments",
       "required": ["name", "namespace", "machine_type", "resource_group", "ssh_key"],
-      "server_defaults": [
-        "block_all_services",
-        "disk_size",
-        "ingress_gw.accelerated_networking",
-        "ingress_gw.performance_enhancement_mode",
-        "logs_streaming_disabled",
-        "machine_type",
-        "no_worker_nodes",
-        "tags"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/azure_vnet_site.txt#minimal-valid-config"
@@ -1398,17 +1292,6 @@
       "category": "kubernetes",
       "description": "K8s_cluster will create the object in the storage backend for namespace metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": [
-        "cluster_scoped_access_deny",
-        "no_cluster_wide_apps",
-        "no_global_access",
-        "no_insecure_registries",
-        "no_local_access",
-        "use_default_cluster_role_bindings",
-        "use_default_cluster_roles",
-        "use_default_psp",
-        "vk8s_namespace_access_deny"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/k8s_cluster.txt#minimal-valid-config"
@@ -1703,13 +1586,6 @@
       "category": "api-security",
       "description": "API Definition",
       "required": ["name", "namespace"],
-      "server_defaults": [
-        "api_inventory_exclusion_list",
-        "api_inventory_inclusion_list",
-        "non_api_endpoints",
-        "strict_schema_origin",
-        "swagger_specs"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/api_definition.txt#minimal-valid-config"
@@ -1724,11 +1600,6 @@
       "category": "api-security",
       "description": "API discovery creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace", "user_defined_api_discovery_policy"],
-      "server_defaults": [
-        "custom_auth_types",
-        "user_defined_api_discovery_policy.discovery_rules",
-        "user_defined_api_discovery_policy.inclusive"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/api_discovery.txt#minimal-valid-config"
@@ -1967,7 +1838,6 @@
       "category": "monitoring",
       "description": "New Global Log Receiver object",
       "required": ["name", "namespace", "log_type", "receiver_choice"],
-      "server_defaults": ["ns_current", "request_logs.sampled"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/global_log_receiver.txt#minimal-valid-config"
@@ -2205,7 +2075,6 @@
       "category": "service-mesh",
       "description": "New policer with traffic rate limits",
       "required": ["name", "namespace", "burst_size", "committed_information_rate"],
-      "server_defaults": ["policer_mode", "policer_type"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/policer.txt#minimal-valid-config"

--- a/docs/terraform-llms-index.json
+++ b/docs/terraform-llms-index.json
@@ -261,6 +261,15 @@
       "category": "security",
       "description": "Application Firewall",
       "required": ["name", "namespace"],
+      "server_defaults": [
+        "allow_all_response_codes",
+        "default_anonymization",
+        "default_bot_setting",
+        "default_detection_settings",
+        "disable_ai_enhancements",
+        "monitoring",
+        "use_default_blocking_page"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/app_firewall.txt#minimal-valid-config"
@@ -345,6 +354,7 @@
       "category": "security",
       "description": "Enhanced firewall policy specification. configuration",
       "required": ["name", "namespace"],
+      "server_defaults": ["allow_all"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/enhanced_firewall_policy.txt#minimal-valid-config"
@@ -415,6 +425,7 @@
       "category": "security",
       "description": "Malicious_user_mitigation creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
+      "server_defaults": ["mitigation_type"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/malicious_user_mitigation.txt#minimal-valid-config"
@@ -443,6 +454,7 @@
       "category": "security",
       "description": "Network firewall is created by users in system namespace. configuration",
       "required": ["name", "namespace"],
+      "server_defaults": ["disable_fast_acl", "disable_forward_proxy_policy", "disable_network_policy"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/network_firewall.txt#minimal-valid-config"
@@ -499,6 +511,7 @@
       "category": "security",
       "description": "Protocol Inspection Specification in a given namespace. If one already exists it will give an error",
       "required": ["name", "namespace", "enable_disable_compliance_checks", "enable_disable_signatures"],
+      "server_defaults": ["action"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/protocol_inspection.txt#minimal-valid-config"
@@ -527,6 +540,7 @@
       "category": "security",
       "description": "Rate_limiter creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
+      "server_defaults": ["user_identification"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/rate_limiter.txt#minimal-valid-config"
@@ -541,6 +555,7 @@
       "category": "security",
       "description": "Rate limiter policy create specification. configuration",
       "required": ["name", "namespace", "burst_size", "committed_information_rate"],
+      "server_defaults": ["rules"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/rate_limiter_policy.txt#minimal-valid-config"
@@ -555,6 +570,7 @@
       "category": "security",
       "description": "Sensitive_data_policy creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
+      "server_defaults": ["compliances", "custom_data_types", "disabled_predefined_data_types"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/sensitive_data_policy.txt#minimal-valid-config"
@@ -569,6 +585,7 @@
       "category": "security",
       "description": "Service_policy creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
+      "server_defaults": ["port_matcher"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/service_policy.txt#minimal-valid-config"
@@ -911,7 +928,15 @@
       "category": "load-balancing",
       "description": "Healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration",
       "required": ["name", "namespace", "interval", "timeout", "healthy_threshold", "unhealthy_threshold"],
-      "server_defaults": ["jitter_percent", "use_http2"],
+      "server_defaults": [
+        "http_health_check.expected_response",
+        "http_health_check.expected_status_codes",
+        "http_health_check.headers",
+        "http_health_check.request_headers_to_remove",
+        "http_health_check.use_http2",
+        "http_health_check.use_origin_server_name",
+        "jitter_percent"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/healthcheck.txt#minimal-valid-config"
@@ -927,7 +952,51 @@
       "category": "load-balancing",
       "description": "Load balancing HTTP/HTTPS traffic with advanced routing and security",
       "required": ["name", "namespace", "domains"],
-      "server_defaults": ["connection_timeout", "http_idle_timeout"],
+      "server_defaults": [
+        "add_location",
+        "default_pool.advanced_options.auto_http_config",
+        "default_pool.advanced_options.connection_timeout",
+        "default_pool.advanced_options.default_circuit_breaker",
+        "default_pool.advanced_options.disable_outlier_detection",
+        "default_pool.advanced_options.disable_subsets",
+        "default_pool.advanced_options.http_idle_timeout",
+        "default_pool.advanced_options.no_panic_threshold",
+        "default_pool.advanced_options.no_request_limit_per_connection",
+        "default_pool.endpoint_selection",
+        "default_pool.healthcheck",
+        "default_pool.loadbalancer_algorithm",
+        "default_pool.no_tls",
+        "default_pool.same_as_endpoint_port",
+        "default_pool.use_tls.default_session_key_caching",
+        "default_pool.use_tls.no_mtls",
+        "default_pool.use_tls.use_host_header_as_sni",
+        "default_pool.use_tls.volterra_trusted_ca",
+        "default_sensitive_data_policy",
+        "disable_api_definition",
+        "disable_api_discovery",
+        "disable_api_testing",
+        "disable_bot_defense",
+        "disable_ip_reputation",
+        "disable_malicious_user_detection",
+        "disable_malware_protection",
+        "disable_rate_limit",
+        "disable_threat_mesh",
+        "disable_trust_client_ip_headers",
+        "disable_waf",
+        "https_auto_cert.add_hsts",
+        "https_auto_cert.connection_idle_timeout",
+        "https_auto_cert.enable_path_normalize",
+        "https_auto_cert.http_redirect",
+        "https_auto_cert.no_mtls",
+        "l7_ddos_protection",
+        "no_challenge",
+        "rate_limit.no_ip_allowed_list",
+        "rate_limit.no_policies",
+        "rate_limit.rate_limiter.period_multiplier",
+        "round_robin",
+        "service_policies_from_namespace",
+        "user_id_client_ip"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/http_loadbalancer.txt#minimal-valid-config"
@@ -943,7 +1012,25 @@
       "category": "load-balancing",
       "description": "Defining backend server pools for load balancer targets",
       "required": ["name", "namespace", "origin_servers", "port"],
-      "server_defaults": ["connection_timeout", "http_idle_timeout"],
+      "server_defaults": [
+        "advanced_options.auto_http_config",
+        "advanced_options.connection_timeout",
+        "advanced_options.default_circuit_breaker",
+        "advanced_options.disable_outlier_detection",
+        "advanced_options.disable_subsets",
+        "advanced_options.http_idle_timeout",
+        "advanced_options.no_panic_threshold",
+        "advanced_options.no_request_limit_per_connection",
+        "endpoint_selection",
+        "healthcheck",
+        "loadbalancer_algorithm",
+        "no_tls",
+        "same_as_endpoint_port",
+        "use_tls.default_session_key_caching",
+        "use_tls.no_mtls",
+        "use_tls.use_host_header_as_sni",
+        "use_tls.volterra_trusted_ca"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/origin_pool.txt#minimal-valid-config"
@@ -1065,6 +1152,15 @@
       "category": "load-balancing",
       "description": "Load balancing TCP traffic across origin pools",
       "required": ["name", "namespace", "origin_pools"],
+      "server_defaults": [
+        "dns_volterra_managed",
+        "hash_policy_choice_round_robin",
+        "idle_timeout",
+        "no_sni",
+        "retract_cluster",
+        "service_policies_from_namespace",
+        "tcp"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/tcp_loadbalancer.txt#minimal-valid-config"
@@ -1145,6 +1241,16 @@
       "category": "sites",
       "description": "Deploying F5 sites within Azure Virtual Network environments",
       "required": ["name", "namespace", "machine_type", "resource_group", "ssh_key"],
+      "server_defaults": [
+        "block_all_services",
+        "disk_size",
+        "ingress_gw.accelerated_networking",
+        "ingress_gw.performance_enhancement_mode",
+        "logs_streaming_disabled",
+        "machine_type",
+        "no_worker_nodes",
+        "tags"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/azure_vnet_site.txt#minimal-valid-config"
@@ -1292,6 +1398,17 @@
       "category": "kubernetes",
       "description": "K8s_cluster will create the object in the storage backend for namespace metadata.namespace",
       "required": ["name", "namespace"],
+      "server_defaults": [
+        "cluster_scoped_access_deny",
+        "no_cluster_wide_apps",
+        "no_global_access",
+        "no_insecure_registries",
+        "no_local_access",
+        "use_default_cluster_role_bindings",
+        "use_default_cluster_roles",
+        "use_default_psp",
+        "vk8s_namespace_access_deny"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/k8s_cluster.txt#minimal-valid-config"
@@ -1586,6 +1703,13 @@
       "category": "api-security",
       "description": "API Definition",
       "required": ["name", "namespace"],
+      "server_defaults": [
+        "api_inventory_exclusion_list",
+        "api_inventory_inclusion_list",
+        "non_api_endpoints",
+        "strict_schema_origin",
+        "swagger_specs"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/api_definition.txt#minimal-valid-config"
@@ -1600,6 +1724,11 @@
       "category": "api-security",
       "description": "API discovery creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace", "user_defined_api_discovery_policy"],
+      "server_defaults": [
+        "custom_auth_types",
+        "user_defined_api_discovery_policy.discovery_rules",
+        "user_defined_api_discovery_policy.inclusive"
+      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/api_discovery.txt#minimal-valid-config"
@@ -1838,6 +1967,7 @@
       "category": "monitoring",
       "description": "New Global Log Receiver object",
       "required": ["name", "namespace", "log_type", "receiver_choice"],
+      "server_defaults": ["ns_current", "request_logs.sampled"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/global_log_receiver.txt#minimal-valid-config"
@@ -2075,6 +2205,7 @@
       "category": "service-mesh",
       "description": "New policer with traffic rate limits",
       "required": ["name", "namespace", "burst_size", "committed_information_rate"],
+      "server_defaults": ["policer_mode", "policer_type"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/policer.txt#minimal-valid-config"

--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> **Note** For more information about this data source, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ description: |-
 {{ end }}
 {{ else }}
 
-```terraform
+```hcl
 data "{{ .Name }}" "example" {
   name      = "example-resource"
   namespace = "system"

--- a/templates/functions.md.tmpl
+++ b/templates/functions.md.tmpl
@@ -25,11 +25,11 @@ description: |-
 {{ tffile . }}
 {{ end }}
 {{- else }}
-```terraform
+```hcl
 # No example available
 ```
 {{- end }}
 
 ## See Also
 
-- [F5XC Secret Management Documentation](https://docs.cloud.f5.com/docs/how-to/advanced-security/blindfold-your-tls-certificates)
+- [F5 Distributed Cloud Secret Management Documentation](https://docs.cloud.f5.com/docs/how-to/advanced-security/blindfold-your-tls-certificates)

--- a/templates/guides/addon-activation.md
+++ b/templates/guides/addon-activation.md
@@ -2,22 +2,22 @@
 page_title: "Guide: Addon Service Activation"
 subcategory: "Guides"
 description: |-
-  Report F5XC addon service activation with Terraform and gate resources on it.
+  Report F5 Distributed Cloud addon service activation with Terraform and gate dependent resources.
   Covers Bot Defense, Client-Side Defense, WAAP, and more.
 ---
 
 # Addon Service Activation
 
-This guide covers F5 Distributed Cloud addon services in Terraform. The provider exposes the addon API read-only, so Terraform reports activation and gates on it rather than performing it. By the end, you'll understand how to:
+This guide explains how to activate, configure, and manage tenant addon services in F5 Distributed Cloud using Terraform. Topics covered include:
 
-- **Check activation eligibility** - Determine if an addon can be activated
-- **Activate an addon** - where activation actually happens, and why it is not a Terraform resource
-- **Handle managed activation** - Services requiring sales contact
-- **Gate dependent resources** - create them only once the addon is active
+- **Check activation eligibility** — Determine whether an addon service is available for activation.
+- **Understand activation workflows** — Learn where activation occurs and why activation is not managed as a Terraform resource.
+- **Handle managed activation** — Coordinate services that require F5 account engagement.
+- **Gate dependent resources** — Provision resources only after the addon reaches the active state.
 
 ## Overview
 
-F5 Distributed Cloud addon services are additional security and performance features that can be activated for your tenant. These include:
+F5 Distributed Cloud addon services are optional security and performance features that you can activate for your tenant:
 
 | Addon Service                        | Description                                   | Tier Required |
 | ------------------------------------ | --------------------------------------------- | ------------- |
@@ -71,28 +71,28 @@ Addon services have different activation types that determine how they can be ac
 
 Before you begin, ensure you have:
 
-- **Terraform >= 1.0** - The F5XC provider requires Terraform 1.0 or later
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **API Credentials** - Token or P12 certificate authentication configured
-- **Appropriate Subscription Tier** - Most addon services require ADVANCED tier
+- **Terraform >= 1.0** — Download from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication
+- **Appropriate Subscription Tier** — Most addon services require the ADVANCED tier
 
 ### Authentication Setup
 
-Configure one of these authentication methods via environment variables:
+Configure one of these authentication methods using environment variables:
 
 #### Option 1: API Token (Recommended for development)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 #### Option 2: P12 Certificate (Recommended for production)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/your-credentials.p12"
-export XCSH_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"  # pragma: allowlist secret
 ```
 
 ## Quick Start
@@ -110,13 +110,13 @@ cd terraform-provider-xcsh/examples/guides/addon-activation
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Edit `terraform.tfvars` to choose the addon services you want reported:
+Edit `terraform.tfvars` to select the addon services you want to report:
 
 ```hcl
-# Enable Bot Defense activation
+# Enable Bot Defense reporting
 enable_bot_defense = true
 
-# Enable Client-Side Defense
+# Enable Client-Side Defense reporting
 enable_client_side_defense = false
 ```
 
@@ -130,12 +130,12 @@ terraform apply
 
 ## Checking Activation Eligibility
 
-Check where an addon stands for your tenant before relying on it.
+Check where an addon stands for your tenant before relying on it in configuration.
 
 ### Using the Activation Status Data Source
 
 ```hcl
-# Check if Bot Defense can be activated
+# Check whether Bot Defense can be activated
 data "xcsh_addon_service_activation_status" "bot_defense" {
   addon_service = "f5xc-bot-defense-standard"
 }
@@ -161,7 +161,7 @@ output "bot_defense_status" {
 ### Querying Addon Service Details
 
 ```hcl
-# Get detailed information about an addon service
+# Retrieve detailed information about an addon service
 data "xcsh_addon_service" "bot_defense" {
   name = "f5xc-bot-defense-standard"
 }
@@ -177,29 +177,27 @@ output "addon_details" {
 
 ## Activating an Addon
 
-The provider exposes the addon API read-only: there is no `xcsh_addon_subscription`
-resource, so Terraform reports activation rather than performing it. Activation
-happens in the F5 Distributed Cloud console under **Administration > Billing &
-Subscriptions**, or through your F5 account team for services that report managed
-activation.
+The provider exposes the addon API as read-only: there is no `xcsh_addon_subscription`
+resource, so Terraform reports activation rather than performing it directly. Activate
+services in the F5 Distributed Cloud Console under **Administration > Billing &
+Subscriptions**, or through your F5 account team for managed services.
 
-That split is deliberate rather than a gap. Activation is a billing event against
-the tenant, not a piece of per-environment infrastructure, so it does not belong
-in a plan that several environments apply independently.
+This design is intentional. Activation is a tenant-level billing event rather than
+an ephemeral infrastructure resource, so it does not belong in configuration plans
+applied independently across multiple environments.
 
-The workflow is therefore:
+Follow this workflow:
 
-1. Read `can_activate` and `state` to find out where an addon stands.
-2. Activate it in the console, once, for the tenant.
-3. Gate the resources that depend on the addon on `state` reaching `AS_SUBSCRIBED`.
+1. Read `can_activate` and `state` to determine the current addon status.
+2. Activate the service in the console once for the tenant.
+3. Gate dependent resources on `state` reaching `AS_SUBSCRIBED`.
 
 ### Reporting Pending Addons
 
-Collect the addons a configuration expects and surface the ones that still need
-attention. `pending` is the actionable output — anything in it has to be
-activated in the console before dependent resources can be created.
+Collect the addons that a configuration requires and report any that still need
+activation:
 
-```terraform
+```hcl
 locals {
   expected_addons = [
     "f5xc-bot-defense-standard",
@@ -222,18 +220,18 @@ locals {
 }
 
 output "pending_addons" {
-  description = "Activate these in the F5 Distributed Cloud console"
+  description = "Addons requiring activation in the F5 Distributed Cloud Console"
   value       = local.pending
 }
 ```
 
 ### Gating Dependent Resources
 
-Use the reported state as the condition on anything that needs the addon. A plan
-run against a tenant where the addon is not active then creates nothing that
-would depend on a feature that is not there.
+Use the reported state as a condition on any resource that requires the addon. When
+a plan runs against a tenant where the addon is inactive, Terraform skips creating
+dependent resources:
 
-```terraform
+```hcl
 data "xcsh_addon_service_activation_status" "bot_defense" {
   addon_service = "f5xc-bot-defense-standard"
 }
@@ -241,13 +239,13 @@ data "xcsh_addon_service_activation_status" "bot_defense" {
 resource "xcsh_http_loadbalancer" "with_bot_defense" {
   count = data.xcsh_addon_service_activation_status.bot_defense.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  name      = "my-protected-app"
+  name      = "example-protected-app"
   namespace = "production"
   domains   = ["app.example.com"]
 
   bot_defense {
     policy {
-      name      = "my-bot-policy"
+      name      = "example-bot-policy"
       namespace = "shared"
     }
   }
@@ -258,14 +256,12 @@ resource "xcsh_http_loadbalancer" "with_bot_defense" {
 }
 ```
 
-### Failing Loudly Instead of Silently Skipping
+### Asserting Addon Activation with Preconditions
 
-`count = 0` skips quietly, which is the right behaviour for an optional feature
-and the wrong one for a hard requirement. When the addon is mandatory, assert it
-so the plan stops with a readable message rather than applying a half-configured
-environment.
+When an addon is a mandatory requirement rather than an optional feature, use a
+precondition so the plan stops with an informative message:
 
-```terraform
+```hcl
 resource "terraform_data" "require_bot_defense" {
   lifecycle {
     precondition {
@@ -278,12 +274,10 @@ resource "terraform_data" "require_bot_defense" {
 
 ## Managed Activation Workflow
 
-For addon services requiring sales contact, use Terraform to monitor status after F5 activates the service.
-
-### Verifying Managed Addon Status
+For addon services requiring sales contact, use Terraform to monitor status after F5 activates the service:
 
 ```hcl
-# Managed addons are activated by F5; Terraform reports the resulting state
+# F5 activates managed addons; Terraform reports the resulting state
 data "xcsh_addon_service_activation_status" "managed_addon" {
   addon_service = "some_managed_addon"
 }
@@ -295,20 +289,19 @@ output "managed_addon_status" {
   }
 }
 
-# Use conditional logic based on activation status
+# Gate resources using conditional logic based on activation status
 resource "xcsh_http_loadbalancer" "with_managed_feature" {
   count = data.xcsh_addon_service_activation_status.managed_addon.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  # Configuration that uses the managed addon feature
-  name      = "lb-with-managed-addon"
+  name      = "example-managed-app"
   namespace = "production"
-  # ... rest of configuration
+  # ... remaining configuration
 }
 ```
 
 ## Using Addon Features
 
-Once an addon is activated, you can use its features in your configurations.
+After an addon is active, you can configure its features in your resources.
 
 ### Bot Defense in HTTP Load Balancer
 
@@ -316,7 +309,7 @@ Once an addon is activated, you can use its features in your configurations.
 resource "xcsh_http_loadbalancer" "with_bot_defense" {
   count = data.xcsh_addon_service_activation_status.bot_defense.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  name      = "my-protected-app"
+  name      = "example-protected-app"
   namespace = "production"
 
   domains = ["app.example.com"]
@@ -332,7 +325,7 @@ resource "xcsh_http_loadbalancer" "with_bot_defense" {
   # Enable Bot Defense
   bot_defense {
     policy {
-      name      = "my-bot-policy"
+      name      = "example-bot-policy"
       namespace = "shared"
     }
   }
@@ -349,7 +342,7 @@ resource "xcsh_http_loadbalancer" "with_bot_defense" {
 resource "xcsh_http_loadbalancer" "with_csd" {
   count = data.xcsh_addon_service_activation_status.client_side_defense.state == "AS_SUBSCRIBED" ? 1 : 0
 
-  name      = "my-protected-app"
+  name      = "example-protected-app"
   namespace = "production"
 
   domains = ["app.example.com"]
@@ -357,7 +350,7 @@ resource "xcsh_http_loadbalancer" "with_csd" {
   # Enable Client-Side Defense
   enable_client_side_defense = true
 
-  # ... rest of configuration
+  # ... remaining configuration
 }
 ```
 
@@ -367,23 +360,23 @@ resource "xcsh_http_loadbalancer" "with_csd" {
 
 #### Access denied when reading activation status
 
-- Verify your API token has addon management permissions
-- Check that your subscription tier supports the addon
+- Verify that your API credentials have addon management permissions.
+- Verify that your tenant subscription tier supports the requested addon.
 
-#### Activation stuck in AS_PENDING
+#### Activation remains in AS_PENDING state
 
-- For partially managed addons, contact F5 support
-- For self-activation, wait and retry after a few minutes
+- For partially managed addons, contact F5 support if review takes longer than expected.
+- For self-activation, wait a few minutes and retry the plan.
 
-#### State shows AS_ERROR
+#### State reports AS_ERROR
 
-- Check F5XC console for detailed error messages
-- Contact F5 support with your tenant ID
+- Check the F5 Distributed Cloud Console for detailed error messages.
+- Contact F5 support with your tenant ID and addon name.
 
-### Debugging Tips
+### Debugging Status Output
 
 ```hcl
-# Output detailed status for debugging
+# Output detailed status for troubleshooting
 output "debug_addon_status" {
   value = {
     addon_service = "f5xc-bot-defense-standard"
@@ -396,11 +389,11 @@ output "debug_addon_status" {
 
 ## Best Practices
 
-1. **Always check eligibility first** - Use the activation status data source before attempting activation
-2. **Use conditional resource creation** - Gate dependent resources on `state` being `AS_SUBSCRIBED`
-3. **Handle dependencies properly** - Use `depends_on` to ensure addons are active before using features
-4. **Monitor activation state** - For partially managed addons, monitor the state for completion
-5. **Document addon requirements** - Clearly document which addons your configuration requires
+1. **Check eligibility first** — Query the activation status data source before configuring dependent features.
+2. **Use conditional resource creation** — Gate dependent resources on `state == "AS_SUBSCRIBED"`.
+3. **Assert hard requirements** — Use lifecycle preconditions to halt execution when mandatory addons are inactive.
+4. **Monitor activation state** — Track state progression for partially managed or pending addons.
+5. **Document addon dependencies** — Specify required subscription tiers and addons in module documentation.
 
 ## Complete Example
 

--- a/templates/guides/advanced-http-loadbalancer.md
+++ b/templates/guides/advanced-http-loadbalancer.md
@@ -2,39 +2,38 @@
 page_title: "Guide: Advanced HTTP Load Balancer Security"
 subcategory: "Guides"
 description: |-
-  Advanced guide to deploying a fully-secured HTTP Load Balancer with all security
-  controls including WAF, Data Guard, IP Reputation, Malicious User Detection, and
-  Threat Mesh using F5 Distributed Cloud and Terraform.
+  Deploy a secured HTTP Load Balancer with security controls including WAF, Data Guard,
+  IP Reputation, Malicious User Detection, and Threat Mesh using F5 Distributed Cloud and Terraform.
 ---
 
 # Advanced HTTP Load Balancer Security
 
-This guide extends the [basic HTTP Load Balancer guide](http-loadbalancer.md) with advanced security features for production deployments requiring comprehensive protection against sophisticated threats.
+This guide extends the [HTTP Load Balancer Guide](http-loadbalancer.md) with security features for production deployments requiring comprehensive protection against application and network threats.
 
-By following this guide, you'll deploy an HTTP Load Balancer with **11 security controls**:
+This guide demonstrates how to deploy an HTTP Load Balancer configured with defense-in-depth security controls across multiple layers:
 
-| Security Layer      | Feature                    | Protection                                     |
-| ------------------- | -------------------------- | ---------------------------------------------- |
-| **Perimeter**       | IP Reputation              | Blocks known malicious IPs by threat category  |
-| **Perimeter**       | Threat Mesh                | Global threat intelligence sharing             |
-| **Bot Defense**     | JavaScript Challenge       | Client-side bot detection                      |
-| **Bot Defense**     | Malicious User Detection   | Behavioral analysis and risk scoring           |
-| **Application**     | Web Application Firewall   | Blocks SQLi, XSS, and OWASP Top 10             |
-| **Application**     | Bot Protection Settings    | Signature-based bot classification             |
-| **Rate Control**    | Rate Limiting              | Prevents abuse with configurable thresholds    |
-| **Data Protection** | Data Guard                 | Masks sensitive data (CC, SSN) in responses    |
+| Security Layer      | Feature                  | Protection                                    |
+| ------------------- | ------------------------ | --------------------------------------------- |
+| **Perimeter**       | IP Reputation            | Blocks known malicious IPs by threat category |
+| **Perimeter**       | Threat Mesh              | Global threat intelligence sharing            |
+| **Bot Defense**     | JavaScript Challenge     | Client-side bot detection                     |
+| **Bot Defense**     | Malicious User Detection | Behavioral analysis and risk scoring          |
+| **Application**     | Web Application Firewall | Blocks SQLi, XSS, and OWASP Top 10            |
+| **Application**     | Bot Protection Settings  | Signature-based bot classification            |
+| **Rate Control**    | Rate Limiting            | Prevents abuse with configurable thresholds   |
+| **Data Protection** | Data Guard               | Masks sensitive data (CC, SSN) in responses   |
 
 ## Prerequisites
 
 Before you begin, ensure you have:
 
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **API Token** - Generate credentials from the F5XC Console ([documentation](https://docs.cloud.f5.com/docs/how-to/user-mgmt/credentials))
-- **Terraform >= 1.8** - Download from <https://www.terraform.io/downloads>
-- **Namespace** - An existing namespace or permissions to create one
-- **Backend Origin** - Your application server accessible from the internet
+- **Terraform >= 1.0** — Download from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication (see the [Authentication Guide](authentication.md))
+- **Namespace** — An existing namespace or permissions to create one
+- **Backend Origin** — An application server reachable by F5 Distributed Cloud Regional Edges
 
--> **Tip:** Review the [Authentication Guide](authentication.md) for detailed credential setup instructions.
+-> **Tip:** See the [Authentication Guide](authentication.md) for detailed credential setup instructions.
 
 ## Complete Configuration
 
@@ -63,18 +62,18 @@ provider "xcsh" {
 
 ```hcl
 variable "api_token" {
-  description = "F5 XC API token for authentication"
+  description = "F5 Distributed Cloud API token for authentication"
   type        = string
   sensitive   = true
 }
 
 variable "api_url" {
-  description = "F5 XC API URL (e.g., https://your-tenant.console.ves.volterra.io/api)"
+  description = "F5 Distributed Cloud API URL (for example, https://<XC_TENANT>.console.ves.volterra.io/api)"
   type        = string
 }
 
 variable "namespace" {
-  description = "F5 XC namespace for the load balancer"
+  description = "F5 Distributed Cloud namespace for the load balancer"
   type        = string
   default     = "default"
 }
@@ -82,7 +81,7 @@ variable "namespace" {
 variable "name_prefix" {
   description = "Prefix for resource names"
   type        = string
-  default     = "secure-app"
+  default     = "example-secure-app"
 }
 
 variable "domain" {
@@ -326,7 +325,7 @@ Data Guard automatically detects and masks sensitive data in HTTP responses befo
 - Social Security Numbers (SSN)
 - Custom patterns (configurable)
 
-!> **Important:** Data Guard requires WAF to be enabled. If you disable WAF, Data Guard will not function.
+~> **Important:** Data Guard requires WAF to be enabled. If you disable WAF, Data Guard does not function.
 
 ### Malicious User Detection
 
@@ -519,7 +518,7 @@ output "security_summary" {
 ```hcl
 rate_limit {
   ip_allowed_list {
-    prefixes = ["10.0.0.0/8", "192.168.0.0/16"]
+    prefixes = ["198.51.100.0/24", "203.0.113.0/24"]
   }
   rate_limiter {
     # ... configuration ...
@@ -529,21 +528,21 @@ rate_limit {
 
 ### JavaScript Challenge Breaking Application
 
-**Symptom:** API calls or mobile apps fail with JavaScript challenge.
+**Symptom:** API calls or mobile applications fail when encountering the JavaScript challenge.
 
 **Solutions:**
 
 1. Use `no_challenge {}` instead of `js_challenge {}` for API-only endpoints
-2. Configure trusted client rules to bypass JS challenge for specific clients
-3. Consider using `captcha_challenge {}` for interactive applications
+2. Configure trusted client rules to bypass the JavaScript challenge for specific clients
+3. Use `captcha_challenge {}` for interactive web applications
 
 ## Security Best Practices
 
-1. **Start with monitoring mode** - Deploy WAF in monitoring mode first to understand your traffic patterns
-2. **Review security analytics** - Regularly review blocked requests in the F5XC Console
-3. **Tune gradually** - Enable features one at a time and monitor impact
-4. **Use all layers** - Defense in depth requires multiple security controls
-5. **Keep Terraform state secure** - Use remote state with encryption for production
+1. **Start with monitoring mode** — Deploy WAF in monitoring mode initially to establish traffic baselines without blocking legitimate requests.
+2. **Review security analytics** — Regularly inspect blocked requests and threat detections in the F5 Distributed Cloud Console.
+3. **Tune controls incrementally** — Enable individual security controls sequentially and verify application behavior after each change.
+4. **Apply defense in depth** — Combine network, transport, and application layer controls for comprehensive protection.
+5. **Protect Terraform state** — Use remote state backends with server-side encryption and strict access control for production environments.
 
 ## Related Documentation
 

--- a/templates/guides/authentication.md
+++ b/templates/guides/authentication.md
@@ -361,10 +361,10 @@ openssl pkcs12 -in credentials.p12 -nokeys -info
 
 1. Verify that variables are exported:
 
-```bash
-export XCSH_API_TOKEN="<XC_API_TOKEN>"  # Correct
-XCSH_API_TOKEN="<XC_API_TOKEN>"         # Is not visible to child processes
-```
+   ```bash
+   export XCSH_API_TOKEN="<XC_API_TOKEN>"  # Correct
+   XCSH_API_TOKEN="<XC_API_TOKEN>"         # Is not visible to child processes
+   ```
 
 2. Verify that variable names match the exact required casing (`XCSH_API_URL`, `XCSH_API_TOKEN`).
 3. Check for hidden or unexpected characters in variable values.

--- a/templates/guides/authentication.md
+++ b/templates/guides/authentication.md
@@ -20,64 +20,64 @@ This guide covers authentication configuration for the F5 Distributed Cloud Terr
 
 ## Prerequisites
 
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **Terraform >= 1.8** - Download from <https://www.terraform.io/downloads>
-- **Console Access** - Ability to create credentials in the F5XC Console
+- **Terraform >= 1.0** — Download from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **Console Access** — Tenant credentials with permissions to generate API tokens or certificates
 
 ## Creating Credentials in F5 Distributed Cloud
 
 ### Personal Credentials
 
-Personal credentials are tied to your user account and ideal for development.
+Personal credentials are tied to your user account and suitable for development environments.
 
 #### Creating an API Token
 
-1. Open the F5 Distributed Cloud Console
-2. Navigate to **Administration** → **Personal Management** → **Credentials**
-3. Click **+ Add Credentials**
-4. Enter a name (e.g., "terraform-dev-token")
-5. Select **API Token** from the dropdown
-6. Choose an expiry date
-7. Click **Generate**, then **Copy** the token value
+1. Open the F5 Distributed Cloud Console.
+2. Navigate to **Administration** → **Personal Management** → **Credentials**.
+3. Select **+ Add Credentials**.
+4. Enter a name (for example, `terraform-dev-token`).
+5. In the **Credential Type** list, select **API Token**.
+6. Choose an expiration date.
+7. Select **Generate**, and then copy the token value.
 
-!> **Warning:** Copy and save your token immediately. You cannot retrieve it after closing this dialog.
+~> **Warning:** Copy and store your token immediately. You cannot retrieve the token value after closing the dialog.
 
 #### Creating a P12 Certificate
 
-1. Navigate to **Administration** → **Personal Management** → **Credentials**
-2. Click **+ Add Credentials**
-3. Enter a name (e.g., "terraform-dev-cert")
-4. Select **API Certificate** from the dropdown
-5. Enter and confirm a password
-6. Select an expiry date
-7. Click **Download** to get the `.p12` file
+1. Navigate to **Administration** → **Personal Management** → **Credentials**.
+2. Select **+ Add Credentials**.
+3. Enter a name (for example, `terraform-dev-cert`).
+4. In the **Credential Type** list, select **API Certificate**.
+5. Enter and confirm a password.
+6. Select an expiration date.
+7. Select **Download** to save the `.p12` certificate file.
 
--> **Tip:** Store the P12 file securely and never commit it to version control.
+-> **Tip:** Store the P12 certificate securely and never commit it to version control.
 
 ### Service Credentials (IAM)
 
-Service credentials are managed through IAM and recommended for production. They can be scoped to specific roles and namespaces.
+Service credentials are managed through IAM and recommended for CI/CD pipelines and production automation. You can scope service credentials to specific roles and namespaces.
 
 #### Creating a Service API Token
 
-1. Navigate to **Administration** → **IAM** → **Service Credentials**
-2. Click **+ Add Service Credentials**
-3. Enter a name (e.g., "terraform-cicd-token")
-4. Select **API Token** from the dropdown
-5. Optionally assign roles and namespaces to limit scope
-6. Choose an expiry date
-7. Click **Generate**, then **Copy** the token value
+1. Navigate to **Administration** → **IAM** → **Service Credentials**.
+2. Select **+ Add Service Credentials**.
+3. Enter a name (for example, `terraform-cicd-token`).
+4. In the **Credential Type** list, select **API Token**.
+5. Assign roles and namespaces to restrict credential scope.
+6. Choose an expiration date.
+7. Select **Generate**, and then copy the token value.
 
 #### Creating a Service P12 Certificate
 
-1. Navigate to **Administration** → **IAM** → **Service Credentials**
-2. Click **+ Add Service Credentials**
-3. Enter a name
-4. Select **API Certificate** from the dropdown
-5. Optionally assign roles and namespaces
-6. Enter and confirm a password
-7. Select an expiry date
-8. Click **Download** to get the `.p12` file
+1. Navigate to **Administration** → **IAM** → **Service Credentials**.
+2. Select **+ Add Service Credentials**.
+3. Enter a name (for example, `terraform-cicd-cert`).
+4. In the **Credential Type** list, select **API Certificate**.
+5. Assign roles and namespaces to restrict scope.
+6. Enter and confirm a password.
+7. Select an expiration date.
+8. Select **Download** to save the `.p12` certificate file.
 
 ## Provider Configuration
 
@@ -88,8 +88,8 @@ API tokens provide bearer token authentication over TLS. This is the quickest wa
 **Using Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 **Using Provider Configuration:**
@@ -108,9 +108,9 @@ P12 certificates provide mutual TLS (mTLS) authentication, where both client and
 **Using Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/your-credentials.p12"
-export XCSH_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"  # pragma: allowlist secret
 ```
 
 **Using Provider Configuration:**
@@ -125,9 +125,9 @@ provider "xcsh" {
 
 ### Method 3: PEM Certificate Authentication (Derived from P12)
 
-PEM authentication uses separate certificate and private key files. Since F5XC only provides P12 certificates, you must extract PEM files using OpenSSL.
+PEM authentication uses separate certificate and private key files. Because F5 Distributed Cloud generates P12 certificates, you must extract PEM files using OpenSSL when required by external tooling.
 
-**When to use this method:** Only when your tooling specifically requires PEM format instead of P12.
+**When to use this method:** Use PEM authentication only when your tooling specifically requires PEM format rather than P12.
 
 **Step 1: Extract PEM files from P12:**
 
@@ -136,14 +136,14 @@ PEM authentication uses separate certificate and private key files. Since F5XC o
 mkdir -p certs
 
 # Extract the certificate
-openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
+openssl pkcs12 -in ~/<XC_TENANT>.console.ves.volterra.io.api-creds.p12 \
   -nodes -nokeys -out certs/xcsh.cert
-# Enter Import Password: <your p12 password>
+# Enter Import Password: <XC_P12_PASSWORD>
 
 # Extract the private key
-openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
+openssl pkcs12 -in ~/<XC_TENANT>.console.ves.volterra.io.api-creds.p12 \
   -nodes -nocerts -out certs/xcsh.key
-# Enter Import Password: <your p12 password>
+# Enter Import Password: <XC_P12_PASSWORD>
 ```
 
 **Step 2: Configure the provider:**
@@ -151,7 +151,7 @@ openssl pkcs12 -in ~/your-tenant.console.ves.volterra.io.api-creds.p12 \
 **Using Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
 export XCSH_CERT="/path/to/certs/xcsh.cert"
 export XCSH_KEY="/path/to/certs/xcsh.key"
 ```
@@ -166,13 +166,13 @@ provider "xcsh" {
 }
 ```
 
-~> **Note:** For server certificate verification, specify a CA certificate using `XCSH_CACERT` environment variable or `api_ca_cert` provider attribute.
+~> **Note:** For server certificate verification, specify a CA certificate using the `XCSH_CACERT` environment variable or the `api_ca_cert` provider attribute.
 
 ## Environment Variable Reference
 
 | Variable            | Description                                    | Required                       |
 | ------------------- | ---------------------------------------------- | ------------------------------ |
-| `XCSH_API_URL`      | F5XC tenant API URL                            | Yes                            |
+| `XCSH_API_URL`      | F5 Distributed Cloud tenant API URL            | Yes                            |
 | `XCSH_API_TOKEN`    | API token for bearer authentication            | One of: token, P12, or PEM     |
 | `XCSH_P12_FILE`     | Path to P12 certificate file                   | With `XCSH_P12_PASSWORD`       |
 | `XCSH_P12_PASSWORD` | Password for P12 file                          | With `XCSH_P12_FILE`           |
@@ -184,20 +184,20 @@ provider "xcsh" {
 
 ```bash
 # Add to ~/.bashrc or ~/.zshrc
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 Then reload: `source ~/.zshrc` or `source ~/.bashrc`
 
 ### Authentication Priority
 
-When multiple methods are configured, the provider uses this priority:
+When multiple authentication methods are configured, the provider evaluates them in this order:
 
-1. **P12 Certificate** - If `api_p12_file` is set (requires `p12_password`)
-2. **PEM Certificate** - If both `api_cert` and `api_key` are set
-3. **API Token** - If `api_token` is set
-4. **Error** - If none are provided
+1. **P12 Certificate** — Evaluated when `api_p12_file` is set (requires `p12_password`)
+2. **PEM Certificate** — Evaluated when both `api_cert` and `api_key` are set
+3. **API Token** — Evaluated when `api_token` is set
+4. **Error** — Returned when no valid credentials are provided
 
 ## CI/CD Integration
 
@@ -241,10 +241,10 @@ jobs:
 
 **GitHub Secrets to configure:**
 
-| Secret Name        | Value                                          |
-| ------------------ | ---------------------------------------------- |
-| `XCSH_API_URL`     | `https://your-tenant.console.ves.volterra.io`  |
-| `XCSH_API_TOKEN`   | Your API token value                           |
+| Secret Name        | Value                                         |
+| ------------------ | --------------------------------------------- |
+| `XCSH_API_URL`     | `https://<XC_TENANT>.console.ves.volterra.io` |
+| `XCSH_API_TOKEN`   | `<XC_API_TOKEN>`                              |
 
 ### GitHub Actions with P12 Certificate
 
@@ -298,26 +298,26 @@ jobs:
 
 ```bash
 # On macOS
-base64 -i your-credentials.p12 | pbcopy
+base64 -i credentials.p12 | pbcopy
 
 # On Linux
-base64 -w 0 your-credentials.p12
+base64 -w 0 credentials.p12
 ```
 
 **GitHub Secrets to configure:**
 
-| Secret Name         | Value                                          |
-| ------------------- | ---------------------------------------------- |
-| `XCSH_API_URL`      | `https://your-tenant.console.ves.volterra.io`  |
-| `XCSH_P12_BASE64`   | Base64-encoded P12 file contents               |
-| `XCSH_P12_PASSWORD` | Password for the P12 file                      |
+| Secret Name         | Value                                         |
+| ------------------- | --------------------------------------------- |
+| `XCSH_API_URL`      | `https://<XC_TENANT>.console.ves.volterra.io` |
+| `XCSH_P12_BASE64`   | Base64-encoded P12 file contents              |
+| `XCSH_P12_PASSWORD` | Password for the P12 file                     |
 
 ## Security Best Practices
 
-- **Never commit credentials** to version control. Add `*.tfvars`, `*.p12`, and `*.pem` to `.gitignore`
-- **Use environment variables** for sensitive values in local development
-- **Use GitHub Secrets** or equivalent for CI/CD pipelines
-- **Limit credential scope** using Service Credentials with specific roles and namespaces
+- **Never commit credentials** to version control. Add `*.tfvars`, `*.p12`, and `*.pem` to `.gitignore`.
+- **Use environment variables** for sensitive values in local development.
+- **Use secret managers or CI/CD secrets** for automated pipelines.
+- **Limit credential scope** using Service Credentials with specific roles and namespaces.
 
 ### Choosing the Right Method
 
@@ -331,58 +331,58 @@ base64 -w 0 your-credentials.p12
 
 ### Authentication Failed (401 Unauthorized)
 
-1. Verify API URL does **NOT** include `/api` suffix (e.g., `https://tenant.console.ves.volterra.io`)
-2. Check token hasn't expired
-3. Verify token copied correctly (no whitespace)
-4. Ensure environment variables are exported:
+1. Verify that the API URL does **not** include the `/api` suffix (for example, `https://<XC_TENANT>.console.ves.volterra.io`).
+2. Verify that the token has not expired.
+3. Verify that the token was copied without leading or trailing whitespace.
+4. Verify that the environment variables are exported:
 
 ```bash
-echo $XCSH_API_URL
-echo $XCSH_API_TOKEN
+echo "$XCSH_API_URL"
+echo "$XCSH_API_TOKEN"
 ```
 
 ### Certificate Verification Failed
 
-1. Verify P12 password is correct
-2. Check file path is absolute or correctly relative
-3. Test P12 file:
+1. Verify that the P12 password is correct.
+2. Verify that the file path is accessible and correctly referenced.
+3. Test the P12 file locally:
 
 ```bash
-openssl pkcs12 -in your-credentials.p12 -nokeys -info
+openssl pkcs12 -in credentials.p12 -nokeys -info
 ```
 
 ### Permission Denied (403 Forbidden)
 
-1. Verify credential has required permissions
-2. For Service Credentials, check role and namespace assignments
-3. Some operations require specific system roles
+1. Verify that the credential has required permissions for the target resources.
+2. For Service Credentials, check assigned roles and namespace access.
+3. Some operations require specific system roles (for example, tenant administration).
 
 ### Environment Variables Not Working
 
-1. Ensure variables are exported:
+1. Verify that variables are exported:
 
 ```bash
-export XCSH_API_TOKEN="token"  # Correct
-XCSH_API_TOKEN="token"         # Won't work
+export XCSH_API_TOKEN="<XC_API_TOKEN>"  # Correct
+XCSH_API_TOKEN="<XC_API_TOKEN>"         # Is not visible to child processes
 ```
 
-1. Verify spelling is exact (case-sensitive)
-2. Check for hidden characters in values
+2. Verify that variable names match the exact required casing (`XCSH_API_URL`, `XCSH_API_TOKEN`).
+3. Check for hidden or unexpected characters in variable values.
 
 ## Revoking Credentials
 
-1. Navigate to **Administration** → **Personal Management** → **Credentials** (or **IAM** → **Service Credentials**)
-2. Find the credential
-3. Click **Actions** (three dots) → **Force Expiry**
+1. Navigate to **Administration** → **Personal Management** → **Credentials** (or **IAM** → **Service Credentials**).
+2. Locate the credential to revoke.
+3. Select **Actions** (three dots) → **Force Expiry**.
 
 ## Next Steps
 
-- [HTTP Load Balancer Guide](http-loadbalancer.md) - Deploy your first load balancer
-- [Blindfold Functions Guide](blindfold.md) - Secure secret management
+- [HTTP Load Balancer Guide](http-loadbalancer.md) — Deploy your first load balancer
+- [Blindfold Functions Guide](blindfold.md) — Secure secret management
 
 ## Support
 
 - [Provider Documentation](../index.md)
-- [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
 - [F5 Credentials Guide](https://docs.cloud.f5.com/docs-v2/administration/how-tos/user-mgmt/Credentials)
 - [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)

--- a/templates/guides/blindfold.md
+++ b/templates/guides/blindfold.md
@@ -2,22 +2,22 @@
 page_title: "Guide: Blindfold Secret Management Functions"
 subcategory: "Guides"
 description: |-
-  Learn how to securely encrypt secrets using F5XC Blindfold functions.
+  Securely encrypt sensitive data using F5 Distributed Cloud Blindfold functions.
   Covers TLS certificates, cloud credentials, and container registry authentication.
 ---
 
 # Blindfold Secret Management Functions
 
-This guide walks you through using F5XC Blindfold functions to securely encrypt sensitive data. By the end, you'll understand how to:
+This guide explains how to use F5 Distributed Cloud Blindfold functions to encrypt sensitive data locally before transmitting it to the control plane. Topics covered include:
 
-- **Encrypt TLS private keys** - Secure certificate key storage
-- **Protect cloud credentials** - AWS, Azure, and GCP secrets
-- **Secure container registries** - Private image pull authentication
-- **Understand the security model** - Local encryption, never transmitted unencrypted
+- **Encrypt TLS private keys** — Configure certificate key storage
+- **Protect cloud credentials** — Secure AWS, Azure, and Google Cloud credentials
+- **Secure container registries** — Authenticate private container image pulls
+- **Understand the security model** — Apply client-side encryption without plaintext transmission
 
 ## Overview
 
-F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryption for sensitive data. The blindfold functions encrypt your secrets locally using RSA-OAEP with SHA-256, meaning **your plaintext secrets never leave your machine unencrypted**.
+F5 Distributed Cloud Secret Management (Blindfold) provides client-side encryption for sensitive data. The blindfold functions encrypt secrets locally using RSA-OAEP with SHA-256, ensuring that **plaintext secrets never leave your local environment unencrypted**.
 
 ### How It Works
 
@@ -32,7 +32,8 @@ F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryp
 │                      └────────┬─────────┘             │            │
 │                               │                       │            │
 │                      ┌────────▼─────────┐             │            │
-│                      │ F5XC Public Key  │             │            │
+│                      │ F5 Distributed   │             │            │
+│                      │ Cloud Public Key │             │            │
 │                      │ (fetched once)   │             │            │
 │                      └──────────────────┘             │            │
 └──────────────────────────────────────────────────────│────────────┘
@@ -47,39 +48,39 @@ F5 Distributed Cloud Secret Management ("blindfold") provides client-side encryp
 
 ### Security Properties
 
-- **Local encryption**: Secrets encrypted on your machine before transmission
-- **RSA-OAEP with SHA-256**: Industry-standard encryption algorithm
-- **Policy-controlled decryption**: Only authorized F5XC services can decrypt
-- **No plaintext storage**: F5XC never receives or stores plaintext secrets
+- **Local encryption**: Secrets are encrypted on your local machine before transmission.
+- **RSA-OAEP with SHA-256**: Industry-standard asymmetric encryption.
+- **Policy-controlled decryption**: Only authorized F5 Distributed Cloud services can decrypt the payload.
+- **No plaintext storage**: The control plane never receives or stores plaintext secrets.
 
 ## Prerequisites
 
 Before you begin, ensure you have:
 
-- **Terraform >= 1.8** - Provider-defined functions require Terraform 1.8 or later
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
-- **API Credentials** - Token or P12 certificate authentication configured
+- **Terraform >= 1.8** — Provider-defined functions require Terraform 1.8 or later (download from <https://www.terraform.io/downloads>)
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication (see the [Authentication Guide](authentication.md))
 
 ### Authentication Setup
 
-Configure one of these authentication methods via environment variables:
+Configure one of these authentication methods using environment variables:
 
 #### Option 1: API Token (Recommended for development)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 #### Option 2: P12 Certificate (Recommended for production)
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/your-credentials.p12"
-export XCSH_P12_PASSWORD="your-p12-password"  # pragma: allowlist secret
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"  # pragma: allowlist secret
 ```
 
--> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
+-> **Tip:** Add these variables to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
 
 ## Quick Start
 
@@ -187,13 +188,13 @@ location = provider::xcsh::blindfold_file(
 
 ### Built-in SecretPolicy
 
-Every F5XC tenant includes a default policy: `ves-io-allow-volterra` in the `shared` namespace. This policy allows Volterra (F5XC) services to decrypt secrets.
+Every F5 Distributed Cloud tenant includes a default policy: `ves-io-allow-volterra` in the `shared` namespace. This policy allows F5 Distributed Cloud platform services to decrypt secrets.
 
 ## Use Cases
 
 ### TLS Certificate Private Key
 
-Store TLS certificates for load balancers. Note that TLS private keys are typically too large (>1000 bytes) for direct blindfold encryption (~190 byte limit). Use `clear_secret_info` for TLS keys:
+Store TLS certificates for load balancers. Note that RSA TLS private keys are typically too large (>1000 bytes) for direct asymmetric blindfold encryption (~190 byte limit). Use `clear_secret_info` for TLS keys:
 
 ```hcl
 resource "xcsh_certificate" "example" {
@@ -202,8 +203,8 @@ resource "xcsh_certificate" "example" {
 
   certificate_url = "string:///${base64encode(file("${path.module}/certs/server.crt"))}"
 
-  # TLS private keys are too large for blindfold encryption
-  # Use clear_secret_info - the key is transmitted securely over HTTPS
+  # TLS private keys exceed the RSA-OAEP direct encryption size limit
+  # Use clear_secret_info — the key is transmitted securely over HTTPS (TLS)
   private_key {
     clear_secret_info {
       url = "string:///${base64encode(file("${path.module}/certs/server.key"))}"
@@ -214,7 +215,7 @@ resource "xcsh_certificate" "example" {
 }
 ```
 
-~> **Size Limitation:** Blindfold encryption uses RSA-OAEP which limits plaintext to ~190 bytes. TLS private keys exceed this limit. Use `clear_secret_info` for certificates - the data is transmitted securely over HTTPS. For secrets under 190 bytes (API keys, passwords), use blindfold functions as shown below.
+~> **Size Limitation:** Direct Blindfold encryption uses RSA-OAEP which limits plaintext to ~190 bytes for 2048-bit keys. TLS private keys exceed this limit. Use `clear_secret_info` for certificates — the payload is encrypted in transit over HTTPS. For secrets under 190 bytes (such as API keys, passwords, and client tokens), use the `blindfold()` function as shown below.
 
 ### AWS Cloud Credentials
 
@@ -369,7 +370,7 @@ RSA-OAEP encryption has a maximum plaintext size based on the key size:
 | 2048-bit | ~190 bytes        |
 | 4096-bit | ~446 bytes        |
 
-~> **Note:** If your secret exceeds the size limit, consider splitting it or using a different approach. The function will return a clear error message if the plaintext is too large.
+~> **Note:** If your secret exceeds the size limit, consider splitting it or using an alternative approach. The function returns an error message if the plaintext exceeds the maximum allowed size.
 
 ### Output Format
 
@@ -385,7 +386,7 @@ When base64-decoded, the sealed JSON contains these fields:
 {
   "key_version": "v1.2.3",
   "policy_id": "shared/ves-io-allow-volterra",
-  "tenant": "example-corp",
+  "tenant": "<XC_TENANT>",
   "data": "ABCDEF1234567890..."
 }
 ```
@@ -393,99 +394,102 @@ When base64-decoded, the sealed JSON contains these fields:
 Field descriptions:
 
 - `key_version`: Public key version used for encryption
-- `policy_id`: Reference to the SecretPolicy (namespace/name format)
-- `tenant`: example-corp
-- `data`: base64-encoded RSA-OAEP ciphertext
+- `policy_id`: Reference to the SecretPolicy (`namespace/name` format)
+- `tenant`: F5 Distributed Cloud tenant identifier
+- `data`: Base64-encoded RSA-OAEP ciphertext
 
 ### Function Behavior
 
-- **Idempotent**: Same input produces different output (due to random padding)
-- **Network required**: Functions fetch the public key from F5XC API
-- **Caching**: Public keys are cached for the Terraform run
+- **Non-deterministic output**: The same plaintext generates different ciphertext on each run due to randomized OAEP padding.
+- **Network access required**: Functions fetch the active public key from the F5 Distributed Cloud API.
+- **In-memory caching**: Public keys are cached for the duration of the Terraform execution.
 
 ## Troubleshooting
 
 ### Authentication Configuration Error
 
-**Symptom:** Error message about missing authentication configuration.
+**Symptom:** Error message indicates missing or invalid authentication credentials.
 
 **Solution:**
 
 ```bash
 # Verify environment variables are set
-echo $XCSH_API_URL
-echo $XCSH_API_TOKEN  # or XCSH_P12_FILE
+echo "$XCSH_API_URL"
+echo "$XCSH_API_TOKEN"  # or XCSH_P12_FILE
 
 # Set them if missing
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 ### Policy Not Found
 
-**Symptom:** Error about secret policy not found.
+**Symptom:** Error indicating that the specified SecretPolicy was not found.
 
 **Solutions:**
 
-1. Use the built-in policy:
+1. Use the built-in default policy:
 
    ```hcl
    policy_name = "ves-io-allow-volterra"
    namespace   = "shared"
    ```
 
-2. Verify your custom policy exists in F5XC Console
+2. Verify that any custom SecretPolicy exists in the specified namespace in the F5 Distributed Cloud Console.
 
 ### Plaintext Too Large
 
-**Symptom:** Error indicating plaintext exceeds maximum size.
+**Symptom:** Error indicates that the plaintext exceeds the maximum allowed size for RSA-OAEP encryption.
 
 **Solutions:**
 
-1. Verify your secret size:
+1. Check your secret payload size:
 
    ```bash
    wc -c < your-secret-file
    ```
 
-2. For large files (like some GCP credentials), consider:
-   - Extracting only the private key portion
-   - Using F5XC's external secret management integration
+2. For larger files (such as GCP credentials or TLS private keys):
+   - Extract only the private key or secret token portion
+   - Use `clear_secret_info` with TLS in transit
 
 ### File Not Found
 
-**Symptom:** Error about file not found when using `blindfold_file()`.
+**Symptom:** Error indicating file not found when calling `blindfold_file()`.
 
 **Solutions:**
 
-1. Use `${path.module}` for relative paths:
+1. Use `${path.module}` for relative file paths:
 
    ```hcl
    location = provider::xcsh::blindfold_file(
-     "${path.module}/certs/server.key",  # Correct
-     ...
+     "${path.module}/certs/server.key",
+     "ves-io-allow-volterra",
+     "shared"
    )
    ```
 
-2. Verify the file exists and is readable
+2. Verify that the file exists and has appropriate read permissions.
 
-### Invalid base64
+### Invalid Base64 Encoding
 
-**Symptom:** Error about invalid base64 encoding.
+**Symptom:** Error indicating invalid base64 encoding.
 
-**Solution:** Ensure you're base64-encoding your plaintext:
+**Solution:** Ensure you base64-encode plaintext strings before passing them to `blindfold()`:
 
 ```hcl
 # Correct
 location = provider::xcsh::blindfold(
-  base64encode(var.secret),  # base64encode() wraps the secret
-  ...
+  base64encode(var.secret),
+  "ves-io-allow-volterra",
+  "shared"
 )
 
 # Incorrect
 location = provider::xcsh::blindfold(
-  var.secret,  # Raw secret will fail
-  ...
+  var.secret,  # Raw plaintext string fails
+  "ves-io-allow-volterra",
+  "shared"
 )
 ```
 
@@ -497,23 +501,21 @@ To remove all resources created by this guide:
 terraform destroy
 ```
 
-Type `yes` to confirm destruction.
+Type `yes` when prompted to confirm resource destruction.
 
-!> **Warning:** This will immediately remove all created resources. Ensure you have backups of any certificates or credentials you need.
+~> **Warning:** This command immediately destroys all managed resources in the plan. Ensure you have backups of any certificates or credentials before proceeding.
 
 ## Next Steps
 
-Now that you understand blindfold encryption, explore related resources:
-
-- [Certificate Resource](../resources/certificate.md) - Full certificate management
-- [Cloud Credentials Resource](../resources/cloud_credentials.md) - Cloud provider authentication
-- [HTTP Load Balancer Guide](./http-loadbalancer.md) - Use certificates in load balancers
-- [blindfold Function Reference](../functions/blindfold.md) - Function API details
-- [blindfold_file Function Reference](../functions/blindfold_file.md) - Function API details
+- [Certificate Resource](../resources/certificate.md) — Full certificate management
+- [Cloud Credentials Resource](../resources/cloud_credentials.md) — Cloud provider authentication
+- [HTTP Load Balancer Guide](./http-loadbalancer.md) — Use certificates in load balancers
+- [blindfold Function Reference](../functions/blindfold.md) — Function API details
+- [blindfold_file Function Reference](../functions/blindfold_file.md) — Function API details
 
 ## Support
 
-- **Provider Documentation:** [F5XC Provider](../index.md)
-- **F5 Documentation:** [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
-- **Secret Management:** [F5XC Secret Management](https://docs.cloud.f5.com/docs/how-to/secrets-management)
-- **Issues:** [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)
+- [Provider Documentation](../index.md)
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
+- [F5 Secret Management](https://docs.cloud.f5.com/docs/how-to/secrets-management)
+- [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)

--- a/templates/guides/http-loadbalancer.md
+++ b/templates/guides/http-loadbalancer.md
@@ -8,15 +8,15 @@ description: |-
 
 # HTTP Load Balancer with Security Features
 
-This guide walks you through deploying a complete HTTP Load Balancer on F5 Distributed Cloud. By the end, you'll have a production-ready load balancer with:
+This guide explains how to deploy a complete HTTP Load Balancer on F5 Distributed Cloud with the following security features:
 
-- **Web Application Firewall (WAF)** - Blocks common web attacks (SQLi, XSS, etc.)
-- **Bot Defense** - Protects against automated attacks and scrapers
-- **Rate Limiting** - Prevents abuse by limiting requests per client
-- **JavaScript Challenge** - Client-side bot detection
-- **Automatic TLS Certificates** - HTTPS with auto-renewal
-- **Health Monitoring** - Active health checks on origin servers
-- **Threat Mesh** - Global threat intelligence sharing
+- **Web Application Firewall (WAF)** — Blocks common web attacks (SQL injection, XSS, and command injection)
+- **Bot Defense** — Protects against automated attacks and scrapers
+- **Rate Limiting** — Prevents abuse by limiting requests per client IP
+- **JavaScript Challenge** — Validates client browsers and detects automation
+- **Automatic TLS Certificates** — Automates HTTPS provisioning and renewal
+- **Health Monitoring** — Actively tests origin server health
+- **Threat Mesh** — Integrates global threat intelligence telemetry
 
 For a minimal copy-paste example, see the [Httpbin Minimal Guide](httpbin-minimal.md).
 
@@ -24,11 +24,11 @@ For a minimal copy-paste example, see the [Httpbin Minimal Guide](httpbin-minima
 
 Before you begin, ensure you have:
 
-- **F5 Distributed Cloud Account** - Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console> if you don't have one
-- **API Token** - Generate credentials from the F5XC Console at <https://docs.cloud.f5.com/docs/how-to/user-mgmt/credentials>
-- **Terraform >= 1.8** - Download and install from <https://www.terraform.io/downloads>
-- **A Domain** - Domain you control for DNS configuration
-- **Backend Origin Server** - Your application server accessible from the internet
+- **Terraform >= 1.0** — Download and install from <https://www.terraform.io/downloads>
+- **F5 Distributed Cloud Account** — Sign up at <https://www.f5.com/cloud/products/distributed-cloud-console>
+- **API Credentials** — Configure API token or P12 certificate authentication (see the [Authentication Guide](authentication.md))
+- **A Domain** — Domain you control for DNS delegation or CNAME routing
+- **Backend Origin Server** — Application server accessible by F5 Distributed Cloud Regional Edges
 
 ## Quick Start
 
@@ -44,11 +44,11 @@ cd terraform-provider-xcsh/examples/guides/http-loadbalancer
 Configure authentication using environment variables. **Never commit credentials to version control.**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
--> **Tip:** Add these to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
+-> **Tip:** Add these variables to your shell profile (`~/.bashrc` or `~/.zshrc`) for persistence across terminal sessions.
 
 ### Step 3: Configure Your Deployment
 
@@ -85,23 +85,23 @@ terraform plan
 terraform apply
 ```
 
-Review the plan output, then type `yes` to confirm deployment.
+Review the plan output, and then type `yes` when prompted to confirm deployment.
 
 ### Step 5: Configure DNS
 
-After deployment, Terraform outputs a CNAME target. Create a DNS record:
+After deployment, Terraform outputs a CNAME target. Create a DNS record with your DNS provider:
 
-| Type  | Name            | Value                                |
-| ----- | --------------- | ------------------------------------ |
-| CNAME | app.example.com | ves-io-app-example-com.ac.vh.ves.io  |
+| Type  | Name              | Value                                |
+| ----- | ----------------- | ------------------------------------ |
+| CNAME | `app.example.com` | `ves-io-app-example-com.ac.vh.ves.io` |
 
-~> **Note:** DNS propagation may take up to 48 hours, though typically completes within minutes.
+~> **Note:** DNS propagation time varies by provider and typically completes within a few minutes.
 
 ### Step 6: Verify
 
-1. **Wait for TLS provisioning** - Auto-cert typically provisions within 5 minutes
-2. **Access your application** - Navigate to `https://your-domain.com`
-3. **Check the console** - View traffic and security events in F5 Distributed Cloud Console
+1. **Wait for TLS provisioning** — Automatic certificate provisioning typically completes within 5 minutes.
+2. **Access your application** — Navigate to `https://app.example.com` in your browser.
+3. **Inspect telemetry** — View traffic and security events in the F5 Distributed Cloud Console.
 
 ## Configuration Options
 
@@ -204,49 +204,49 @@ This guide creates the following resources:
 
 **Solutions:**
 
-1. Verify DNS CNAME is correctly configured
-2. Wait up to 10 minutes for certificate provisioning
-3. Check the Load Balancer status in F5XC Console
+1. Verify that the DNS CNAME record is correctly configured with your DNS provider.
+2. Wait up to 10 minutes for automated certificate provisioning and challenge completion.
+3. Check the load balancer status in the F5 Distributed Cloud Console.
 
 ### 502 Bad Gateway
 
-**Symptom:** Load balancer returns 502 errors.
+**Symptom:** Load balancer returns HTTP 502 Bad Gateway errors.
 
 **Solutions:**
 
-1. Verify `origin_server` is accessible from the internet
-2. Check health check path returns HTTP 200
-3. Verify origin port is correct
-4. Check origin server TLS configuration
+1. Verify that `origin_server` is reachable by F5 Distributed Cloud Regional Edges.
+2. Verify that the health check endpoint returns HTTP 200.
+3. Verify that the origin port matches the backend service configuration.
+4. Check backend TLS settings if using HTTPS to origin.
 
 ### WAF Blocking Legitimate Traffic
 
-**Symptom:** Valid requests are blocked by WAF.
+**Symptom:** Valid requests are blocked by the Web Application Firewall.
 
 **Solutions:**
 
-1. Check Security Analytics in F5XC Console
-2. Review blocked request details
-3. Consider temporarily setting WAF to monitoring mode:
+1. Inspect Security Analytics in the F5 Distributed Cloud Console.
+2. Review the triggered signature and rule IDs.
+3. Temporarily configure WAF in monitoring mode during initial testing:
 
    ```hcl
-   enable_waf = false  # Disable in Terraform
+   enable_waf = false  # Disable or switch to monitoring
    ```
 
 ### Rate Limiting Too Aggressive
 
-**Symptom:** Users hitting rate limits during normal usage.
+**Symptom:** Users encounter rate limit errors during normal usage.
 
 **Solutions:**
 
-1. Increase the rate limit:
+1. Increase the rate limit threshold:
 
    ```hcl
    rate_limit_requests = 500
    ```
 
-2. Review rate limiting events in the console
-3. Consider user identification beyond IP address
+2. Inspect rate limiting telemetry in the console.
+3. Consider scoping rate limits to specific paths or user identifiers.
 
 ## Clean Up
 
@@ -256,21 +256,19 @@ To remove all resources created by this guide:
 terraform destroy
 ```
 
-Type `yes` to confirm destruction.
+Type `yes` when prompted to confirm resource destruction.
 
-!> **Warning:** This will immediately remove the load balancer and all associated resources. Traffic to your domain will no longer be handled by F5XC.
+~> **Warning:** This command immediately destroys the load balancer and all associated resources. Traffic to your domain is no longer handled by F5 Distributed Cloud.
 
 ## Next Steps
 
-Now that you have a basic HTTP Load Balancer deployed, consider exploring:
-
-- [Origin Pool Resource](../resources/origin_pool.md) - Add multiple origins for redundancy
-- [App Firewall Resource](../resources/app_firewall.md) - Customize WAF rules
-- [Service Policy Resource](../resources/service_policy.md) - Add custom access control
-- [TCP Load Balancer Resource](../resources/tcp_loadbalancer.md) - For non-HTTP applications
+- [Origin Pool Resource](../resources/origin_pool.md) — Add multiple origins for high availability
+- [App Firewall Resource](../resources/app_firewall.md) — Customize WAF rules and signatures
+- [Service Policy Resource](../resources/service_policy.md) — Configure custom access control policies
+- [TCP Load Balancer Resource](../resources/tcp_loadbalancer.md) — Load balance non-HTTP TCP traffic
 
 ## Support
 
-- **Provider Documentation:** [F5XC Provider](../index.md)
-- **F5 Documentation:** [F5 Distributed Cloud Docs](https://docs.cloud.f5.com/)
-- **Issues:** [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)
+- [Provider Documentation](../index.md)
+- [F5 Distributed Cloud Documentation](https://docs.cloud.f5.com/)
+- [GitHub Issues](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues)

--- a/templates/guides/http-loadbalancer.md
+++ b/templates/guides/http-loadbalancer.md
@@ -91,9 +91,9 @@ Review the plan output, and then type `yes` when prompted to confirm deployment.
 
 After deployment, Terraform outputs a CNAME target. Create a DNS record with your DNS provider:
 
-| Type  | Name              | Value                                |
-| ----- | ----------------- | ------------------------------------ |
-| CNAME | `app.example.com` | `ves-io-app-example-com.ac.vh.ves.io` |
+| Type  | Name              | Value                                  |
+| ----- | ----------------- | -------------------------------------- |
+| CNAME | `app.example.com` | `ves-io-app-example-com.ac.vh.ves.io`  |
 
 ~> **Note:** DNS propagation time varies by provider and typically completes within a few minutes.
 

--- a/templates/guides/httpbin-minimal.md
+++ b/templates/guides/httpbin-minimal.md
@@ -19,9 +19,9 @@ A complete, validated Terraform configuration that deploys four resources:
 
 Copy this entire block into a `main.tf` file. Set `XCSH_API_URL` and `XCSH_API_TOKEN` environment variables, then run `terraform init && terraform apply`.
 
-~> **Important:** Replace `your-namespace` with your actual F5 XC namespace.
+~> **Important:** Replace `demo-app` with your target F5 Distributed Cloud namespace.
 
-```terraform
+```hcl
 terraform {
   required_version = ">= 1.0"
 
@@ -154,4 +154,4 @@ This configuration relies on server-applied defaults for fields you don't need t
 - **Challenge:** `no_challenge` (server default)
 - **API features:** `disable_api_definition`, `disable_api_discovery`, `disable_api_testing` (server defaults)
 
-To enable any of these features, add them explicitly. See the [full HTTP Load Balancer guide](http-loadbalancer.md) for production configurations.
+To enable any of these features, configure them explicitly in your resource block. For production configurations, see the [HTTP Load Balancer Guide](http-loadbalancer.md).

--- a/templates/guides/index.md
+++ b/templates/guides/index.md
@@ -1,14 +1,15 @@
 # Guides
 
-Step-by-step tutorials for common F5 Distributed Cloud scenarios.
+Step-by-step tutorials for common F5 Distributed Cloud scenarios and architecture patterns.
 
 ## Available Guides
 
-- [HTTP Load Balancer](http-loadbalancer.md) - Deploy a basic HTTP Load Balancer
-- [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) - Production-ready security features
-- [Authentication](authentication.md) - Configure provider authentication
-- [Blindfold Encryption](blindfold.md) - Secure secret management
-- [Addon Service Activation](addon-activation.md) - Activate and manage addon services
+- [HTTP Load Balancer](http-loadbalancer.md) — Deploy a production-ready HTTP load balancer with WAF, bot defense, and rate limiting
+- [Httpbin Minimal](httpbin-minimal.md) — Copy-paste minimal HTTP load balancer deployment pointing to httpbin.org
+- [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) — Multi-layered defense-in-depth with custom rules, IP allowlists, and deep inspection
+- [Authentication](authentication.md) — Configure API tokens, P12 certificates, and PEM authentication for local and CI/CD environments
+- [Blindfold Encryption](blindfold.md) — Client-side secret encryption using RSA-OAEP for cloud credentials and certificates
+- [Addon Service Activation](addon-activation.md) — Activate and manage tenant addon services with life-cycle management
 
 ## Related Documentation
 

--- a/templates/guides/index.md
+++ b/templates/guides/index.md
@@ -9,7 +9,7 @@ Step-by-step tutorials for common F5 Distributed Cloud scenarios and architectur
 - [Advanced HTTP Load Balancer Security](advanced-http-loadbalancer.md) — Multi-layered defense-in-depth with custom rules, IP allowlists, and deep inspection
 - [Authentication](authentication.md) — Configure API tokens, P12 certificates, and PEM authentication for local and CI/CD environments
 - [Blindfold Encryption](blindfold.md) — Client-side secret encryption using RSA-OAEP for cloud credentials and certificates
-- [Addon Service Activation](addon-activation.md) — Activate and manage tenant addon services with life-cycle management
+- [Addon Service Activation](addon-activation.md) — Activate and manage tenant addon services with lifecycle management
 
 ## Related Documentation
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,12 +1,12 @@
 ---
 page_title: "XCSH Provider"
 description: |-
-  Terraform provider for F5 Distributed Cloud (F5XC) enabling infrastructure as code for load balancers, security policies, sites, and networking. Community-maintained provider built from public F5 API documentation.
+  Terraform provider for F5 Distributed Cloud enabling infrastructure as code for load balancers, security policies, sites, and networking. Community-maintained provider built from public F5 API documentation.
 ---
 
 # XCSH Provider
 
-The XCSH Terraform provider enables infrastructure as code management for F5 Distributed Cloud (F5XC) resources. Configure HTTP/TCP load balancers, origin pools, application firewalls, service policies, cloud sites, and more through declarative Terraform configurations.
+The XCSH Terraform provider enables infrastructure as code management for F5 Distributed Cloud resources. Configure HTTP/TCP load balancers, origin pools, application firewalls, service policies, cloud sites, and networking through declarative Terraform configurations.
 
 This is a community-maintained provider built from public F5 API documentation.
 
@@ -16,17 +16,17 @@ This is a community-maintained provider built from public F5 API documentation.
 |-----------|---------|
 | terraform | >= 1.8  |
 
--> **Note:** This provider uses provider-defined functions which require Terraform 1.8 or later. For details, see the [Functions](/docs/functions) documentation.
+~> **Note:** This provider uses provider-defined functions which require Terraform 1.8 or later. For details, see the [Functions](/docs/functions) documentation.
 
 ## Authenticating to F5 Distributed Cloud
 
 The XCSH Terraform provider supports multiple authentication methods:
 
-1. **API Token** - Simplest method using a personal API token
-2. **P12 Certificate** - Certificate-based authentication using PKCS#12 bundle
-3. **PEM Certificate** - Certificate-based authentication using separate cert/key files
+1. **API Token** — Token-based bearer authentication
+2. **P12 Certificate** — Mutual TLS authentication using a PKCS#12 bundle (recommended for production)
+3. **PEM Certificate** — Certificate-based authentication using separate PEM certificate and private key files
 
-Learn more about [how to generate API credentials](https://docs.cloud.f5.com/docs/how-to/user-mgmt/credentials).
+For more information, see the [F5 Distributed Cloud Credentials Guide](https://docs.cloud.f5.com/docs-v2/administration/how-tos/user-mgmt/Credentials).
 
 ## Example Usage
 
@@ -36,31 +36,31 @@ Learn more about [how to generate API credentials](https://docs.cloud.f5.com/doc
 
 ### Required (one of the following authentication methods)
 
-* `api_token` - F5 Distributed Cloud API Token (`String`, Sensitive). Can also be set via `XCSH_API_TOKEN` environment variable.
+* `api_token` — F5 Distributed Cloud API token (`String`, Sensitive). Can also be set with the `XCSH_API_TOKEN` environment variable.
 
-* `api_p12_file` - Path to PKCS#12 certificate bundle file (`String`). Can also be set via `XCSH_P12_FILE` environment variable. Requires `p12_password`.
+* `api_p12_file` — Path to a PKCS#12 certificate bundle file (`String`). Can also be set with the `XCSH_P12_FILE` environment variable. Requires `p12_password`.
 
-* `api_cert` and `api_key` - Paths to PEM-encoded certificate and private key files (`String`). Can also be set via `XCSH_CERT` and `XCSH_KEY` environment variables.
+* `api_cert` and `api_key` — Paths to PEM-encoded certificate and private key files (`String`). Can also be set with the `XCSH_CERT` and `XCSH_KEY` environment variables.
 
 ### Optional
 
-* `api_url` - F5 Distributed Cloud API URL (`String`). Base URL **without** `/api` suffix. Required. No default. Set to your tenant URL (e.g., `https://your-tenant.console.ves.volterra.io`). Can also be set via `XCSH_API_URL` environment variable.
+* `api_url` — F5 Distributed Cloud API URL (`String`). Base URL **without** `/api` suffix. Required. No default. Set to your tenant URL (for example, `https://<XC_TENANT>.console.ves.volterra.io`). Can also be set with the `XCSH_API_URL` environment variable.
 
-* `p12_password` - Password for PKCS#12 certificate bundle (`String`, Sensitive). Required when using `api_p12_file`. Can also be set via `XCSH_P12_PASSWORD` environment variable.
+* `p12_password` — Password for the PKCS#12 certificate bundle (`String`, Sensitive). Required when using `api_p12_file`. Can also be set with the `XCSH_P12_PASSWORD` environment variable.
 
-* `api_ca_cert` - Path to PEM-encoded CA certificate file (`String`). Optional, used for server certificate verification. Can also be set via `XCSH_CACERT` environment variable.
+* `api_ca_cert` — Path to a PEM-encoded CA certificate file (`String`). Optional, used for server certificate verification. Can also be set with the `XCSH_CACERT` environment variable.
 
 ## Authentication Options
 
 ### Option 1: API Token Authentication
 
-The simplest authentication method using a personal API token.
+The simplest authentication method using an API token.
 
 **Provider Configuration:**
 
 ```hcl
 provider "xcsh" {
-  api_url   = "https://your-tenant.console.ves.volterra.io"
+  api_url   = "https://<XC_TENANT>.console.ves.volterra.io"
   api_token = var.xcsh_api_token
 }
 ```
@@ -68,8 +68,8 @@ provider "xcsh" {
 **Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_API_TOKEN="your-api-token"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_API_TOKEN="<XC_API_TOKEN>"
 ```
 
 ### Option 2: P12 Certificate Authentication
@@ -80,8 +80,8 @@ Certificate-based authentication using a PKCS#12 bundle downloaded from F5 Distr
 
 ```hcl
 provider "xcsh" {
-  api_url      = "https://your-tenant.console.ves.volterra.io"
-  api_p12_file = "/path/to/certificate.p12"
+  api_url      = "https://<XC_TENANT>.console.ves.volterra.io"
+  api_p12_file = "/path/to/credentials.p12"
   p12_password = var.xcsh_p12_password
 }
 ```
@@ -89,20 +89,20 @@ provider "xcsh" {
 **Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
-export XCSH_P12_FILE="/path/to/certificate.p12"
-export XCSH_P12_PASSWORD="your-p12-password"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
+export XCSH_P12_FILE="/path/to/credentials.p12"
+export XCSH_P12_PASSWORD="<XC_P12_PASSWORD>"
 ```
 
 ### Option 3: PEM Certificate Authentication
 
-Certificate-based authentication using separate PEM-encoded certificate and key files.
+Certificate-based authentication using separate PEM-encoded certificate and private key files.
 
 **Provider Configuration:**
 
 ```hcl
 provider "xcsh" {
-  api_url     = "https://your-tenant.console.ves.volterra.io"
+  api_url     = "https://<XC_TENANT>.console.ves.volterra.io"
   api_cert    = "/path/to/certificate.crt"
   api_key     = "/path/to/private.key"
   api_ca_cert = "/path/to/ca-certificate.crt"  # Optional
@@ -112,21 +112,21 @@ provider "xcsh" {
 **Environment Variables:**
 
 ```bash
-export XCSH_API_URL="https://your-tenant.console.ves.volterra.io"
+export XCSH_API_URL="https://<XC_TENANT>.console.ves.volterra.io"
 export XCSH_CERT="/path/to/certificate.crt"
 export XCSH_KEY="/path/to/private.key"
 export XCSH_CACERT="/path/to/ca-certificate.crt"  # Optional
 ```
 
--> **Note:** Environment variables are the recommended approach for CI/CD pipelines and to avoid storing sensitive credentials in version control.
+~> **Note:** Environment variables are the recommended approach for automated CI/CD pipelines to avoid storing sensitive credentials in version control.
 
 ## Getting Started
 
-1. **Generate API Credentials**: Navigate to your F5 Distributed Cloud console, go to **Administration** > **Personal Management** > **Credentials**, and create either an API Token or download a certificate bundle.
+1. **Generate API Credentials**: In the F5 Distributed Cloud Console, navigate to **Administration** → **Personal Management** → **Credentials**, and create an API Token or download a certificate bundle.
 
-2. **Configure the Provider**: Add the provider configuration to your Terraform files using one of the authentication options above.
+2. **Configure the Provider**: Add the provider configuration block to your Terraform root module using one of the authentication options above.
 
-3. **Create Resources**: Start managing XCSH resources like namespaces, load balancers, and origin pools.
+3. **Create Resources**: Manage F5 Distributed Cloud resources such as namespaces, load balancers, and origin pools.
 
 ### Example: Create a Namespace
 

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> **Note** For more information about this resource, please refer to the [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api/).
+~> **Note:** For more information, see the [F5 Distributed Cloud API documentation](https://docs.cloud.f5.com/docs/api/).
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ description: |-
 {{ end }}
 {{ else }}
 
-```terraform
+```hcl
 resource "{{ .Name }}" "example" {
   name      = "example"
   namespace = "system"
@@ -38,7 +38,7 @@ resource "{{ .Name }}" "example" {
 
 Import is supported using the following syntax:
 
-```shell
+```bash
 # Import using namespace/name format
 terraform import {{ .Name }}.example system/example
 ```

--- a/tools/generate-llms-txt.go
+++ b/tools/generate-llms-txt.go
@@ -988,8 +988,12 @@ func generateL0(config *LLMsConfig, categories []CategoryInfo) error {
 	// Guides
 	sb.WriteString("## Guides\n\n")
 	guides := []struct{ name, desc string }{
-		{"authentication", "API token, P12 certificate, and PEM auth methods"},
-		{"http-loadbalancer", "Deploy production load balancers with security"},
+		{"addon-activation", "Activate and manage F5 Distributed Cloud addon services"},
+		{"advanced-http-loadbalancer", "Deploy HTTP load balancers with WAF, bot defense, and security controls"},
+		{"authentication", "Configure API token, P12 certificate, and PEM certificate authentication"},
+		{"blindfold", "Encrypt secrets locally with public key encryption"},
+		{"http-loadbalancer", "Deploy HTTP load balancers with origin pools and health checks"},
+		{"httpbin-minimal", "Deploy a minimal HTTP load balancer with httpbin backend"},
 	}
 	for _, g := range guides {
 		sb.WriteString(fmt.Sprintf("- [%s](guides/%s) : %s\n", g.name, g.name, g.desc))

--- a/tools/pkg/codegen/templates.go
+++ b/tools/pkg/codegen/templates.go
@@ -275,7 +275,7 @@ func (r *{{.TitleCase}}Resource) ModifyPlan(ctx context.Context, req resource.Mo
 	if req.Plan.Raw.IsNull() {
 		resp.Diagnostics.AddWarning(
 			"Resource Destruction",
-			"This will permanently delete the {{.Name}} from F5 Distributed Cloud.",
+			"This permanently deletes the {{.Name}} from F5 Distributed Cloud.",
 		)
 		return
 	}

--- a/tools/pkg/description/description.go
+++ b/tools/pkg/description/description.go
@@ -240,6 +240,7 @@ func TransformResourceDescription(resourceName, rawDescription string) string {
 					remainder := desc[len(verb):]
 					remainder = strings.TrimPrefix(remainder, "s") // handle "Creates" -> "Create"
 					remainder = strings.TrimSpace(remainder)
+					remainder = strings.TrimSuffix(remainder, ".")
 					if remainder != "" {
 						// Clean up articles
 						remainder = strings.TrimPrefix(remainder, "a ")
@@ -261,7 +262,11 @@ func TransformResourceDescription(resourceName, rawDescription string) string {
 					if capability != "" {
 						humanDesc = fmt.Sprintf("Manages a %s resource in F5 Distributed Cloud for %s.", humanName, capability)
 					} else {
-						humanDesc = fmt.Sprintf("Manages a %s resource in F5 Distributed Cloud. %s", humanName, desc)
+						cleanDesc := desc
+						if !strings.HasSuffix(cleanDesc, ".") {
+							cleanDesc += "."
+						}
+						humanDesc = fmt.Sprintf("Manages a %s resource in F5 Distributed Cloud. %s", humanName, cleanDesc)
 					}
 				} else {
 					// If description already looks good, just ensure it ends properly
@@ -292,31 +297,31 @@ func GenerateCapabilityDescriptionOnly(resourceName, humanName, rawDesc string) 
 	// Resource-specific capability mappings for common F5 XC resources
 	capabilities := map[string]string{
 		// Sites
-		"securemesh_site":    "deploying secure mesh edge sites with distributed security capabilities",
-		"securemesh_site_v2": "deploying secure mesh edge sites with enhanced security and networking features",
+		"securemesh_site":    "deploying secure mesh edge sites with distributed security",
+		"securemesh_site_v2": "deploying secure mesh edge sites with security and networking controls",
 		"aws_vpc_site":       "deploying F5 sites within AWS VPC environments",
 		"azure_vnet_site":    "deploying F5 sites within Azure Virtual Network environments",
 		"gcp_vpc_site":       "deploying F5 sites within Google Cloud VPC environments",
 		"aws_tgw_site":       "deploying F5 sites connected via AWS Transit Gateway",
-		"voltstack_site":     "deploying Volterra stack sites for edge computing",
+		"voltstack_site":     "deploying App Stack edge computing sites",
 		"virtual_site":       "creating logical groupings of sites based on labels and selectors",
 
 		// Load Balancing
-		"http_loadbalancer": "load balancing HTTP/HTTPS traffic with advanced routing and security",
+		"http_loadbalancer": "load balancing HTTP/HTTPS traffic with routing and security controls",
 		"tcp_loadbalancer":  "load balancing TCP traffic across origin pools",
 		"udp_loadbalancer":  "load balancing UDP traffic across origin pools",
-		"dns_load_balancer": "intelligent DNS-based load balancing across multiple endpoints",
+		"dns_load_balancer": "DNS load balancing across multiple endpoints",
 		"cdn_loadbalancer":  "content delivery and edge caching with load balancing",
 		"origin_pool":       "defining backend server pools for load balancer targets",
 		"healthcheck":       "monitoring backend server health and availability",
 		"route":             "defining traffic routing rules for load balancers",
 
 		// Security
-		"app_firewall":                   "web application firewall (WAF) protection",
+		"app_firewall":                   "Web Application Firewall (WAF) protection",
 		"service_policy":                 "defining service-level access control and security policies",
 		"network_firewall":               "network-level firewall rules and security controls",
 		"rate_limiter":                   "protecting services from traffic spikes and DDoS attacks",
-		"bot_defense_app_infrastructure": "bot detection and mitigation capabilities",
+		"bot_defense_app_infrastructure": "bot detection and mitigation",
 		"malicious_user_mitigation":      "identifying and blocking malicious user behavior",
 		"waf_exclusion_policy":           "excluding specific requests from WAF inspection",
 
@@ -364,7 +369,7 @@ func GenerateCapabilityDescriptionOnly(resourceName, humanName, rawDesc string) 
 		// API Security
 		"api_definition": "API schema and endpoint definitions for security",
 		"api_discovery":  "automatic API endpoint discovery and inventory",
-		"api_testing":    "API testing and validation capabilities",
+		"api_testing":    "API testing and validation",
 		"api_crawler":    "API endpoint crawling and discovery",
 
 		// Organization

--- a/tools/pkg/docfmt/markdown.go
+++ b/tools/pkg/docfmt/markdown.go
@@ -11,7 +11,7 @@ const calloutSignature = "-> **Syntax Rule:**"
 const syntaxRulesCallout = "-> **Syntax Rule:** This provider uses OneOf groups for mutually " +
 	"exclusive options. Fields documented as \"Optional Block\" use empty block " +
 	"syntax `field_name {}`, **never** `field_name = true`. Boolean attributes " +
-	"(like `add_hsts`, `http_redirect`) use `= true/false` as normal."
+	"(such as `add_hsts` and `http_redirect`) use `= true` or `= false`."
 
 var (
 	headingPattern = regexp.MustCompile(`^#{1,6}\s+\S`)

--- a/tools/pkg/schema/extract.go
+++ b/tools/pkg/schema/extract.go
@@ -187,7 +187,7 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 	} else if hasNamespace {
 		idComponentAttrs = append(idComponentAttrs, openapi.TerraformAttribute{
 			Name: "namespace", GoName: "Namespace", TfsdkTag: "namespace", Type: "string",
-			Description: fmt.Sprintf("Namespace where the %s will be created.", naming.ToHumanReadableName(resourceName)),
+			Description: fmt.Sprintf("Namespace where the %s is created.", naming.ToHumanReadableName(resourceName)),
 			Required:    true, PlanModifier: "RequiresReplace"})
 	} else {
 		idComponentAttrs = append(idComponentAttrs, openapi.TerraformAttribute{
@@ -204,7 +204,7 @@ func ExtractResourceSchema(spec *openapi.Spec, resourceName string, extractAPIPa
 		{Name: "description", GoName: "Description", TfsdkTag: "description", Type: "string",
 			Description: "Human readable description for the object.", Optional: true},
 		{Name: "disable", GoName: "Disable", TfsdkTag: "disable", Type: "bool",
-			Description: "A value of true will administratively disable the object.", Optional: true},
+			Description: "A value of true administratively disables the object.", Optional: true},
 		{Name: "labels", GoName: "Labels", TfsdkTag: "labels", Type: "map", ElementType: "string",
 			Description: "Labels is a user defined key value map that can be attached to resources for organization and filtering.", Optional: true},
 	}
@@ -714,7 +714,7 @@ func SystemMetadataUIDAttribute(resourceName string) openapi.TerraformAttribute 
 	uidDesc := "Server-generated unique identifier (`system_metadata.uid`). Read-only; assigned by F5 Distributed Cloud on creation."
 	uidSens := false
 	if naming.ToResourceTypeName(resourceName) == "Token" {
-		uidDesc += " For tokens, this value is the sensitive CE registration token. Note: This value will be stored in plain text in the Terraform state file; ensure your state file is properly secured."
+		uidDesc += " For tokens, this value is the sensitive CE registration token. Note: This value is stored in plain text in the Terraform state file; ensure your state file is properly secured."
 		uidSens = true
 	}
 	return openapi.TerraformAttribute{

--- a/tools/transform-docs.go
+++ b/tools/transform-docs.go
@@ -963,9 +963,9 @@ func transformAnchorsOnly(filePath string, content string) error {
 		line := lines[i]
 
 		// Replace API documentation link (generic or previously generated) with current resource-specific link
-		if apiDocURL != "" && (strings.Contains(line, "F5 XC API Documentation") || strings.Contains(line, "API docs]")) {
+		if apiDocURL != "" && (strings.Contains(line, "F5 XC API Documentation") || strings.Contains(line, "API docs]") || strings.Contains(line, "API documentation]")) {
 			displayName := naming.ToTitleCase(resourceName)
-			line = fmt.Sprintf("~> **Note** Please refer to [%s API docs](%s) to learn more.", displayName, apiDocURL)
+			line = fmt.Sprintf("~> **Note:** For more information, see the [%s API documentation](%s).", displayName, apiDocURL)
 		}
 
 		// Check if this is an anchor line
@@ -1366,9 +1366,9 @@ func transformDoc(filePath string) error {
 			line = fmt.Sprintf("subcategory: \"%s\"", subcategory)
 		}
 		// Replace API documentation link (generic or previously generated) with current resource-specific link
-		if apiDocURL != "" && (strings.Contains(line, "F5 XC API Documentation") || strings.Contains(line, "API docs]")) {
+		if apiDocURL != "" && (strings.Contains(line, "F5 XC API Documentation") || strings.Contains(line, "API docs]") || strings.Contains(line, "API documentation]")) {
 			displayName := naming.ToTitleCase(resourceName)
-			line = fmt.Sprintf("~> **Note** Please refer to [%s API docs](%s) to learn more.", displayName, apiDocURL)
+			line = fmt.Sprintf("~> **Note:** For more information, see the [%s API documentation](%s).", displayName, apiDocURL)
 		}
 		output.WriteString(line)
 		output.WriteString("\n")


### PR DESCRIPTION
## Summary
Improves provider documentation templates, generator descriptions, schema extractors, and developer guides to adhere to Microsoft Technical Documentation standards (present tense, active voice, imperative steps, em-dashes, and standard placeholders).

- Updates guide templates (`templates/guides/*.md`) and provider/resource templates (`templates/*.md.tmpl`).
- Updates generator capability descriptions and schema attribute strings (`tools/pkg/description/`, `tools/pkg/docfmt/`, `tools/pkg/schema/`, `tools/pkg/codegen/`, `tools/transform-docs.go`).
- Updates `DEVELOPMENT.md`.
- Regenerates `docs/llms.txt` and related indices.

Closes #1745