### PR TITLE
fix PII checker handling of escaped fmt placeholders

### DIFF
--- a/docs/guides/blindfold.md
+++ b/docs/guides/blindfold.md
@@ -395,7 +395,7 @@ Field descriptions:
 
 - `key_version`: Public key version used for encryption
 - `policy_id`: Reference to the SecretPolicy (`namespace/name` format)
-- `tenant`: F5 Distributed Cloud tenant identifier
+- `tenant`: Tenant or organization identifier
 - `data`: Base64-encoded RSA-OAEP ciphertext
 
 ### Function Behavior

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -151,6 +151,9 @@ ENUM_HEADER_RE = re.compile(
     r"[A-Za-z_$][A-Za-z0-9_$]*",
 )
 SOURCE_SNIPPET_INDEX_RE = re.compile(r"\$\{[A-Za-z_$][A-Za-z0-9_$]*(?:\+\+|--)?\}")
+GO_FORMAT_CONVERSION_RE = re.compile(
+    r"%(?:\[[1-9][0-9]*\])?[+#0 'I-]*(?:[1-9][0-9]*|\*)?(?:\.(?:[0-9]+|\*))?[vTtbcdoOqxXUeEfFgGspw]"
+)
 IDENTITY_FIELD_RE = re.compile(
     r"(?i)(?P<field_prefix>^|[^A-Za-z0-9_/-])"
     r"(?P<key_open>[*_~`'\"]*)"
@@ -2106,6 +2109,13 @@ def scan_structured_identity(
         if not is_literal_structured_identity_field(path, line, match):
             continue
         value = structured_field_value(path, line, match)
+        placeholder = value
+        captured = normalized_value(match.group("value"))
+        escaped_source_quote = context.source_code and match.group("quote").startswith(
+            "\\"
+        )
+        if escaped_source_quote and captured.endswith("\\"):
+            placeholder = captured[:-1]
         if numeric_enum_member(match, value, context):
             continue
         in_jq_span = match_is_in_spans(match, context.jq_spans)
@@ -2134,7 +2144,11 @@ def scan_structured_identity(
             safe_alias = aliases_at_value.get(alias.group(1), False)
         else:
             safe_alias = None
-        if jq_literal or not (safe_alias if alias else placeholder_value(value)):
+        source_format_placeholder = context.source_code and bool(
+            GO_FORMAT_CONVERSION_RE.fullmatch(placeholder)
+        )
+        safe_value = placeholder_value(placeholder) or source_format_placeholder
+        if jq_literal or not (safe_alias if alias else safe_value):
             add_finding(
                 findings,
                 path=path,

--- a/templates/guides/blindfold.md
+++ b/templates/guides/blindfold.md
@@ -395,7 +395,7 @@ Field descriptions:
 
 - `key_version`: Public key version used for encryption
 - `policy_id`: Reference to the SecretPolicy (`namespace/name` format)
-- `tenant`: F5 Distributed Cloud tenant identifier
+- `tenant`: Tenant or organization identifier
 - `data`: Base64-encoded RSA-OAEP ciphertext
 
 ### Function Behavior

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -2203,6 +2203,20 @@ git -C "$repo" add fixture.ts
 git -C "$repo" commit -qm literal
 assert_violation "quoted identity literals in code" "$repo" --scope head --mode enforce
 
+repo=$(new_repo go-fmt-identity-placeholder)
+cat >"${repo}/fixture.go" <<'EOF'
+package fixture
+
+import "fmt"
+
+func render(namespaceValue string) string {
+	return fmt.Sprintf("  namespace = \"%s\"\n", namespaceValue)
+}
+EOF
+git -C "$repo" add fixture.go
+git -C "$repo" commit -qm go-fmt-identity-placeholder
+assert_clean "escaped Go fmt identity placeholders are dynamic" "$repo" --scope head --mode enforce
+
 repo=$(new_repo code-numeric-literal)
 printf 'const context = { account_id: 987654321 };\n' >"${repo}/fixture.ts"
 git -C "$repo" add fixture.ts


### PR DESCRIPTION
Closes #1760

Recognize escaped Go format conversion placeholders without treating them as literal tenant identifiers, retain strict PII enforcement elsewhere, and use neutral Blindfold field wording.

Validation:
- `bash tests/test-check-pii.sh`
- `make lint`
- repository pre-commit hooks
- direct two-pass AGY review: approved, zero findings
