### PR TITLE
ci: bound regeneration build memory

### DIFF
--- a/.github/workflows/_generate-provider.yml
+++ b/.github/workflows/_generate-provider.yml
@@ -70,7 +70,15 @@ jobs:
         # ./... so hand-written packages the root binary does not import — above
         # all internal/acctest — are compiled against the freshly regenerated
         # code. See #1351: `go build .` verified nothing about them.
-        run: scripts/go-retry.sh 3 go build -v ./...
+        # Generated provider packages are large enough to exhaust the hosted
+        # runner when Go compiles packages concurrently with optimizations on.
+        # Keep this verification equivalent to the proven constrained-runner
+        # acceptance build so a regeneration can finish its release chain.
+        env:
+          GOGC: "10"
+          GOMEMLIMIT: 4GiB
+          GOMAXPROCS: "1"
+        run: scripts/go-retry.sh 3 go build -p 1 -gcflags='all=-N -l' -v ./...
 
       - name: Vet to verify
         # Type-checks _test.go files, which go build skips (#1351).

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -1937,6 +1937,105 @@ func TestReleaseReadyStateRejectsInvalidRecoveryRebind(t *testing.T) {
 	}
 }
 
+func TestDeliveryStateValidatorPermitsOnlyInheritedStaleReceiptForPRValidation(t *testing.T) {
+	root := testRepositoryRoot(t)
+	validator := filepath.Join(root, "scripts", "validate-provider-delivery-state.sh")
+
+	t.Run("unchanged inherited receipt is accepted only with a base reference", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		staleSource := createNonAncestorReceiptSource(t, fixture.repo, "stale-source")
+		setRegenerationReceiptSource(t, fixture.repo, staleSource)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", "tools/spec-regeneration-receipt.json")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "persist inherited stale receipt")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "tag", "delivery-base")
+		writeReleaseTestFile(t, fixture.repo, "governance.txt", "PR-only change\n", 0o600)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", "governance.txt")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "governance change")
+
+		runReleaseTestCommand(t, fixture.repo, []string{"TARGET_REPOSITORY=" + dispatchTarget}, validator, "--base-ref", "delivery-base")
+
+		cmd := exec.Command(validator)
+		cmd.Dir = fixture.repo
+		cmd.Env = append(os.Environ(), "TARGET_REPOSITORY="+dispatchTarget)
+		output, runErr := cmd.CombinedOutput()
+		if runErr == nil || !strings.Contains(string(output), "source is not an ancestor") {
+			t.Fatalf("stale receipt without a base reference was accepted: err=%v\n%s", runErr, output)
+		}
+
+		cmd = exec.Command(validator, "--release-ready")
+		cmd.Dir = fixture.repo
+		cmd.Env = append(os.Environ(), "TARGET_REPOSITORY="+dispatchTarget)
+		output, runErr = cmd.CombinedOutput()
+		if runErr == nil || !strings.Contains(string(output), "release commit did not introduce") {
+			t.Fatalf("release-ready validation accepted an inherited stale receipt: err=%v\n%s", runErr, output)
+		}
+
+		secondStaleSource := createNonAncestorReceiptSource(t, fixture.repo, "second-stale-source")
+		setRegenerationReceiptSource(t, fixture.repo, secondStaleSource)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", "tools/spec-regeneration-receipt.json")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "change stale receipt")
+		cmd = exec.Command(validator, "--base-ref", "delivery-base")
+		cmd.Dir = fixture.repo
+		cmd.Env = append(os.Environ(), "TARGET_REPOSITORY="+dispatchTarget)
+		output, runErr = cmd.CombinedOutput()
+		if runErr == nil || !strings.Contains(string(output), "source is not an ancestor") {
+			t.Fatalf("changed stale receipt was accepted: err=%v\n%s", runErr, output)
+		}
+	})
+
+	t.Run("new stale receipt is rejected even with a base reference", func(t *testing.T) {
+		fixture := newReceiptFixture(t, false, false)
+		regenerationPath := filepath.Join(fixture.repo, "tools/spec-regeneration-receipt.json")
+		regeneration, err := os.ReadFile(regenerationPath) //nolint:gosec // isolated fixture
+		if err != nil {
+			t.Fatal(err)
+		}
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "rm", "-q", "tools/spec-regeneration-receipt.json")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "remove stale receipt")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "tag", "delivery-base")
+		staleSource := createNonAncestorReceiptSource(t, fixture.repo, "new-stale-source")
+		if err := os.WriteFile(regenerationPath, regeneration, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		setRegenerationReceiptSource(t, fixture.repo, staleSource)
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "add", "tools/spec-regeneration-receipt.json")
+		runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "add stale receipt")
+
+		cmd := exec.Command(validator, "--base-ref", "delivery-base")
+		cmd.Dir = fixture.repo
+		cmd.Env = append(os.Environ(), "TARGET_REPOSITORY="+dispatchTarget)
+		output, runErr := cmd.CombinedOutput()
+		if runErr == nil || !strings.Contains(string(output), "source is not an ancestor") {
+			t.Fatalf("new stale receipt was accepted: err=%v\n%s", runErr, output)
+		}
+	})
+}
+
+func createNonAncestorReceiptSource(t *testing.T, repo, branch string) string {
+	t.Helper()
+	runReleaseTestCommand(t, repo, nil, "git", "checkout", "-q", "-b", branch)
+	writeReleaseTestFile(t, repo, branch+".txt", "stale source\n", 0o600)
+	runReleaseTestCommand(t, repo, nil, "git", "add", branch+".txt")
+	runReleaseTestCommand(t, repo, nil, "git", "commit", "-qm", branch)
+	source := strings.TrimSpace(runReleaseTestCommand(t, repo, nil, "git", "rev-parse", "HEAD"))
+	runReleaseTestCommand(t, repo, nil, "git", "checkout", "-q", "main")
+	return source
+}
+
+func setRegenerationReceiptSource(t *testing.T, repo, source string) {
+	t.Helper()
+	path := filepath.Join(repo, "tools/spec-regeneration-receipt.json")
+	data, err := os.ReadFile(path) //nolint:gosec // isolated fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	receipt["source_commit"] = source
+	writeReleaseTestJSON(t, path, receipt)
+}
 func TestDraftCleanupDeletesEveryMeasuredAsset(t *testing.T) {
 	script := extractWorkflowRunStep(t, "_tag-release.yml", "publish", "Clear repairable draft artifacts")
 	tmp := t.TempDir()

--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -1496,6 +1496,47 @@ grep -qx expected "$4/asset"
 	}
 }
 
+func TestRegenerationBuildUsesBoundedMemory(t *testing.T) {
+	workflowPath := filepath.Join(testRepositoryRoot(t), ".github", "workflows", "_generate-provider.yml")
+	workflowBytes, err := os.ReadFile(workflowPath) //nolint:gosec // fixed repository path
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string            `yaml:"name"`
+				Run  string            `yaml:"run"`
+				Env  map[string]string `yaml:"env"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(workflowBytes, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range workflow.Jobs["generate"].Steps {
+		if step.Name != "Build to verify" {
+			continue
+		}
+		for key, want := range map[string]string{
+			"GOGC":       "10",
+			"GOMEMLIMIT": "4GiB",
+			"GOMAXPROCS": "1",
+		} {
+			if got := step.Env[key]; got != want {
+				t.Fatalf("regeneration build %s = %q, want %q", key, got, want)
+			}
+		}
+		for _, want := range []string{"go build -p 1", "-gcflags='all=-N -l'", "-v ./..."} {
+			if !strings.Contains(step.Run, want) {
+				t.Fatalf("regeneration build does not use %q: %s", want, step.Run)
+			}
+		}
+		return
+	}
+	t.Fatal("regeneration build step not found")
+}
+
 func TestScheduledAcceptanceFailureFailsWorkflow(t *testing.T) {
 	workflowPath := filepath.Join(testRepositoryRoot(t), ".github", "workflows", "acc-tests.yml")
 	workflowBytes, err := os.ReadFile(workflowPath) //nolint:gosec // fixed repository path

--- a/scripts/validate-provider-delivery-state.sh
+++ b/scripts/validate-provider-delivery-state.sh
@@ -214,11 +214,14 @@ if [ -e "$pending" ]; then
         # branch. Permit that exact inherited state only while validating a PR:
         # the candidate must not create or alter either pending-delivery file,
         # and release-ready validation always requires a fresh exact binding.
-        [ -n "$base_ref" ] &&
+        if [ -n "$base_ref" ] &&
           git cat-file -e "${base_ref}:${pending}" 2>/dev/null &&
           git cat-file -e "${base_ref}:${regeneration}" 2>/dev/null &&
-          git diff --quiet "$base_ref" HEAD -- "$pending" "$regeneration" ||
+          git diff --quiet "$base_ref" HEAD -- "$pending" "$regeneration"; then
+          :
+        else
           fail "regeneration source is not an ancestor of HEAD"
+        fi
       fi
     fi
   elif [ "$release_ready" = true ]; then

--- a/scripts/validate-provider-delivery-state.sh
+++ b/scripts/validate-provider-delivery-state.sh
@@ -209,8 +209,17 @@ if [ -e "$pending" ]; then
       [ "$source_commit" = "$(git rev-parse HEAD^)" ] ||
         fail "regeneration receipt source is not the exact release parent"
     else
-      git merge-base --is-ancestor "$source_commit" HEAD ||
-        fail "regeneration source is not an ancestor of HEAD"
+      if ! git merge-base --is-ancestor "$source_commit" HEAD; then
+        # A historical merge can have carried a stale receipt onto the protected
+        # branch. Permit that exact inherited state only while validating a PR:
+        # the candidate must not create or alter either pending-delivery file,
+        # and release-ready validation always requires a fresh exact binding.
+        [ -n "$base_ref" ] &&
+          git cat-file -e "${base_ref}:${pending}" 2>/dev/null &&
+          git cat-file -e "${base_ref}:${regeneration}" 2>/dev/null &&
+          git diff --quiet "$base_ref" HEAD -- "$pending" "$regeneration" ||
+          fail "regeneration source is not an ancestor of HEAD"
+      fi
     fi
   elif [ "$release_ready" = true ]; then
     fail "pending delivery has no regeneration receipt"


### PR DESCRIPTION
Closes #1769

Applies the proven constrained-runner Go build settings to the reusable provider-regeneration verification step and enforces them with a workflow contract test. This unblocks the pending v2.1.222 regeneration/release recovery.