### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,9 +129,11 @@ oauth-success.html
 .omx/
 
 # Lock file preferences (Bun-based repos)
-package-lock.json
 yarn.lock
 /bun.lock
+
+# Terraform provider build artifacts
+/terraform-provider-xcsh
 
 # Monorepo build
 .turbo/


### PR DESCRIPTION
Closes #1749

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore