### PR TITLE
fix receiver handling of additive release assets

### DIFF
--- a/.github/actions/download-api-specs/action.yml
+++ b/.github/actions/download-api-specs/action.yml
@@ -146,17 +146,18 @@ runs:
           exit 1
         fi
 
-        EXPECTED_ASSETS=$(printf '%s\n' \
+        REQUIRED_ASSETS=$(printf '%s\n' \
           api-catalog.json \
           "$BUNDLE_NAME" \
           index.json \
           minimal-export-defaults.json \
-          openapi.json | sort)
-        ACTUAL_ASSETS=$(jq -r '.assets[].name' "$RELEASE_METADATA" | sort)
-        [ "$ACTUAL_ASSETS" = "$EXPECTED_ASSETS" ] || {
-          echo "::error::Release asset set differs from the five-asset contract"
-          exit 1
-        }
+          openapi.json)
+        while IFS= read -r required_asset; do
+          [ "$(jq --arg name "$required_asset" '[.assets[] | select(.name == $name)] | length' "$RELEASE_METADATA")" -eq 1 ] || {
+            echo "::error::Release must contain exactly one required ${required_asset} asset"
+            exit 1
+          }
+        done <<< "$REQUIRED_ASSETS"
 
         RELEASE_BODY="${STAGING_ROOT}/release-body.txt"
         jq -r '.body // ""' "$RELEASE_METADATA" > "$RELEASE_BODY"
@@ -167,26 +168,26 @@ runs:
         }
         RECEIPT=$(sed -n 's/^<!-- publication-receipt:\(.*\) -->$/\1/p' "$RELEASE_BODY")
         printf '%s' "$RECEIPT" | jq -e \
-          --arg bundle "$BUNDLE_NAME" \
           --slurpfile pin "$PIN_FILE" '
+            . as $receipt |
             type == "object" and
             (keys | sort) == ["assets", "commit", "version"] and
             .commit == $pin[0].target_commit and
             .version == $pin[0].version and
-            .assets == $pin[0].assets and
-            (.assets | keys | sort) ==
-              ["api-catalog.json", $bundle, "index.json", "minimal-export-defaults.json", "openapi.json"] and
-            ([.assets[] | test("^sha256:[0-9a-f]{64}$")] | all)
+            ([ $pin[0].assets | to_entries[] |
+              $receipt.assets[.key] == .value
+            ] | all)
           ' >/dev/null || {
-          echo "::error::Publication receipt does not exactly match the tracked release pin"
+          echo "::error::Publication receipt does not match the tracked core release pin"
           exit 1
         }
-        jq -e --argjson receipt "$RECEIPT" '
-          [.assets[] |
-            .digest == $receipt.assets[.name]
+        jq -e --slurpfile pin "$PIN_FILE" '
+          [.assets[] | . as $asset |
+            select($pin[0].assets[$asset.name] != null) |
+            $asset.digest == $pin[0].assets[$asset.name]
           ] | all
         ' "$RELEASE_METADATA" >/dev/null || {
-          echo "::error::GitHub asset digests do not exactly match the publication receipt"
+          echo "::error::GitHub core asset digests do not match the tracked release pin"
           exit 1
         }
 

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -272,17 +272,18 @@ jobs:
           fi
 
           BUNDLE_NAME="f5xc-api-specs-${SPEC_VERSION}.zip"
-          EXPECTED_ASSETS=$(printf '%s\n' \
+          REQUIRED_ASSETS=$(printf '%s\n' \
             api-catalog.json \
             "$BUNDLE_NAME" \
             index.json \
             minimal-export-defaults.json \
-            openapi.json | sort)
-          ACTUAL_ASSETS=$(jq -r '.assets[].name' "$RELEASE_METADATA" | sort)
-          [ "$ACTUAL_ASSETS" = "$EXPECTED_ASSETS" ] || {
-            echo "::error::Release ${SPEC_VERSION} asset set differs from the five-asset contract"
-            exit 1
-          }
+            openapi.json)
+          while IFS= read -r required_asset; do
+            [ "$(jq --arg name "$required_asset" '[.assets[] | select(.name == $name)] | length' "$RELEASE_METADATA")" -eq 1 ] || {
+              echo "::error::Release ${SPEC_VERSION} must contain exactly one required ${required_asset} asset"
+              exit 1
+            }
+          done <<< "$REQUIRED_ASSETS"
 
           RELEASE_BODY="${STAGING_ROOT}/release-body.txt"
           jq -r '.body // ""' "$RELEASE_METADATA" > "$RELEASE_BODY"
@@ -301,9 +302,10 @@ jobs:
               (keys | sort) == ["assets", "commit", "version"] and
               .version == $version and
               .commit == $commit and
-              (.assets | keys | sort) ==
-                ["api-catalog.json", $bundle, "index.json", "minimal-export-defaults.json", "openapi.json"] and
-              ([.assets[] | test("^sha256:[0-9a-f]{64}$")] | all)
+              (.assets as $assets |
+                [$assets["api-catalog.json"], $assets[$bundle], $assets["index.json"],
+                 $assets["minimal-export-defaults.json"], $assets["openapi.json"]] |
+                all(type == "string" and test("^sha256:[0-9a-f]{64}$")))
             ' >/dev/null || {
             echo "::error::Publication receipt does not match the release identity"
             exit 1
@@ -417,9 +419,17 @@ jobs:
           fi
           mkdir -p tools
           PIN_TMP=$(mktemp tools/spec-release.json.XXXXXX)
-          printf '%s' "$RECEIPT" | jq -S --arg tag "$SPEC_VERSION" '
-            {assets:.assets,release_tag:$tag,target_commit:.commit,version:.version}
-          ' > "$PIN_TMP"
+          printf '%s' "$RECEIPT" | jq -S \
+            --arg tag "$SPEC_VERSION" \
+            --arg bundle "$BUNDLE_NAME" '
+              {assets:{
+                "api-catalog.json":.assets["api-catalog.json"],
+                ($bundle):.assets[$bundle],
+                "index.json":.assets["index.json"],
+                "minimal-export-defaults.json":.assets["minimal-export-defaults.json"],
+                "openapi.json":.assets["openapi.json"]
+              },release_tag:$tag,target_commit:.commit,version:.version}
+            ' > "$PIN_TMP"
           mv "$PIN_TMP" tools/spec-release.json
 
       # The downloaded specs live under docs/specifications/api/, which is gitignored

--- a/docs/guides/blindfold.md
+++ b/docs/guides/blindfold.md
@@ -395,7 +395,7 @@ Field descriptions:
 
 - `key_version`: Public key version used for encryption
 - `policy_id`: Reference to the SecretPolicy (`namespace/name` format)
-- `tenant`: F5 Distributed Cloud tenant identifier
+- `tenant`: Tenant or organization identifier
 - `data`: Base64-encoded RSA-OAEP ciphertext
 
 ### Function Behavior

--- a/internal/acctest/download_specs_action_test.go
+++ b/internal/acctest/download_specs_action_test.go
@@ -243,14 +243,16 @@ case "$*" in
         {id: 101, name: "f5xc-api-specs-v2.1.208.zip", digest: ("sha256:" + $bundle_sha)},
         {id: 204, name: "index.json", digest: ("sha256:" + $index_sha)},
         {id: 203, name: "minimal-export-defaults.json", digest: ("sha256:" + $minimal_sha)},
-        {id: 205, name: "openapi.json", digest: ("sha256:" + $openapi_sha)}
+        {id: 205, name: "openapi.json", digest: ("sha256:" + $openapi_sha)},
+        {id: 206, name: "smsv2-contract.json", digest: ("sha256:" + ("6" * 64))}
       ], body: ("<!-- publication-receipt:" + ({
         assets: {
           "api-catalog.json": ("sha256:" + $catalog_sha),
           "f5xc-api-specs-v2.1.208.zip": ("sha256:" + $bundle_sha),
           "index.json": ("sha256:" + $index_sha),
           "minimal-export-defaults.json": ("sha256:" + $minimal_sha),
-          "openapi.json": ("sha256:" + $openapi_sha)
+          "openapi.json": ("sha256:" + $openapi_sha),
+          "smsv2-contract.json": ("sha256:" + ("6" * 64))
         }, commit: $commit, version: "2.1.208"
       } | tojson) + " -->")}' ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 9 ;;
@@ -361,6 +363,40 @@ func TestDownloadSpecsActionRejectsMutableRelease(t *testing.T) {
 	}
 }
 
+func TestDownloadSpecsActionRequiresEachCoreAssetExactlyOnce(t *testing.T) {
+	tag := "v2.1.208"
+	commit := strings.Repeat("a", 40)
+	receipt := testSpecPublicationReceipt(tag, commit)
+	base := testSpecReleaseMetadata(t, tag, true, []map[string]any{receipt}, nil)
+	tests := []struct {
+		name   string
+		mutate func([]any) []any
+	}{
+		{
+			name: "missing core asset",
+			mutate: func(assets []any) []any {
+				return assets[:len(assets)-1]
+			},
+		},
+		{
+			name: "duplicate core asset",
+			mutate: func(assets []any) []any {
+				return append(assets, assets[0])
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := mutateSpecReleaseAssets(t, base, test.mutate)
+			output, err := runDownloadActionWithMetadata(t, metadata, commit)
+			if err == nil || !strings.Contains(output, "must contain exactly one required") {
+				t.Fatalf("invalid core asset set was accepted: err=%v\n%s", err, output)
+			}
+		})
+	}
+}
+
 func TestDownloadSpecsActionRejectsContradictoryPublicationReceipt(t *testing.T) {
 	tag := "v2.1.208"
 	commit := strings.Repeat("a", 40)
@@ -407,7 +443,7 @@ func TestDownloadSpecsActionRejectsContradictoryPublicationReceipt(t *testing.T)
 			metadata := testSpecReleaseMetadata(t, tag, true, []map[string]any{receipt}, nil)
 
 			output, err := runDownloadActionWithMetadata(t, metadata, commit)
-			if err == nil || !strings.Contains(output, "does not exactly match the tracked release pin") {
+			if err == nil || !strings.Contains(output, "does not match the tracked core release pin") {
 				t.Fatalf("contradictory publication receipt was accepted: err=%v\n%s", err, output)
 			}
 		})
@@ -481,7 +517,7 @@ func TestDownloadSpecsActionRejectsGitHubDigestMismatch(t *testing.T) {
 	})
 
 	output, err := runDownloadActionWithMetadata(t, metadata, commit)
-	if err == nil || !strings.Contains(output, "GitHub asset digests do not exactly match") {
+	if err == nil || !strings.Contains(output, "GitHub core asset digests do not match") {
 		t.Fatalf("GitHub digest contradicting the receipt was accepted: err=%v\n%s", err, output)
 	}
 }
@@ -579,6 +615,24 @@ func testSpecReleaseMetadata(
 		t.Fatal(err)
 	}
 	return metadata
+}
+
+func mutateSpecReleaseAssets(t *testing.T, metadata []byte, mutate func([]any) []any) []byte {
+	t.Helper()
+	var release map[string]any
+	if err := json.Unmarshal(metadata, &release); err != nil {
+		t.Fatal(err)
+	}
+	assets, ok := release["assets"].([]any)
+	if !ok {
+		t.Fatal("release metadata assets are not an array")
+	}
+	release["assets"] = mutate(assets)
+	updated, err := json.Marshal(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return updated
 }
 
 func testSpecAssetDigests(tag string, overrides map[string]string) map[string]string {

--- a/internal/acctest/sync_openapi_dispatch_test.go
+++ b/internal/acctest/sync_openapi_dispatch_test.go
@@ -381,14 +381,16 @@ case "$*" in
         {id: 301, name: "f5xc-api-specs-v2.1.208.zip"},
         {id: 303, name: "index.json"},
         {id: 304, name: "minimal-export-defaults.json"},
-        {id: 305, name: "openapi.json"}
+        {id: 305, name: "openapi.json"},
+        {id: 306, name: "smsv2-contract.json"}
       ], body: ("<!-- publication-receipt:" + ({
         assets: {
           "api-catalog.json": ("sha256:" + $catalog_sha),
           "f5xc-api-specs-v2.1.208.zip": ("sha256:" + $bundle_sha),
           "index.json": ("sha256:" + $index_sha),
           "minimal-export-defaults.json": ("sha256:" + $minimal_sha),
-          "openapi.json": ("sha256:" + $openapi_sha)
+          "openapi.json": ("sha256:" + $openapi_sha),
+          "smsv2-contract.json": ("sha256:" + ("6" * 64))
         }, commit: $commit, version: "2.1.208"
       } | tojson) + " -->")}' ;;
   *) echo "unexpected gh invocation: $*" >&2; exit 9 ;;
@@ -449,6 +451,9 @@ esac
 		pin.Assets["api-catalog.json"] != wantCatalogDigest {
 		t.Fatalf("release pin does not preserve the verified receipt identity: %+v", pin)
 	}
+	if _, ok := pin.Assets["smsv2-contract.json"]; ok {
+		t.Fatalf("release pin persisted an additive asset that the provider does not consume: %+v", pin)
+	}
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
 		t.Fatalf("stale pre-release content survived exact bundle promotion: %v", err)
 	}
@@ -506,6 +511,63 @@ printf '%s\n' '{"tag_name":"v2.1.208","draft":false,"prerelease":false,"immutabl
 	output, err := cmd.CombinedOutput()
 	if err == nil || !strings.Contains(string(output), "final and immutable") {
 		t.Fatalf("mutable spec release was accepted: err=%v\n%s", err, output)
+	}
+}
+
+func TestSyncOpenAPIDownloadRequiresEachCoreAssetExactlyOnce(t *testing.T) {
+	script := extractSyncOpenAPIStep(t, "Download OpenAPI specs")
+	tag := "v2.1.208"
+	commit := strings.Repeat("a", 40)
+	receipt := testSpecPublicationReceipt(tag, commit)
+	base := testSpecReleaseMetadata(t, tag, true, []map[string]any{receipt}, nil)
+	tests := []struct {
+		name   string
+		mutate func([]any) []any
+	}{
+		{
+			name: "missing core asset",
+			mutate: func(assets []any) []any {
+				return assets[:len(assets)-1]
+			},
+		},
+		{
+			name: "duplicate core asset",
+			mutate: func(assets []any) []any {
+				return append(assets, assets[0])
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			metadata := mutateSpecReleaseAssets(t, base, test.mutate)
+			metadataPath := filepath.Join(tmp, "release.json")
+			if err := os.WriteFile(metadataPath, metadata, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			binDir := filepath.Join(tmp, "bin")
+			if err := os.Mkdir(binDir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			stub := `#!/usr/bin/env bash
+case "$*" in
+  *releases/tags/v2.1.208*) cat "$STUB_RELEASE_METADATA" ;;
+  *commits/v2.1.208*) printf '%s\n' "$RESOLVED_COMMIT" ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 88 ;;
+esac
+`
+			if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(stub), 0o700); err != nil { //nolint:gosec // executable test stub
+				t.Fatal(err)
+			}
+			cmd := exec.Command("bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script)
+			cmd.Dir = tmp
+			cmd.Env = append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"), "SPEC_DIR="+filepath.Join(tmp, "specs"), "SPEC_VERSION="+tag, "ENRICHED_REPO="+dispatchSource, "GH_TOKEN=stub", "DISPATCH_TARGET_COMMIT="+commit, "RUNNER_TEMP="+filepath.Join(tmp, "runner"), "STUB_RELEASE_METADATA="+metadataPath, "RESOLVED_COMMIT="+commit)
+			output, err := cmd.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), "must contain exactly one required") {
+				t.Fatalf("invalid core asset set was accepted: err=%v\n%s", err, output)
+			}
+		})
 	}
 }
 

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -151,6 +151,9 @@ ENUM_HEADER_RE = re.compile(
     r"[A-Za-z_$][A-Za-z0-9_$]*",
 )
 SOURCE_SNIPPET_INDEX_RE = re.compile(r"\$\{[A-Za-z_$][A-Za-z0-9_$]*(?:\+\+|--)?\}")
+GO_FORMAT_CONVERSION_RE = re.compile(
+    r"%(?:\[[1-9][0-9]*\])?[+#0 'I-]*(?:[1-9][0-9]*|\*)?(?:\.(?:[0-9]+|\*))?[vTtbcdoOqxXUeEfFgGspw]"
+)
 IDENTITY_FIELD_RE = re.compile(
     r"(?i)(?P<field_prefix>^|[^A-Za-z0-9_/-])"
     r"(?P<key_open>[*_~`'\"]*)"
@@ -2106,6 +2109,13 @@ def scan_structured_identity(
         if not is_literal_structured_identity_field(path, line, match):
             continue
         value = structured_field_value(path, line, match)
+        placeholder = value
+        captured = normalized_value(match.group("value"))
+        escaped_source_quote = context.source_code and match.group("quote").startswith(
+            "\\"
+        )
+        if escaped_source_quote and captured.endswith("\\"):
+            placeholder = captured[:-1]
         if numeric_enum_member(match, value, context):
             continue
         in_jq_span = match_is_in_spans(match, context.jq_spans)
@@ -2134,7 +2144,11 @@ def scan_structured_identity(
             safe_alias = aliases_at_value.get(alias.group(1), False)
         else:
             safe_alias = None
-        if jq_literal or not (safe_alias if alias else placeholder_value(value)):
+        source_format_placeholder = context.source_code and bool(
+            GO_FORMAT_CONVERSION_RE.fullmatch(placeholder)
+        )
+        safe_value = placeholder_value(placeholder) or source_format_placeholder
+        if jq_literal or not (safe_alias if alias else safe_value):
             add_finding(
                 findings,
                 path=path,

--- a/templates/guides/blindfold.md
+++ b/templates/guides/blindfold.md
@@ -395,7 +395,7 @@ Field descriptions:
 
 - `key_version`: Public key version used for encryption
 - `policy_id`: Reference to the SecretPolicy (`namespace/name` format)
-- `tenant`: F5 Distributed Cloud tenant identifier
+- `tenant`: Tenant or organization identifier
 - `data`: Base64-encoded RSA-OAEP ciphertext
 
 ### Function Behavior

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -2203,6 +2203,20 @@ git -C "$repo" add fixture.ts
 git -C "$repo" commit -qm literal
 assert_violation "quoted identity literals in code" "$repo" --scope head --mode enforce
 
+repo=$(new_repo go-fmt-identity-placeholder)
+cat >"${repo}/fixture.go" <<'EOF'
+package fixture
+
+import "fmt"
+
+func render(namespaceValue string) string {
+	return fmt.Sprintf("  namespace = \"%s\"\n", namespaceValue)
+}
+EOF
+git -C "$repo" add fixture.go
+git -C "$repo" commit -qm go-fmt-identity-placeholder
+assert_clean "escaped Go fmt identity placeholders are dynamic" "$repo" --scope head --mode enforce
+
 repo=$(new_repo code-numeric-literal)
 printf 'const context = { account_id: 987654321 };\n' >"${repo}/fixture.ts"
 git -C "$repo" add fixture.ts


### PR DESCRIPTION
Closes #1759

Require exactly one copy of each provider-consumed core asset while permitting unrelated additive release assets such as the independently owned SMSv2 bundle. Persist and validate only the five provider core digests. This branch also contains the approved #1760 PII prerequisite so the recovery workflow can run before that blocked prerequisite PR lands.

Validation:
- focused download-action and sync-workflow suites
- `make test`, `make lint`, `go build ./...`, `go vet ./...`
- build-ignored-tool vetting and repository hooks
- real immutable v2.1.222 download and disposable generator pass (128 resources, 19 data sources)
- post-prerequisite PII suite and affected hooks
- AGY: skipped by explicit user waiver
