### PR TITLE
fix(generator): accept enriched response metadata

### DIFF
--- a/tools/pkg/openapi/catalog.go
+++ b/tools/pkg/openapi/catalog.go
@@ -35,11 +35,13 @@ var (
 // These fields are consumed as data; the provider does not reconstruct them from
 // Terraform names or RPC naming conventions.
 type CatalogOperation struct {
-	Method        string
-	Path          string
-	OperationID   string
-	Surface       string
-	RequestSchema string
+	Method         string
+	Path           string
+	OperationID    string
+	Surface        string
+	Role           string
+	RequestSchema  string
+	ResponseSchema string
 }
 
 // APIOperationIdentity groups the exact operations published for one
@@ -99,11 +101,13 @@ type apiOperationIdentityWire struct {
 }
 
 type catalogOperationWire struct {
-	Method        *string         `json:"method"`
-	Path          *string         `json:"path"`
-	OperationID   *string         `json:"operationId"`
-	Surface       *string         `json:"surface"`
-	RequestSchema json.RawMessage `json:"requestSchema"`
+	Method         *string         `json:"method"`
+	Path           *string         `json:"path"`
+	OperationID    *string         `json:"operationId"`
+	Surface        *string         `json:"surface"`
+	Role           json.RawMessage `json:"role"`
+	RequestSchema  json.RawMessage `json:"requestSchema"`
+	ResponseSchema json.RawMessage `json:"responseSchema"`
 }
 
 type apiExclusionWire struct {
@@ -550,12 +554,32 @@ func parseCatalogOperation(raw json.RawMessage, apiIdentity string) (CatalogOper
 			return CatalogOperation{}, fmt.Errorf("requestSchema must be absent or a non-empty schema name")
 		}
 	}
+	responseSchema := ""
+	if len(wire.ResponseSchema) > 0 {
+		if bytes.Equal(bytes.TrimSpace(wire.ResponseSchema), []byte("null")) {
+			return CatalogOperation{}, fmt.Errorf("responseSchema must be absent or a non-empty schema name")
+		}
+		if err := json.Unmarshal(wire.ResponseSchema, &responseSchema); err != nil || !schemaNamePattern.MatchString(responseSchema) {
+			return CatalogOperation{}, fmt.Errorf("responseSchema must be absent or a non-empty schema name")
+		}
+	}
+	role := ""
+	if len(wire.Role) > 0 {
+		if bytes.Equal(bytes.TrimSpace(wire.Role), []byte("null")) {
+			return CatalogOperation{}, fmt.Errorf("role must be absent, query, or issuance")
+		}
+		if err := json.Unmarshal(wire.Role, &role); err != nil || (role != "query" && role != "issuance") {
+			return CatalogOperation{}, fmt.Errorf("role must be absent, query, or issuance")
+		}
+	}
 	return CatalogOperation{
-		Method:        *wire.Method,
-		Path:          *wire.Path,
-		OperationID:   *wire.OperationID,
-		Surface:       *wire.Surface,
-		RequestSchema: requestSchema,
+		Method:         *wire.Method,
+		Path:           *wire.Path,
+		OperationID:    *wire.OperationID,
+		Surface:        *wire.Surface,
+		Role:           role,
+		RequestSchema:  requestSchema,
+		ResponseSchema: responseSchema,
 	}, nil
 }
 

--- a/tools/pkg/openapi/catalog_test.go
+++ b/tools/pkg/openapi/catalog_test.go
@@ -78,6 +78,111 @@ func TestParseOperationCatalogPreservesExactOperationFacts(t *testing.T) {
 	}
 }
 
+func TestParseOperationCatalogPreservesOptionalResponseSchema(t *testing.T) {
+	raw := strings.Replace(
+		validOperationCatalog,
+		`"surface": "config"`,
+		`"surface": "config", "responseSchema": "probeResponse"`,
+		1,
+	)
+	catalog, err := ParseOperationCatalog([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParseOperationCatalog() error = %v", err)
+	}
+	identity, ok := catalog.Identity("ves.io.schema.probe")
+	if !ok {
+		t.Fatal("Identity(ves.io.schema.probe) was not found")
+	}
+	if got := identity.Operations[0].ResponseSchema; got != "probeResponse" {
+		t.Fatalf("ResponseSchema = %q, want probeResponse", got)
+	}
+	if got := identity.Operations[1].ResponseSchema; got != "" {
+		t.Fatalf("absent ResponseSchema = %q, want empty", got)
+	}
+}
+
+func TestParseOperationCatalogRejectsInvalidResponseSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		fragment string
+		wantErr  string
+	}{
+		{name: "null", fragment: `"responseSchema": null`, wantErr: "responseSchema must be absent or a non-empty schema name"},
+		{name: "empty", fragment: `"responseSchema": ""`, wantErr: "responseSchema must be absent or a non-empty schema name"},
+		{name: "non-string", fragment: `"responseSchema": 42`, wantErr: "responseSchema must be absent or a non-empty schema name"},
+		{name: "malformed", fragment: `"responseSchema": "probe-response"`, wantErr: "responseSchema must be absent or a non-empty schema name"},
+		{name: "duplicate", fragment: `"responseSchema": "first", "responseSchema": "second"`, wantErr: "duplicate field"},
+		{name: "unknown field", fragment: `"unexpectedResponseSchema": "probeResponse"`, wantErr: `unknown field "unexpectedResponseSchema"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := strings.Replace(
+				validOperationCatalog,
+				`"surface": "config"`,
+				`"surface": "config", `+tt.fragment,
+				1,
+			)
+			_, err := ParseOperationCatalog([]byte(raw))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseOperationCatalog() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseOperationCatalogPreservesOptionalOperationRole(t *testing.T) {
+	raw := strings.Replace(
+		validOperationCatalog,
+		`"surface": "config"`,
+		`"surface": "config", "role": "query"`,
+		1,
+	)
+	catalog, err := ParseOperationCatalog([]byte(raw))
+	if err != nil {
+		t.Fatalf("ParseOperationCatalog() error = %v", err)
+	}
+	identity, ok := catalog.Identity("ves.io.schema.probe")
+	if !ok {
+		t.Fatal("Identity(ves.io.schema.probe) was not found")
+	}
+	if got := identity.Operations[0].Role; got != "query" {
+		t.Fatalf("Role = %q, want query", got)
+	}
+	if got := identity.Operations[1].Role; got != "" {
+		t.Fatalf("absent Role = %q, want empty", got)
+	}
+}
+
+func TestParseOperationCatalogRejectsInvalidOperationRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		fragment string
+		wantErr  string
+	}{
+		{name: "null", fragment: `"role": null`, wantErr: "role must be absent, query, or issuance"},
+		{name: "empty", fragment: `"role": ""`, wantErr: "role must be absent, query, or issuance"},
+		{name: "non-string", fragment: `"role": 42`, wantErr: "role must be absent, query, or issuance"},
+		{name: "unsupported", fragment: `"role": "lookup"`, wantErr: "role must be absent, query, or issuance"},
+		{name: "duplicate", fragment: `"role": "query", "role": "issuance"`, wantErr: "duplicate field"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := strings.Replace(
+				validOperationCatalog,
+				`"surface": "config"`,
+				`"surface": "config", `+tt.fragment,
+				1,
+			)
+			_, err := ParseOperationCatalog([]byte(raw))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseOperationCatalog() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestParseOperationCatalogFromDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "api-catalog.json"), []byte(validOperationCatalog), 0o600); err != nil {


### PR DESCRIPTION
## Summary

- retain optional enriched API catalog `responseSchema` values while rejecting null, empty, non-string, malformed, and duplicate values
- retain the release's intentional optional `role` metadata only for `query` and `issuance`
- preserve strict rejection of unrelated unknown operation fields

## Validation

- `go test ./tools/pkg/openapi`
- disposable `v2.1.221` release generation: 128 resources + 19 read-only data sources, 0 failures; 128 resource examples + 149 data-source lookups
- `make test`
- `make lint` (0 issues)
- `go build ./...`
- `go vet ./...`
- `bash scripts/vet-build-ignored-tools.sh`
- `pre-commit run --all-files`

Direct Remote AGY review: N/A — explicitly waived for this recovery task.

Closes #1753
