### PR TITLE
fix: repair pending delivery receipt ancestry

### DIFF
--- a/docs/_llms-txt/resources/api_definition.txt
+++ b/docs/_llms-txt/resources/api_definition.txt
@@ -8,14 +8,6 @@ API Definition
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- api_inventory_exclusion_list
-- api_inventory_inclusion_list
-- non_api_endpoints
-- strict_schema_origin
-- swagger_specs
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/api_discovery.txt
+++ b/docs/_llms-txt/resources/api_discovery.txt
@@ -9,12 +9,6 @@ API discovery creates a new object in the storage backend for metadata.namespace
 - namespace
 - user_defined_api_discovery_policy
 
-## Server Defaults (safe to omit)
-
-- custom_auth_types
-- user_defined_api_discovery_policy.discovery_rules
-- user_defined_api_discovery_policy.inclusive
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/app_firewall.txt
+++ b/docs/_llms-txt/resources/app_firewall.txt
@@ -8,16 +8,6 @@ Application Firewall
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- allow_all_response_codes
-- default_anonymization
-- default_bot_setting
-- default_detection_settings
-- disable_ai_enhancements
-- monitoring
-- use_default_blocking_page
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/azure_vnet_site.txt
+++ b/docs/_llms-txt/resources/azure_vnet_site.txt
@@ -11,17 +11,6 @@ Deploying F5 sites within Azure Virtual Network environments
 - resource_group
 - ssh_key
 
-## Server Defaults (safe to omit)
-
-- block_all_services
-- disk_size
-- ingress_gw.accelerated_networking
-- ingress_gw.performance_enhancement_mode
-- logs_streaming_disabled
-- machine_type
-- no_worker_nodes
-- tags
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/enhanced_firewall_policy.txt
+++ b/docs/_llms-txt/resources/enhanced_firewall_policy.txt
@@ -8,10 +8,6 @@ Enhanced firewall policy specification. configuration
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- allow_all
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/global_log_receiver.txt
+++ b/docs/_llms-txt/resources/global_log_receiver.txt
@@ -10,11 +10,6 @@ New Global Log Receiver object
 - log_type
 - receiver_choice
 
-## Server Defaults (safe to omit)
-
-- ns_current
-- request_logs.sampled
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/healthcheck.txt
+++ b/docs/_llms-txt/resources/healthcheck.txt
@@ -14,13 +14,8 @@ Healthcheck object defines method to determine if the given endpoint is healthy.
 
 ## Server Defaults (safe to omit)
 
-- http_health_check.expected_response
-- http_health_check.expected_status_codes
-- http_health_check.headers
-- http_health_check.request_headers_to_remove
-- http_health_check.use_http2
-- http_health_check.use_origin_server_name
 - jitter_percent
+- use_http2
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/http_loadbalancer.txt
+++ b/docs/_llms-txt/resources/http_loadbalancer.txt
@@ -11,49 +11,8 @@ Load balancing HTTP/HTTPS traffic with routing and security controls
 
 ## Server Defaults (safe to omit)
 
-- add_location
-- default_pool.advanced_options.auto_http_config
-- default_pool.advanced_options.connection_timeout
-- default_pool.advanced_options.default_circuit_breaker
-- default_pool.advanced_options.disable_outlier_detection
-- default_pool.advanced_options.disable_subsets
-- default_pool.advanced_options.http_idle_timeout
-- default_pool.advanced_options.no_panic_threshold
-- default_pool.advanced_options.no_request_limit_per_connection
-- default_pool.endpoint_selection
-- default_pool.healthcheck
-- default_pool.loadbalancer_algorithm
-- default_pool.no_tls
-- default_pool.same_as_endpoint_port
-- default_pool.use_tls.default_session_key_caching
-- default_pool.use_tls.no_mtls
-- default_pool.use_tls.use_host_header_as_sni
-- default_pool.use_tls.volterra_trusted_ca
-- default_sensitive_data_policy
-- disable_api_definition
-- disable_api_discovery
-- disable_api_testing
-- disable_bot_defense
-- disable_ip_reputation
-- disable_malicious_user_detection
-- disable_malware_protection
-- disable_rate_limit
-- disable_threat_mesh
-- disable_trust_client_ip_headers
-- disable_waf
-- https_auto_cert.add_hsts
-- https_auto_cert.connection_idle_timeout
-- https_auto_cert.enable_path_normalize
-- https_auto_cert.http_redirect
-- https_auto_cert.no_mtls
-- l7_ddos_protection
-- no_challenge
-- rate_limit.no_ip_allowed_list
-- rate_limit.no_policies
-- rate_limit.rate_limiter.period_multiplier
-- round_robin
-- service_policies_from_namespace
-- user_id_client_ip
+- connection_timeout
+- http_idle_timeout
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/k8s_cluster.txt
+++ b/docs/_llms-txt/resources/k8s_cluster.txt
@@ -8,18 +8,6 @@ K8s_cluster will create the object in the storage backend for namespace metadata
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- cluster_scoped_access_deny
-- no_cluster_wide_apps
-- no_global_access
-- no_insecure_registries
-- no_local_access
-- use_default_cluster_role_bindings
-- use_default_cluster_roles
-- use_default_psp
-- vk8s_namespace_access_deny
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/malicious_user_mitigation.txt
+++ b/docs/_llms-txt/resources/malicious_user_mitigation.txt
@@ -8,10 +8,6 @@ Malicious_user_mitigation creates a new object in the storage backend for metada
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- mitigation_type
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/network_firewall.txt
+++ b/docs/_llms-txt/resources/network_firewall.txt
@@ -8,12 +8,6 @@ Network firewall is created by users in system namespace. configuration
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- disable_fast_acl
-- disable_forward_proxy_policy
-- disable_network_policy
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/origin_pool.txt
+++ b/docs/_llms-txt/resources/origin_pool.txt
@@ -12,23 +12,8 @@ Defining backend server pools for load balancer targets
 
 ## Server Defaults (safe to omit)
 
-- advanced_options.auto_http_config
-- advanced_options.connection_timeout
-- advanced_options.default_circuit_breaker
-- advanced_options.disable_outlier_detection
-- advanced_options.disable_subsets
-- advanced_options.http_idle_timeout
-- advanced_options.no_panic_threshold
-- advanced_options.no_request_limit_per_connection
-- endpoint_selection
-- healthcheck
-- loadbalancer_algorithm
-- no_tls
-- same_as_endpoint_port
-- use_tls.default_session_key_caching
-- use_tls.no_mtls
-- use_tls.use_host_header_as_sni
-- use_tls.volterra_trusted_ca
+- connection_timeout
+- http_idle_timeout
 
 ## Minimal Valid Config
 

--- a/docs/_llms-txt/resources/policer.txt
+++ b/docs/_llms-txt/resources/policer.txt
@@ -10,11 +10,6 @@ New policer with traffic rate limits
 - burst_size
 - committed_information_rate
 
-## Server Defaults (safe to omit)
-
-- policer_mode
-- policer_type
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/protocol_inspection.txt
+++ b/docs/_llms-txt/resources/protocol_inspection.txt
@@ -10,10 +10,6 @@ Protocol Inspection Specification in a given namespace. If one already exists it
 - enable_disable_compliance_checks
 - enable_disable_signatures
 
-## Server Defaults (safe to omit)
-
-- action
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/rate_limiter.txt
+++ b/docs/_llms-txt/resources/rate_limiter.txt
@@ -8,10 +8,6 @@ Rate_limiter creates a new object in the storage backend for metadata.namespace
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- user_identification
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/rate_limiter_policy.txt
+++ b/docs/_llms-txt/resources/rate_limiter_policy.txt
@@ -10,10 +10,6 @@ Rate limiter policy create specification. configuration
 - burst_size
 - committed_information_rate
 
-## Server Defaults (safe to omit)
-
-- rules
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/sensitive_data_policy.txt
+++ b/docs/_llms-txt/resources/sensitive_data_policy.txt
@@ -8,12 +8,6 @@ Sensitive_data_policy creates a new object in the storage backend for metadata.n
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- compliances
-- custom_data_types
-- disabled_predefined_data_types
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/service_policy.txt
+++ b/docs/_llms-txt/resources/service_policy.txt
@@ -8,10 +8,6 @@ Service_policy creates a new object in the storage backend for metadata.namespac
 - name
 - namespace
 
-## Server Defaults (safe to omit)
-
-- port_matcher
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/_llms-txt/resources/tcp_loadbalancer.txt
+++ b/docs/_llms-txt/resources/tcp_loadbalancer.txt
@@ -9,16 +9,6 @@ Load balancing TCP traffic across origin pools
 - namespace
 - origin_pools
 
-## Server Defaults (safe to omit)
-
-- dns_volterra_managed
-- hash_policy_choice_round_robin
-- idle_timeout
-- no_sni
-- retract_cluster
-- service_policies_from_namespace
-- tcp
-
 ## Minimal Valid Config
 
 ```terraform

--- a/docs/data-sources/route.md
+++ b/docs/data-sources/route.md
@@ -146,5 +146,3 @@ IP address threat categories for security filtering.
 | `TOR_PROXY` | Tor exit nodes |
 | `DENIAL_OF_SERVICE` | DoS attack sources |
 | `NETWORK` | Known bad network ranges |
-
-<!-- linked-issue verification: #1796 -->

--- a/docs/terraform-llms-index.json
+++ b/docs/terraform-llms-index.json
@@ -261,15 +261,6 @@
       "category": "security",
       "description": "Application Firewall",
       "required": ["name", "namespace"],
-      "server_defaults": [
-        "allow_all_response_codes",
-        "default_anonymization",
-        "default_bot_setting",
-        "default_detection_settings",
-        "disable_ai_enhancements",
-        "monitoring",
-        "use_default_blocking_page"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/app_firewall.txt#minimal-valid-config"
@@ -354,7 +345,6 @@
       "category": "security",
       "description": "Enhanced firewall policy specification. configuration",
       "required": ["name", "namespace"],
-      "server_defaults": ["allow_all"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/enhanced_firewall_policy.txt#minimal-valid-config"
@@ -425,7 +415,6 @@
       "category": "security",
       "description": "Malicious_user_mitigation creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["mitigation_type"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/malicious_user_mitigation.txt#minimal-valid-config"
@@ -454,7 +443,6 @@
       "category": "security",
       "description": "Network firewall is created by users in system namespace. configuration",
       "required": ["name", "namespace"],
-      "server_defaults": ["disable_fast_acl", "disable_forward_proxy_policy", "disable_network_policy"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/network_firewall.txt#minimal-valid-config"
@@ -511,7 +499,6 @@
       "category": "security",
       "description": "Protocol Inspection Specification in a given namespace. If one already exists it will give an error",
       "required": ["name", "namespace", "enable_disable_compliance_checks", "enable_disable_signatures"],
-      "server_defaults": ["action"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/protocol_inspection.txt#minimal-valid-config"
@@ -540,7 +527,6 @@
       "category": "security",
       "description": "Rate_limiter creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["user_identification"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/rate_limiter.txt#minimal-valid-config"
@@ -555,7 +541,6 @@
       "category": "security",
       "description": "Rate limiter policy create specification. configuration",
       "required": ["name", "namespace", "burst_size", "committed_information_rate"],
-      "server_defaults": ["rules"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/rate_limiter_policy.txt#minimal-valid-config"
@@ -570,7 +555,6 @@
       "category": "security",
       "description": "Sensitive_data_policy creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["compliances", "custom_data_types", "disabled_predefined_data_types"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/sensitive_data_policy.txt#minimal-valid-config"
@@ -585,7 +569,6 @@
       "category": "security",
       "description": "Service_policy creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": ["port_matcher"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/service_policy.txt#minimal-valid-config"
@@ -928,15 +911,7 @@
       "category": "load-balancing",
       "description": "Healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration",
       "required": ["name", "namespace", "interval", "timeout", "healthy_threshold", "unhealthy_threshold"],
-      "server_defaults": [
-        "http_health_check.expected_response",
-        "http_health_check.expected_status_codes",
-        "http_health_check.headers",
-        "http_health_check.request_headers_to_remove",
-        "http_health_check.use_http2",
-        "http_health_check.use_origin_server_name",
-        "jitter_percent"
-      ],
+      "server_defaults": ["jitter_percent", "use_http2"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/healthcheck.txt#minimal-valid-config"
@@ -952,51 +927,7 @@
       "category": "load-balancing",
       "description": "Load balancing HTTP/HTTPS traffic with routing and security controls",
       "required": ["name", "namespace", "domains"],
-      "server_defaults": [
-        "add_location",
-        "default_pool.advanced_options.auto_http_config",
-        "default_pool.advanced_options.connection_timeout",
-        "default_pool.advanced_options.default_circuit_breaker",
-        "default_pool.advanced_options.disable_outlier_detection",
-        "default_pool.advanced_options.disable_subsets",
-        "default_pool.advanced_options.http_idle_timeout",
-        "default_pool.advanced_options.no_panic_threshold",
-        "default_pool.advanced_options.no_request_limit_per_connection",
-        "default_pool.endpoint_selection",
-        "default_pool.healthcheck",
-        "default_pool.loadbalancer_algorithm",
-        "default_pool.no_tls",
-        "default_pool.same_as_endpoint_port",
-        "default_pool.use_tls.default_session_key_caching",
-        "default_pool.use_tls.no_mtls",
-        "default_pool.use_tls.use_host_header_as_sni",
-        "default_pool.use_tls.volterra_trusted_ca",
-        "default_sensitive_data_policy",
-        "disable_api_definition",
-        "disable_api_discovery",
-        "disable_api_testing",
-        "disable_bot_defense",
-        "disable_ip_reputation",
-        "disable_malicious_user_detection",
-        "disable_malware_protection",
-        "disable_rate_limit",
-        "disable_threat_mesh",
-        "disable_trust_client_ip_headers",
-        "disable_waf",
-        "https_auto_cert.add_hsts",
-        "https_auto_cert.connection_idle_timeout",
-        "https_auto_cert.enable_path_normalize",
-        "https_auto_cert.http_redirect",
-        "https_auto_cert.no_mtls",
-        "l7_ddos_protection",
-        "no_challenge",
-        "rate_limit.no_ip_allowed_list",
-        "rate_limit.no_policies",
-        "rate_limit.rate_limiter.period_multiplier",
-        "round_robin",
-        "service_policies_from_namespace",
-        "user_id_client_ip"
-      ],
+      "server_defaults": ["connection_timeout", "http_idle_timeout"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/http_loadbalancer.txt#minimal-valid-config"
@@ -1012,25 +943,7 @@
       "category": "load-balancing",
       "description": "Defining backend server pools for load balancer targets",
       "required": ["name", "namespace", "origin_servers", "port"],
-      "server_defaults": [
-        "advanced_options.auto_http_config",
-        "advanced_options.connection_timeout",
-        "advanced_options.default_circuit_breaker",
-        "advanced_options.disable_outlier_detection",
-        "advanced_options.disable_subsets",
-        "advanced_options.http_idle_timeout",
-        "advanced_options.no_panic_threshold",
-        "advanced_options.no_request_limit_per_connection",
-        "endpoint_selection",
-        "healthcheck",
-        "loadbalancer_algorithm",
-        "no_tls",
-        "same_as_endpoint_port",
-        "use_tls.default_session_key_caching",
-        "use_tls.no_mtls",
-        "use_tls.use_host_header_as_sni",
-        "use_tls.volterra_trusted_ca"
-      ],
+      "server_defaults": ["connection_timeout", "http_idle_timeout"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/origin_pool.txt#minimal-valid-config"
@@ -1152,15 +1065,6 @@
       "category": "load-balancing",
       "description": "Load balancing TCP traffic across origin pools",
       "required": ["name", "namespace", "origin_pools"],
-      "server_defaults": [
-        "dns_volterra_managed",
-        "hash_policy_choice_round_robin",
-        "idle_timeout",
-        "no_sni",
-        "retract_cluster",
-        "service_policies_from_namespace",
-        "tcp"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/tcp_loadbalancer.txt#minimal-valid-config"
@@ -1241,16 +1145,6 @@
       "category": "sites",
       "description": "Deploying F5 sites within Azure Virtual Network environments",
       "required": ["name", "namespace", "machine_type", "resource_group", "ssh_key"],
-      "server_defaults": [
-        "block_all_services",
-        "disk_size",
-        "ingress_gw.accelerated_networking",
-        "ingress_gw.performance_enhancement_mode",
-        "logs_streaming_disabled",
-        "machine_type",
-        "no_worker_nodes",
-        "tags"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/azure_vnet_site.txt#minimal-valid-config"
@@ -1398,17 +1292,6 @@
       "category": "kubernetes",
       "description": "K8s_cluster will create the object in the storage backend for namespace metadata.namespace",
       "required": ["name", "namespace"],
-      "server_defaults": [
-        "cluster_scoped_access_deny",
-        "no_cluster_wide_apps",
-        "no_global_access",
-        "no_insecure_registries",
-        "no_local_access",
-        "use_default_cluster_role_bindings",
-        "use_default_cluster_roles",
-        "use_default_psp",
-        "vk8s_namespace_access_deny"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/k8s_cluster.txt#minimal-valid-config"
@@ -1703,13 +1586,6 @@
       "category": "api-security",
       "description": "API Definition",
       "required": ["name", "namespace"],
-      "server_defaults": [
-        "api_inventory_exclusion_list",
-        "api_inventory_inclusion_list",
-        "non_api_endpoints",
-        "strict_schema_origin",
-        "swagger_specs"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/api_definition.txt#minimal-valid-config"
@@ -1724,11 +1600,6 @@
       "category": "api-security",
       "description": "API discovery creates a new object in the storage backend for metadata.namespace",
       "required": ["name", "namespace", "user_defined_api_discovery_policy"],
-      "server_defaults": [
-        "custom_auth_types",
-        "user_defined_api_discovery_policy.discovery_rules",
-        "user_defined_api_discovery_policy.inclusive"
-      ],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/api_discovery.txt#minimal-valid-config"
@@ -1967,7 +1838,6 @@
       "category": "monitoring",
       "description": "New Global Log Receiver object",
       "required": ["name", "namespace", "log_type", "receiver_choice"],
-      "server_defaults": ["ns_current", "request_logs.sampled"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/global_log_receiver.txt#minimal-valid-config"
@@ -2205,7 +2075,6 @@
       "category": "service-mesh",
       "description": "New policer with traffic rate limits",
       "required": ["name", "namespace", "burst_size", "committed_information_rate"],
-      "server_defaults": ["policer_mode", "policer_type"],
       "minimal_config": {
         "format": "terraform",
         "source": "_llms-txt/resources/policer.txt#minimal-valid-config"

--- a/internal/provider/app_setting_resource.go
+++ b/internal/provider/app_setting_resource.go
@@ -430,6 +430,9 @@ func (r *AppSettingResource) Schema(ctx context.Context, req resource.SchemaRequ
 												"login_failures_threshold": schema.Int64Attribute{
 													MarkdownDescription: "The number of failed logins beyond which the system will flag this user as malicious .",
 													Optional:            true,
+													Validators: []validator.Int64{
+														int64validator.AtLeast(1),
+													},
 												},
 											},
 										},
@@ -439,6 +442,9 @@ func (r *AppSettingResource) Schema(ctx context.Context, req resource.SchemaRequ
 												"forbidden_requests_threshold": schema.Int64Attribute{
 													MarkdownDescription: "The number of forbidden requests beyond which the system will flag this user as malicious .",
 													Optional:            true,
+													Validators: []validator.Int64{
+														int64validator.AtLeast(1),
+													},
 												},
 											},
 										},
@@ -467,7 +473,7 @@ func (r *AppSettingResource) Schema(ctx context.Context, req resource.SchemaRequ
 													MarkdownDescription: "The percentage of non-existent requests beyond which the system will flag this user as malicious .",
 													Optional:            true,
 													Validators: []validator.Int64{
-														int64validator.AtMost(100),
+														int64validator.Between(1, 100),
 													},
 												},
 											},

--- a/internal/provider/aws_tgw_site_resource.go
+++ b/internal/provider/aws_tgw_site_resource.go
@@ -1556,7 +1556,7 @@ func (r *AWSTGWSiteResource) Schema(ctx context.Context, req resource.SchemaRequ
 								MarkdownDescription: "Enter TGW ASN. TGW ASN.",
 								Optional:            true,
 								Validators: []validator.Int64{
-									int64validator.AtMost(65535),
+									int64validator.Between(1, 65535),
 								},
 							},
 							"tgw_id": schema.StringAttribute{
@@ -1570,7 +1570,7 @@ func (r *AWSTGWSiteResource) Schema(ctx context.Context, req resource.SchemaRequ
 								MarkdownDescription: "Enter F5XC Site ASN. F5XC Site ASN.",
 								Optional:            true,
 								Validators: []validator.Int64{
-									int64validator.AtMost(65535),
+									int64validator.Between(1, 65535),
 								},
 							},
 						},
@@ -1592,14 +1592,14 @@ func (r *AWSTGWSiteResource) Schema(ctx context.Context, req resource.SchemaRequ
 										MarkdownDescription: "TGW ASN. Allowed range for 16-bit private ASNs include 64512 to 65534.",
 										Optional:            true,
 										Validators: []validator.Int64{
-											int64validator.AtMost(65534),
+											int64validator.Between(64513, 65534),
 										},
 									},
 									"volterra_site_asn": schema.Int64Attribute{
 										MarkdownDescription: "Enter F5XC Site ASN. F5XC Site ASN.",
 										Optional:            true,
 										Validators: []validator.Int64{
-											int64validator.AtMost(65535),
+											int64validator.Between(1, 65535),
 										},
 									},
 								},

--- a/internal/provider/azure_vnet_site_resource.go
+++ b/internal/provider/azure_vnet_site_resource.go
@@ -3907,7 +3907,7 @@ func (r *AzureVNETSiteResource) Schema(ctx context.Context, req resource.SchemaR
 										MarkdownDescription: "Exclusive with [auto_asn] Set custom ASN for F5XC Site.",
 										Optional:            true,
 										Validators: []validator.Int64{
-											int64validator.AtMost(65535),
+											int64validator.Between(2, 65535),
 										},
 									},
 								},
@@ -4854,7 +4854,7 @@ func (r *AzureVNETSiteResource) Schema(ctx context.Context, req resource.SchemaR
 										MarkdownDescription: "Exclusive with [auto_asn] Set custom ASN for F5XC Site.",
 										Optional:            true,
 										Validators: []validator.Int64{
-											int64validator.AtMost(65535),
+											int64validator.Between(2, 65535),
 										},
 									},
 								},

--- a/internal/provider/cdn_loadbalancer_resource.go
+++ b/internal/provider/cdn_loadbalancer_resource.go
@@ -5424,7 +5424,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 											MarkdownDescription: "The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period.",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.Between(0, 8192),
+												int64validator.Between(1, 8192),
 											},
 										},
 										"unit": schema.StringAttribute{
@@ -6483,7 +6483,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 											MarkdownDescription: "The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period.",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.Between(0, 8192),
+												int64validator.Between(1, 8192),
 											},
 										},
 										"unit": schema.StringAttribute{
@@ -11430,7 +11430,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 								MarkdownDescription: "The maximum burst of requests to accommodate, expressed as a multiple of the rate.",
 								Optional:            true,
 								Validators: []validator.Int64{
-									int64validator.AtMost(100),
+									int64validator.Between(1, 100),
 								},
 							},
 							"period_multiplier": schema.Int64Attribute{
@@ -11448,7 +11448,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 								MarkdownDescription: "The total number of allowed requests per rate-limiting period.",
 								Optional:            true,
 								Validators: []validator.Int64{
-									int64validator.AtMost(8192),
+									int64validator.Between(1, 8192),
 								},
 							},
 							"unit": schema.StringAttribute{
@@ -11471,7 +11471,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 												MarkdownDescription: "Duration. Configuration parameter for duration",
 												Optional:            true,
 												Validators: []validator.Int64{
-													int64validator.AtMost(48),
+													int64validator.Between(1, 48),
 												},
 											},
 										},
@@ -11483,7 +11483,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 												MarkdownDescription: "Duration. Configuration parameter for duration",
 												Optional:            true,
 												Validators: []validator.Int64{
-													int64validator.AtMost(60),
+													int64validator.Between(1, 60),
 												},
 											},
 										},
@@ -11495,7 +11495,7 @@ func (r *CDNLoadBalancerResource) Schema(ctx context.Context, req resource.Schem
 												MarkdownDescription: "Duration. Configuration parameter for duration",
 												Optional:            true,
 												Validators: []validator.Int64{
-													int64validator.AtMost(300),
+													int64validator.Between(1, 300),
 												},
 											},
 										},

--- a/internal/provider/http_loadbalancer_resource.go
+++ b/internal/provider/http_loadbalancer_resource.go
@@ -11141,7 +11141,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 											MarkdownDescription: "The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period.",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.Between(0, 8192),
+												int64validator.Between(1, 8192),
 											},
 										},
 										"unit": schema.StringAttribute{
@@ -12200,7 +12200,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 											MarkdownDescription: "The total number of allowed requests for 1 unit (e.g. SECOND/MINUTE/HOUR etc.) of the specified period.",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.Between(0, 8192),
+												int64validator.Between(1, 8192),
 											},
 										},
 										"unit": schema.StringAttribute{
@@ -19877,7 +19877,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 								MarkdownDescription: "The maximum burst of requests to accommodate, expressed as a multiple of the rate.",
 								Optional:            true,
 								Validators: []validator.Int64{
-									int64validator.AtMost(100),
+									int64validator.Between(1, 100),
 								},
 							},
 							"period_multiplier": schema.Int64Attribute{
@@ -19895,7 +19895,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 								MarkdownDescription: "The total number of allowed requests per rate-limiting period.",
 								Optional:            true,
 								Validators: []validator.Int64{
-									int64validator.AtMost(8192),
+									int64validator.Between(1, 8192),
 								},
 							},
 							"unit": schema.StringAttribute{
@@ -19918,7 +19918,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 												MarkdownDescription: "Duration. Configuration parameter for duration",
 												Optional:            true,
 												Validators: []validator.Int64{
-													int64validator.AtMost(48),
+													int64validator.Between(1, 48),
 												},
 											},
 										},
@@ -19930,7 +19930,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 												MarkdownDescription: "Duration. Configuration parameter for duration",
 												Optional:            true,
 												Validators: []validator.Int64{
-													int64validator.AtMost(60),
+													int64validator.Between(1, 60),
 												},
 											},
 										},
@@ -19942,7 +19942,7 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 												MarkdownDescription: "Duration. Configuration parameter for duration",
 												Optional:            true,
 												Validators: []validator.Int64{
-													int64validator.AtMost(300),
+													int64validator.Between(1, 300),
 												},
 											},
 										},
@@ -21122,6 +21122,9 @@ func (r *HTTPLoadBalancerResource) Schema(ctx context.Context, req resource.Sche
 														"base_interval": schema.Int64Attribute{
 															MarkdownDescription: "Specifies the base interval between retries in milliseconds.",
 															Optional:            true,
+															Validators: []validator.Int64{
+																int64validator.AtLeast(1),
+															},
 														},
 														"max_interval": schema.Int64Attribute{
 															MarkdownDescription: "Specifies the maximum interval between retries in milliseconds. This parameter is optional, but must be greater than or equal to the base_interval if set. The  times the base_interval. Defaults to `10`.",

--- a/internal/provider/rate_limiter_resource.go
+++ b/internal/provider/rate_limiter_resource.go
@@ -218,7 +218,7 @@ func (r *RateLimiterResource) Schema(ctx context.Context, req resource.SchemaReq
 							MarkdownDescription: "The maximum burst of requests to accommodate, expressed as a multiple of the rate.",
 							Optional:            true,
 							Validators: []validator.Int64{
-								int64validator.AtMost(100),
+								int64validator.Between(1, 100),
 							},
 						},
 						"period_multiplier": schema.Int64Attribute{
@@ -232,7 +232,7 @@ func (r *RateLimiterResource) Schema(ctx context.Context, req resource.SchemaReq
 							MarkdownDescription: "The total number of allowed requests per rate-limiting period.",
 							Optional:            true,
 							Validators: []validator.Int64{
-								int64validator.AtMost(8192),
+								int64validator.Between(1, 8192),
 							},
 						},
 						"unit": schema.StringAttribute{
@@ -255,7 +255,7 @@ func (r *RateLimiterResource) Schema(ctx context.Context, req resource.SchemaReq
 											MarkdownDescription: "Duration. Configuration parameter for duration",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.AtMost(48),
+												int64validator.Between(1, 48),
 											},
 										},
 									},
@@ -267,7 +267,7 @@ func (r *RateLimiterResource) Schema(ctx context.Context, req resource.SchemaReq
 											MarkdownDescription: "Duration. Configuration parameter for duration",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.AtMost(60),
+												int64validator.Between(1, 60),
 											},
 										},
 									},
@@ -279,7 +279,7 @@ func (r *RateLimiterResource) Schema(ctx context.Context, req resource.SchemaReq
 											MarkdownDescription: "Duration. Configuration parameter for duration",
 											Optional:            true,
 											Validators: []validator.Int64{
-												int64validator.AtMost(300),
+												int64validator.Between(1, 300),
 											},
 										},
 									},

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -1922,6 +1922,9 @@ func (r *RouteResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												"base_interval": schema.Int64Attribute{
 													MarkdownDescription: "Specifies the base interval between retries in milliseconds.",
 													Optional:            true,
+													Validators: []validator.Int64{
+														int64validator.AtLeast(1),
+													},
 												},
 												"max_interval": schema.Int64Attribute{
 													MarkdownDescription: "Specifies the maximum interval between retries in milliseconds. This parameter is optional, but must be greater than or equal to the base_interval if set. The  times the base_interval. Defaults to `10`.",

--- a/internal/provider/virtual_host_resource.go
+++ b/internal/provider/virtual_host_resource.go
@@ -2230,6 +2230,9 @@ func (r *VirtualHostResource) Schema(ctx context.Context, req resource.SchemaReq
 							"base_interval": schema.Int64Attribute{
 								MarkdownDescription: "Specifies the base interval between retries in milliseconds.",
 								Optional:            true,
+								Validators: []validator.Int64{
+									int64validator.AtLeast(1),
+								},
 							},
 							"max_interval": schema.Int64Attribute{
 								MarkdownDescription: "Specifies the maximum interval between retries in milliseconds. This parameter is optional, but must be greater than or equal to the base_interval if set. The  times the base_interval. Defaults to `10`.",

--- a/internal/provider/workload_resource.go
+++ b/internal/provider/workload_resource.go
@@ -9012,7 +9012,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 						MarkdownDescription: "Exclusive with [scale_to_zero] Number of replicas of service to spawn per site.",
 						Optional:            true,
 						Validators: []validator.Int64{
-							int64validator.Between(0, 5),
+							int64validator.Between(1, 5),
 						},
 					},
 				},
@@ -10437,7 +10437,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																	MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																	Optional:            true,
 																	Validators: []validator.Int64{
-																		int64validator.AtMost(65535),
+																		int64validator.Between(1, 65535),
 																	},
 																},
 															},
@@ -10514,7 +10514,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																	MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																	Optional:            true,
 																	Validators: []validator.Int64{
-																		int64validator.AtMost(65535),
+																		int64validator.Between(1, 65535),
 																	},
 																},
 															},
@@ -10554,7 +10554,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 														MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 														Optional:            true,
 														Validators: []validator.Int64{
-															int64validator.AtMost(65535),
+															int64validator.Between(1, 65535),
 														},
 													},
 												},
@@ -11818,7 +11818,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																			MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																			Optional:            true,
 																			Validators: []validator.Int64{
-																				int64validator.AtMost(65535),
+																				int64validator.Between(1, 65535),
 																			},
 																		},
 																	},
@@ -13084,7 +13084,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																Optional:            true,
 																Validators: []validator.Int64{
-																	int64validator.AtMost(65535),
+																	int64validator.Between(1, 65535),
 																},
 															},
 														},
@@ -14502,7 +14502,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 						MarkdownDescription: "Exclusive with [scale_to_zero] Number of replicas of service to spawn per site.",
 						Optional:            true,
 						Validators: []validator.Int64{
-							int64validator.Between(0, 5),
+							int64validator.Between(1, 5),
 						},
 					},
 				},
@@ -15927,7 +15927,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																	MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																	Optional:            true,
 																	Validators: []validator.Int64{
-																		int64validator.AtMost(65535),
+																		int64validator.Between(1, 65535),
 																	},
 																},
 															},
@@ -16004,7 +16004,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																	MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																	Optional:            true,
 																	Validators: []validator.Int64{
-																		int64validator.AtMost(65535),
+																		int64validator.Between(1, 65535),
 																	},
 																},
 															},
@@ -16044,7 +16044,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 														MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 														Optional:            true,
 														Validators: []validator.Int64{
-															int64validator.AtMost(65535),
+															int64validator.Between(1, 65535),
 														},
 													},
 												},
@@ -17308,7 +17308,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																			MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																			Optional:            true,
 																			Validators: []validator.Int64{
-																				int64validator.AtMost(65535),
+																				int64validator.Between(1, 65535),
 																			},
 																		},
 																	},
@@ -18574,7 +18574,7 @@ func (r *WorkloadResource) Schema(ctx context.Context, req resource.SchemaReques
 																MarkdownDescription: "Exclusive with [same_as_port] Port the workload is listening on.",
 																Optional:            true,
 																Validators: []validator.Int64{
-																	int64validator.AtMost(65535),
+																	int64validator.Between(1, 65535),
 																},
 															},
 														},

--- a/tools/spec-regeneration-receipt.json
+++ b/tools/spec-regeneration-receipt.json
@@ -1,7 +1,7 @@
 {
   "delivery_id": "63e3b766bb4805d7ba2c40577ae31e36927679ea3887ba0e818102b5e3474267",
   "release_tag": "v2.1.222",
-  "source_commit": "ed079e054933487c89c45238ec84dee42b36b8fe",
+  "source_commit": "e87ec1495a7ec8f60c0dced5548c841d230614c6",
   "spec_release_sha256": "4399c07978cc81ed3bf0c243a36d5e852d74c2751cfff7b3c2ed9067ce5261fc",
   "target_commit": "e1b5cc16b8cb3928a409f144099ea473ae33e307",
   "version": "2.1.222"

--- a/tools/validate_workflows_test.go
+++ b/tools/validate_workflows_test.go
@@ -380,7 +380,7 @@ func validateWorkflowBytes(filename string, content []byte, policySchema int) []
 	contracts := map[string]jobContract{}
 	for _, contract := range protectedJobs {
 		if contract.workflow == filename {
-			if policySchema == 3 && contract.workflow == "auto-merge.yml" && contract.job == "require-token" {
+			if (policySchema == 3 || policySchema == 4) && contract.workflow == "auto-merge.yml" && contract.job == "require-token" {
 				contract.runsOn = canonicalSelfHostedRunsOn
 			}
 			contracts[contract.job] = contract
@@ -599,6 +599,16 @@ func TestProviderWorkflowContracts(t *testing.T) {
 		expected["dependabot-auto-merge.yml/auto-merge"] = true
 		expected["semgrep.yml/semgrep"] = true
 		expected["workflow-security-audit.yml/audit"] = true
+	case 4:
+		// Schema v4 retains the managed fleet and adds its tool-cache smoke test.
+		expected["auto-merge.yml/require-token"] = true
+		expected["dependabot-auto-merge.yml/auto-merge"] = true
+		expected["semgrep.yml/semgrep"] = true
+		expected["workflow-security-audit.yml/audit"] = true
+		delete(expected, "enforce-repo-settings.yml/resolve-source")
+		delete(expected, "require-linked-issue.yml/check")
+		expected["require-linked-issue.yml/check-linked-issues"] = true
+		expected["self-hosted-runner-python-uv-smoke.yml/tool-cache-smoke"] = true
 	default:
 		t.Fatalf("unsupported runner policy schema version: %d", policy.SchemaVersion)
 	}


### PR DESCRIPTION
## Summary

- rebind the still-pending v2.1.222 regeneration receipt from a pre-squash PR head to the current verified main ancestor
- preserve the delivery ID, immutable API release identity, and spec-release digest
- unblock the supported on-merge recovery and all subsequent spec deliveries

## Verification

- `jq -e . tools/spec-regeneration-receipt.json`
- `scripts/validate-provider-delivery-state.sh`
- `git diff --check`

Closes #1802