### PR TITLE
fix: accept squash-merged receipt sources

### DIFF
--- a/internal/acctest/release_integrity_test.go
+++ b/internal/acctest/release_integrity_test.go
@@ -2036,6 +2036,64 @@ func TestDeliveryStateValidatorRejectsCrossBindingAndDeletion(t *testing.T) {
 	}
 }
 
+func TestDeliveryStateValidatorAcceptsSquashMergedSourceCommit(t *testing.T) {
+	root := testRepositoryRoot(t)
+	fixture := newReceiptFixture(t, false, false)
+
+	regenerationCommit := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+	sourceBase := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD^"))
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "checkout", "-q", "--detach", sourceBase)
+	writeReleaseTestFile(t, fixture.repo, "squash-source.txt", "source PR content\n", 0o600)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "add", "squash-source.txt")
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "-qm", "source PR commit")
+	squashSource := strings.TrimSpace(runReleaseTestCommand(t, fixture.repo, nil, "git", "rev-parse", "HEAD"))
+
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "checkout", "-q", "--detach", regenerationCommit)
+	receiptPath := filepath.Join(fixture.repo, "tools/spec-regeneration-receipt.json")
+	data, err := os.ReadFile(receiptPath) //nolint:gosec // isolated test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	receipt["source_commit"] = squashSource
+	writeReleaseTestJSON(t, receiptPath, receipt)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "--amend", "--no-edit", "-q")
+
+	validator := filepath.Join(root, "scripts", "validate-provider-delivery-state.sh")
+	runReleaseTestCommand(t, fixture.repo, []string{"TARGET_REPOSITORY=" + dispatchTarget}, validator)
+}
+
+func TestDeliveryStateValidatorRejectsUnavailableSourceCommit(t *testing.T) {
+	root := testRepositoryRoot(t)
+	fixture := newReceiptFixture(t, false, false)
+	receiptPath := filepath.Join(fixture.repo, "tools/spec-regeneration-receipt.json")
+	data, err := os.ReadFile(receiptPath) //nolint:gosec // isolated test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	receipt["source_commit"] = strings.Repeat("f", 40)
+	writeReleaseTestJSON(t, receiptPath, receipt)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "add", receiptPath)
+	runReleaseTestCommand(t, fixture.repo, nil, "git", "commit", "--amend", "--no-edit", "-q")
+
+	validator := filepath.Join(root, "scripts", "validate-provider-delivery-state.sh")
+	cmd := exec.Command(validator)
+	cmd.Dir = fixture.repo
+	cmd.Env = append(os.Environ(), "TARGET_REPOSITORY="+dispatchTarget)
+	output, runErr := cmd.CombinedOutput()
+	if runErr == nil || !strings.Contains(string(output), "source commit is unavailable") {
+		t.Fatalf("unavailable regeneration source was accepted: err=%v\n%s", runErr, output)
+	}
+}
+
 func TestDeliveryStateValidatorRejectsDuplicateIdentities(t *testing.T) {
 	for _, tc := range []struct {
 		name                       string

--- a/scripts/validate-provider-delivery-state.sh
+++ b/scripts/validate-provider-delivery-state.sh
@@ -209,8 +209,15 @@ if [ -e "$pending" ]; then
       [ "$source_commit" = "$(git rev-parse HEAD^)" ] ||
         fail "regeneration receipt source is not the exact release parent"
     else
-      git merge-base --is-ancestor "$source_commit" HEAD ||
-        fail "regeneration source is not an ancestor of HEAD"
+      # `source_commit` identifies the source event that was regenerated. A
+      # source PR may be squash-merged, in which case GitHub puts a distinct
+      # squash commit on main and the attested source is intentionally not an
+      # ancestor of HEAD. The on-merge workflow binds this identity to the
+      # exact associated PR and release commit; this reusable check verifies
+      # that the retained identity names a real commit without imposing an
+      # incompatible merge topology.
+      git cat-file -e "${source_commit}^{commit}" 2>/dev/null ||
+        fail "regeneration source commit is unavailable"
     fi
   elif [ "$release_ready" = true ]; then
     fail "pending delivery has no regeneration receipt"


### PR DESCRIPTION
## Summary

- validate recorded regeneration sources as retained commit objects, including squash-merged source PR commits
- preserve the stronger on-merge source/PR attestation and release-ready exact-parent guard
- cover valid squash topology and unavailable source identities
## Validation

- `scripts/validate-provider-delivery-state.sh`
- `shellcheck --severity=warning scripts/validate-provider-delivery-state.sh`
- `go test ./internal/acctest -run 'TestDeliveryStateValidator(AcceptsSquashMergedSourceCommit|RejectsUnavailableSourceCommit|RejectsCrossBindingAndDeletion|RejectsDuplicateIdentities)' -count=1
- `go test ./internal/acctest -run 'Release|Delivery|Receipt' -count=1`

Closes #1786